### PR TITLE
change ndarray dependency to ^0.16 for downstream compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["mathematics"]
 [dependencies]
 dyn-clone = "1"
 itertools = "0.13.0"
-ndarray = "0.17"
+ndarray = "0.17.1"
 num-traits = "0.2.15"
 serde = { version = "1.0.103", optional = true, features = ["derive"] }
 serde_unit_struct = { version = "0.1.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["mathematics"]
 [dependencies]
 dyn-clone = "1"
 itertools = "0.13.0"
-ndarray = ">=0.15.3, <0.18"
+ndarray = "0.16"
 num-traits = "0.2.15"
 serde = { version = "1.0.103", optional = true, features = ["derive"] }
 serde_unit_struct = { version = "0.1.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["mathematics"]
 [dependencies]
 dyn-clone = "1"
 itertools = "0.13.0"
-ndarray = "0.16"
+ndarray = "0.17"
 num-traits = "0.2.15"
 serde = { version = "1.0.103", optional = true, features = ["derive"] }
 serde_unit_struct = { version = "0.1.3", optional = true }
@@ -25,7 +25,7 @@ thiserror = "1.0.1"
 
 [dev-dependencies]
 criterion = "0.5.1"
-ndarray-rand = "0.16.0" # note: for `cargo bench`, ndarray 0.17 must be used
+ndarray-rand = "0.16.0"
 approx = "0.5.1"
 uom = "0.36.0"
 serde_json = "1.0.140"


### PR DESCRIPTION
hey @kylecarow, i think this range dependency isn't what you need here. i just read up and learned that range dependencies need to be supported transitively. so that means that compass also needs to support _all_ ndarray versions in the range [0.15.3, 0.18.0). 

this PR instead proposes you use a semver-compatible dependency declaration of ndarray versions matching 0.16.x. so that downstream users of ninterp can also import ndarray versions [0.16.0, 0.16.1] into their crate.

edit: everything i just said but "0.17" instead to match your benchmarking CI

