### PR TITLE
Fix misleading error message for coordinate validation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub enum ValidateError {
     ExtrapolateSelection(String),
     #[error("supplied grid coordinates cannot be empty: dim {0}")]
     EmptyGrid(usize),
-    #[error("supplied coordinates must be sorted and non-repeating: dim {0}")]
+    #[error("supplied coordinates must be monotonically increasing: dim {0}")]
     Monotonicity(usize),
     #[error("supplied grid and values are not compatible shapes: dim {0}")]
     IncompatibleShapes(usize),


### PR DESCRIPTION
The error message for `Monotonicity(usize)` claims that coordinates must be "sorted and non-repeating," but the actual implementation only checks for monotonically increasing values (using `<=`), which allows duplicate/repeating values. This makes the error message deceptive - it promises stricter validation than is actually performed.

An alternative fix would be to change the implementation to use < instead of <=, enforcing strictly increasing coordinates (no duplicates). See https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.PchipInterpolator.html: SciPy's interpolation functions explicitly reject duplicate values as they would make the function "overspecified." However, changing the implementation to require strictly increasing coordinates would be a breaking change and may affect existing users. This PR opts for the minimal fix of correcting the error message to match the current behavior.