### PR TITLE
Introduce Step as a replacement for LeftNearest and RightNearest

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,8 @@ An interpolation strategy (e.g.
 [`Linear`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.Linear.html),
 [`LinearUniform`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.LinearUniform.html),
 [`Nearest`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.Nearest.html),
-[`LeftNearest`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.LeftNearest.html),
-[`RightNearest`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.RightNearest.html))
+[`Step`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.Step.html))
 must be specified.
-Not all interpolation strategies are implemented for every dimensionality.
-`Linear`, `LinearUniform`, and `Nearest` are implemented for all dimensionalities.
 
 Custom strategies can be defined. See
 [`examples/custom_strategy.rs`](examples/custom_strategy.rs)

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -223,8 +223,9 @@ where
     ///             [1.0, 1.2, 1.4, 1.6], // f(x1, y1, z0), f(x1, y1, z1), f(x1, y1, z2), f(x1, y1, z3)
     ///             [1.2, 1.4, 1.6, 1.8], // f(x1, y2, z0), f(x1, y2, z1), f(x1, y2, z2), f(x1, y2, z3)
     ///         ],
-    ///     ].into_dyn(),
-    ///     strategy::Linear, // strategy mod is exposed via `use ndarray::prelude::*;`
+    ///     ]
+    ///     .into_dyn(),
+    ///     strategy::Linear,   // strategy mod is exposed via `use ndarray::prelude::*;`
     ///     Extrapolate::Error, // return an error when point is out of bounds
     /// )
     /// .unwrap();

--- a/src/interpolator/n/strategies.rs
+++ b/src/interpolator/n/strategies.rs
@@ -101,79 +101,12 @@ where
     }
 }
 
-impl<D> StrategyND<D> for Nearest
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    fn interpolate(
-        &self,
-        data: &InterpDataND<D>,
-        point: &[D::Elem],
-    ) -> Result<D::Elem, InterpolateError> {
-        let n = data.values.ndim();
-        // Nearest-neighbor on a rectilinear grid factorizes: select the nearest index
-        // independently per dimension, then do a single lookup. No corner extraction or
-        // dimensionality reduction needed — the distance comparison handles exact matches correctly.
-        let mut idx = vec![0usize; n];
-        for dim in 0..n {
-            let lower_idx = find_nearest_index(data.grid[dim].view(), &point[dim]);
-            idx[dim] = if point[dim] - data.grid[dim][lower_idx]
-                < data.grid[dim][lower_idx + 1] - point[dim]
-            {
-                lower_idx
-            } else {
-                lower_idx + 1
-            };
-        }
-        Ok(data.values.view()[idx.as_slice()])
-    }
-
-    /// Returns `false`.
-    fn allow_extrapolate(&self) -> bool {
-        false
-    }
-}
-
-impl<D> StrategyND<D> for Step
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
-        let n = data.values.ndim();
-        if self.0.len() != 1 && self.0.len() != n {
-            return Err(ValidateError::Other(format!(
-                "Step strategy has {} directions but interpolator is {n}-D (expected 1 or {n})",
-                self.0.len()
-            )));
-        }
-        Ok(())
-    }
-
-    fn interpolate(
-        &self,
-        data: &InterpDataND<D>,
-        point: &[D::Elem],
-    ) -> Result<D::Elem, InterpolateError> {
-        let n = data.values.ndim();
-        let mut idx = vec![0usize; n];
-        for dim in 0..n {
-            idx[dim] = step_index(self.dir(dim), data.grid[dim].view(), &point[dim]);
-        }
-        Ok(data.values.view()[idx.as_slice()])
-    }
-
-    fn allow_extrapolate(&self) -> bool {
-        false
-    }
-}
-
 impl<D> StrategyND<D> for LinearUniform
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
+    /// Ensures grid uniformity in all dimensions
     fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
         for (dim, grid) in data.grid.iter().enumerate() {
             check_uniform_grid(grid.view(), dim)?;
@@ -217,7 +150,78 @@ where
         Ok(vals[0])
     }
 
+    /// Returns `true`.
     fn allow_extrapolate(&self) -> bool {
         true
+    }
+}
+
+impl<D> StrategyND<D> for Nearest
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Float + Debug,
+{
+    fn interpolate(
+        &self,
+        data: &InterpDataND<D>,
+        point: &[D::Elem],
+    ) -> Result<D::Elem, InterpolateError> {
+        let n = data.values.ndim();
+        // Nearest-neighbor on a rectilinear grid factorizes: select the nearest index
+        // independently per dimension, then do a single lookup. No corner extraction or
+        // dimensionality reduction needed — the distance comparison handles exact matches correctly.
+        let mut idx = vec![0usize; n];
+        for dim in 0..n {
+            let lower_idx = find_nearest_index(data.grid[dim].view(), &point[dim]);
+            idx[dim] = if point[dim] - data.grid[dim][lower_idx]
+                < data.grid[dim][lower_idx + 1] - point[dim]
+            {
+                lower_idx
+            } else {
+                lower_idx + 1
+            };
+        }
+        Ok(data.values.view()[idx.as_slice()])
+    }
+
+    /// Returns `false`.
+    fn allow_extrapolate(&self) -> bool {
+        false
+    }
+}
+
+impl<D> StrategyND<D> for Step
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Float + Debug,
+{
+    /// Ensures the number of provided step directions matches the dimensionality of the interpolator
+    fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+        let n = data.values.ndim();
+        if self.0.len() != 1 && self.0.len() != n {
+            return Err(ValidateError::Other(format!(
+                "Step strategy has {} step directions but interpolator is {n}-D (expected 1 or {n})",
+                self.0.len()
+            )));
+        }
+        Ok(())
+    }
+
+    fn interpolate(
+        &self,
+        data: &InterpDataND<D>,
+        point: &[D::Elem],
+    ) -> Result<D::Elem, InterpolateError> {
+        let n = data.values.ndim();
+        let mut idx = vec![0usize; n];
+        for dim in 0..n {
+            idx[dim] = step_index(self.dir(dim), data.grid[dim].view(), &point[dim]);
+        }
+        Ok(data.values.view()[idx.as_slice()])
+    }
+
+    /// Returns `false`.
+    fn allow_extrapolate(&self) -> bool {
+        false
     }
 }

--- a/src/interpolator/n/strategies.rs
+++ b/src/interpolator/n/strategies.rs
@@ -134,3 +134,38 @@ where
         false
     }
 }
+
+impl<D> StrategyND<D> for Step
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Num + PartialOrd + Copy + Debug,
+{
+    fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+        let n = data.values.ndim();
+        if self.0.len() != 1 && self.0.len() != n {
+            return Err(ValidateError::Other(format!(
+                "Step strategy has {} directions but interpolator is {n}-D (expected 1 or {n})",
+                self.0.len()
+            )));
+        }
+        Ok(())
+    }
+
+    fn interpolate(
+        &self,
+        data: &InterpDataND<D>,
+        point: &[D::Elem],
+    ) -> Result<D::Elem, InterpolateError> {
+        let n = data.values.ndim();
+        let mut idx = vec![0usize; n];
+        for dim in 0..n {
+            idx[dim] = step_index(self.dir(dim), data.grid[dim].view(), &point[dim]);
+        }
+        Ok(data.values.view()[idx.as_slice()])
+    }
+
+    /// Returns `false`.
+    fn allow_extrapolate(&self) -> bool {
+        false
+    }
+}

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -254,6 +254,71 @@ fn test_nearest() {
 }
 
 #[test]
+fn test_step() {
+    // Uniform Lower (floor) — same grid as test_nearest
+    let interp = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Step::from(strategy::StepDirection::Lower),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    // At grid points: exact value
+    let x = &interp.data.grid[0];
+    let y = &interp.data.grid[1];
+    let z = &interp.data.grid[2];
+    for i in 0..x.len() {
+        for j in 0..y.len() {
+            for k in 0..z.len() {
+                assert_eq!(
+                    interp.interpolate(&[x[i], y[j], z[k]]).unwrap(),
+                    interp.data.values[[i, j, k]]
+                );
+            }
+        }
+    }
+    // Between points: floor each dimension to index 0
+    assert_eq!(interp.interpolate(&[0.3, 0.7, 0.6]).unwrap(), 0.); // floor→[0,0,0]
+    assert_eq!(interp.interpolate(&[0.9, 0.9, 0.9]).unwrap(), 0.); // floor→[0,0,0]
+
+    // Uniform Upper (ceiling)
+    let interp_upper = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Step::from(strategy::StepDirection::Upper),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    assert_eq!(interp_upper.interpolate(&[0.3, 0.7, 0.6]).unwrap(), 7.); // ceil→[1,1,1]
+
+    // Per-dimension: Lower in x, Upper in y, Lower in z
+    let interp_mixed = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Step(vec![
+            strategy::StepDirection::Lower,
+            strategy::StepDirection::Upper,
+            strategy::StepDirection::Lower,
+        ]),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    assert_eq!(interp_mixed.interpolate(&[0.6, 0.4, 0.8]).unwrap(), 2.); // floor x→0, ceil y→1, floor z→0 → [0,1,0]
+
+    // Invalid: direction count mismatch
+    assert!(InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Step(vec![
+            strategy::StepDirection::Lower,
+            strategy::StepDirection::Lower,
+        ]),
+        Extrapolate::Error,
+    )
+    .is_err());
+}
+
+#[test]
 fn test_extrapolate_inputs() {
     // Extrapolate::Extrapolate
     assert!(matches!(

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -97,15 +97,12 @@ where
     ///     array![0., 1., 2.], // x0, x1, x2
     ///     // f(x)
     ///     array![0.0, 0.4, 0.8], // f(x0), f(x1), f(x2)
-    ///     strategy::Linear, // strategy mod is exposed via `use ndarray::prelude::*;`
+    ///     strategy::Linear,      // strategy mod is exposed via `use ndarray::prelude::*;`
     ///     Extrapolate::Enable,
     /// )
     /// .unwrap();
     /// assert_eq!(interp.interpolate(&[1.4]).unwrap(), 0.56);
-    /// assert_eq!(
-    ///     interp.interpolate(&[3.6]).unwrap(),
-    ///     1.44
-    /// );
+    /// assert_eq!(interp.interpolate(&[3.6]).unwrap(), 1.44);
     /// ```
     pub fn new(
         x: ArrayBase<D, Ix1>,

--- a/src/interpolator/one/strategies.rs
+++ b/src/interpolator/one/strategies.rs
@@ -36,6 +36,7 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
+    /// Ensures the grid is uniformly spaced.
     fn init(&mut self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)
     }
@@ -90,6 +91,7 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
+    /// Ensures the number of provided step directions matches the interpolator dimensionality.
     fn init(&mut self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 {
             return Err(ValidateError::Other(format!(

--- a/src/interpolator/one/strategies.rs
+++ b/src/interpolator/one/strategies.rs
@@ -57,56 +57,29 @@ where
     }
 }
 
-impl<D> Strategy1D<D> for LeftNearest
+impl<D> Strategy1D<D> for Step
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Num + PartialOrd + Copy + Debug,
 {
+    fn init(&mut self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
+        if self.0.len() != 1 {
+            return Err(ValidateError::Other(format!(
+                "Step strategy has {} directions but interpolator is 1-D (expected 1)",
+                self.0.len()
+            )));
+        }
+        Ok(())
+    }
+
     fn interpolate(
         &self,
         data: &InterpData1D<D>,
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
-        // find_nearest_index returns i where grid[i] < point <= grid[i+1] for interior matches,
-        // so when point == grid[i+1] exactly we want i+1 (not i), and len-1 for the last element.
-        let x_l = find_nearest_index(data.grid[0].view(), &point[0]);
-        let i = if &point[0] == data.grid[0].last().unwrap() {
-            data.grid[0].len() - 1
-        } else if point[0] == data.grid[0][x_l + 1] {
-            x_l + 1
-        } else {
-            x_l
-        };
-        Ok(data.values[i])
+        Ok(data.values[step_index(self.dir(0), data.grid[0].view(), &point[0])])
     }
 
-    /// Returns `false`.
-    fn allow_extrapolate(&self) -> bool {
-        false
-    }
-}
-
-impl<D> Strategy1D<D> for RightNearest
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Num + PartialOrd + Copy + Debug,
-{
-    fn interpolate(
-        &self,
-        data: &InterpData1D<D>,
-        point: &[D::Elem; 1],
-    ) -> Result<D::Elem, InterpolateError> {
-        // find_nearest_index returns 0 when point == grid[0], so x_u = 1 would skip values[0].
-        // For all other points (including interior exact matches) x_l+1 is correct.
-        let x_u = if &point[0] == data.grid[0].first().unwrap() {
-            0
-        } else {
-            find_nearest_index(data.grid[0].view(), &point[0]) + 1
-        };
-        Ok(data.values[x_u])
-    }
-
-    /// Returns `false`.
     fn allow_extrapolate(&self) -> bool {
         false
     }

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -40,7 +40,7 @@ fn test_left_nearest() {
     let interp = Interp1D::new(
         array![0., 1., 2., 3., 4.],
         array![0.2, 0.4, 0.6, 0.8, 1.0],
-        strategy::LeftNearest,
+        strategy::Step::from(strategy::StepDirection::Lower),
         Extrapolate::Error,
     )
     .unwrap();
@@ -60,7 +60,7 @@ fn test_right_nearest() {
     let interp = Interp1D::new(
         array![0., 1., 2., 3., 4.],
         array![0.2, 0.4, 0.6, 0.8, 1.0],
-        strategy::RightNearest,
+        strategy::Step::from(strategy::StepDirection::Upper),
         Extrapolate::Error,
     )
     .unwrap();

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -150,6 +150,21 @@ fn test_linear_uniform_extrapolate() {
 }
 
 #[test]
+fn test_step_invalid_direction_count() {
+    // 2 directions for a 1-D interpolator → ValidateError
+    assert!(Interp1D::new(
+        array![0., 1., 2., 3., 4.],
+        array![0.2, 0.4, 0.6, 0.8, 1.0],
+        strategy::Step(vec![
+            strategy::StepDirection::Lower,
+            strategy::StepDirection::Upper,
+        ]),
+        Extrapolate::Error,
+    )
+    .is_err());
+}
+
+#[test]
 fn test_extrapolate_inputs() {
     // Incorrect extrapolation selection
     assert!(matches!(
@@ -242,13 +257,13 @@ fn test_serde() {
     let interp = Interp1D::new(
         array![0., 1., 2., 3., 4.],
         array![0.2, 0.4, 0.6, 0.8, 1.0],
-        strategy::LeftNearest,
+        strategy::Step::from(strategy::StepDirection::Lower),
         Extrapolate::Error,
     )
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: Interp1DOwned<f64, strategy::LeftNearest> = serde_json::from_str(&ser).unwrap();
+    let de: Interp1DOwned<f64, strategy::Step> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     let data_ser = serde_json::to_string(&interp.data).unwrap();

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -115,7 +115,7 @@ where
     ///             [1.2, 1.4, 1.6, 1.8], // f(x1, y2, z0), f(x1, y2, z1), f(x1, y2, z2), f(x1, y2, z3)
     ///         ],
     ///     ],
-    ///     strategy::Linear, // strategy mod is exposed via `use ndarray::prelude::*;`
+    ///     strategy::Linear,   // strategy mod is exposed via `use ndarray::prelude::*;`
     ///     Extrapolate::Error, // return an error when point is out of bounds
     /// )
     /// .unwrap();

--- a/src/interpolator/three/strategies.rs
+++ b/src/interpolator/three/strategies.rs
@@ -122,6 +122,7 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
+    /// Ensures all grid dimensions are uniformly spaced.
     fn init(&mut self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)?;
         check_uniform_grid(data.grid[1].view(), 1)?;
@@ -158,6 +159,7 @@ where
         Ok(f0 * (D::Elem::one() - z_diff) + f1 * z_diff)
     }
 
+    /// Returns `true`.
     fn allow_extrapolate(&self) -> bool {
         true
     }
@@ -212,6 +214,7 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
+    /// Ensures the number of provided step directions matches the interpolator dimensionality.
     fn init(&mut self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 && self.0.len() != 3 {
             return Err(ValidateError::Other(format!(
@@ -233,6 +236,7 @@ where
         Ok(data.values[[i, j, k]])
     }
 
+    /// Returns `false`.
     fn allow_extrapolate(&self) -> bool {
         false
     }

--- a/src/interpolator/three/strategies.rs
+++ b/src/interpolator/three/strategies.rs
@@ -98,3 +98,34 @@ where
         false
     }
 }
+
+impl<D> Strategy3D<D> for Step
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Num + PartialOrd + Copy + Debug,
+{
+    fn init(&mut self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
+        if self.0.len() != 1 && self.0.len() != 3 {
+            return Err(ValidateError::Other(format!(
+                "Step strategy has {} directions but interpolator is 3-D (expected 1 or 3)",
+                self.0.len()
+            )));
+        }
+        Ok(())
+    }
+
+    fn interpolate(
+        &self,
+        data: &InterpData3D<D>,
+        point: &[D::Elem; 3],
+    ) -> Result<D::Elem, InterpolateError> {
+        let i = step_index(self.dir(0), data.grid[0].view(), &point[0]);
+        let j = step_index(self.dir(1), data.grid[1].view(), &point[1]);
+        let k = step_index(self.dir(2), data.grid[2].view(), &point[2]);
+        Ok(data.values[[i, j, k]])
+    }
+
+    fn allow_extrapolate(&self) -> bool {
+        false
+    }
+}

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -127,6 +127,64 @@ fn test_nearest() {
 }
 
 #[test]
+fn test_step() {
+    let interp = Interp3D::new(
+        array![0., 1.],
+        array![0., 1.],
+        array![0., 1.],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]],
+        strategy::Step::from(strategy::StepDirection::Lower),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    // At grid points: exact value
+    let x = &interp.data.grid[0];
+    let y = &interp.data.grid[1];
+    let z = &interp.data.grid[2];
+    for (i, xi) in x.iter().enumerate() {
+        for (j, yj) in y.iter().enumerate() {
+            for (k, zk) in z.iter().enumerate() {
+                assert_eq!(
+                    interp.interpolate(&[*xi, *yj, *zk]).unwrap(),
+                    interp.data.values[[i, j, k]]
+                );
+            }
+        }
+    }
+    // Between points: floor each dimension to index 0
+    assert_eq!(interp.interpolate(&[0.3, 0.7, 0.6]).unwrap(), 0.); // floor→[0,0,0]
+    assert_eq!(interp.interpolate(&[0.9, 0.4, 0.1]).unwrap(), 0.); // floor→[0,0,0]
+
+    // Uniform Upper (ceiling)
+    let interp_upper = Interp3D::new(
+        array![0., 1.],
+        array![0., 1.],
+        array![0., 1.],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]],
+        strategy::Step::from(strategy::StepDirection::Upper),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    assert_eq!(interp_upper.interpolate(&[0.3, 0.7, 0.6]).unwrap(), 7.); // ceil→[1,1,1]
+
+    // Per-dimension: Lower in x, Upper in y, Lower in z
+    let interp_mixed = Interp3D::new(
+        array![0., 1.],
+        array![0., 1.],
+        array![0., 1.],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]],
+        strategy::Step(vec![
+            strategy::StepDirection::Lower,
+            strategy::StepDirection::Upper,
+            strategy::StepDirection::Lower,
+        ]),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    assert_eq!(interp_mixed.interpolate(&[0.6, 0.4, 0.8]).unwrap(), 2.); // floor x→0, ceil y→1, floor z→0 → [0,1,0]
+}
+
+#[test]
 fn test_extrapolate_inputs() {
     // Extrapolate::Extrapolate
     assert!(matches!(

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -105,7 +105,7 @@ where
     ///         [0.2, 0.6, 1.0, 1.4], // f(x1, y0), f(x1, y1), f(x1, y2), f(x1, y3)
     ///         [0.4, 0.8, 1.2, 1.6], // f(x2, y0), f(x2, y1), f(x2, y2), f(x2, y3)
     ///     ],
-    ///     strategy::Linear, // strategy mod is exposed via `use ndarray::prelude::*;`
+    ///     strategy::Linear,   // strategy mod is exposed via `use ndarray::prelude::*;`
     ///     Extrapolate::Clamp, // restrict point within grid bounds
     /// )
     /// .unwrap();

--- a/src/interpolator/two/strategies.rs
+++ b/src/interpolator/two/strategies.rs
@@ -80,3 +80,33 @@ where
         false
     }
 }
+
+impl<D> Strategy2D<D> for Step
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Num + PartialOrd + Copy + Debug,
+{
+    fn init(&mut self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
+        if self.0.len() != 1 && self.0.len() != 2 {
+            return Err(ValidateError::Other(format!(
+                "Step strategy has {} directions but interpolator is 2-D (expected 1 or 2)",
+                self.0.len()
+            )));
+        }
+        Ok(())
+    }
+
+    fn interpolate(
+        &self,
+        data: &InterpData2D<D>,
+        point: &[D::Elem; 2],
+    ) -> Result<D::Elem, InterpolateError> {
+        let i = step_index(self.dir(0), data.grid[0].view(), &point[0]);
+        let j = step_index(self.dir(1), data.grid[1].view(), &point[1]);
+        Ok(data.values[[i, j]])
+    }
+
+    fn allow_extrapolate(&self) -> bool {
+        false
+    }
+}

--- a/src/interpolator/two/strategies.rs
+++ b/src/interpolator/two/strategies.rs
@@ -73,6 +73,7 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
+    /// Ensures all grid dimensions are uniformly spaced.
     fn init(&mut self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)?;
         check_uniform_grid(data.grid[1].view(), 1)
@@ -98,6 +99,7 @@ where
         Ok(f0 * (D::Elem::one() - y_diff) + f1 * y_diff)
     }
 
+    /// Returns `true`.
     fn allow_extrapolate(&self) -> bool {
         true
     }
@@ -144,6 +146,7 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
+    /// Ensures the number of provided step directions matches the interpolator dimensionality.
     fn init(&mut self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 && self.0.len() != 2 {
             return Err(ValidateError::Other(format!(
@@ -164,6 +167,7 @@ where
         Ok(data.values[[i, j]])
     }
 
+    /// Returns `false`.
     fn allow_extrapolate(&self) -> bool {
         false
     }

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -94,6 +94,62 @@ fn test_nearest() {
 }
 
 #[test]
+fn test_step() {
+    let grid_x = array![0., 1., 2.];
+    let grid_y = array![0., 1., 2.];
+    let values = array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]];
+
+    // Uniform Lower (floor) in all dimensions
+    let interp = Interp2D::new(
+        grid_x.view(),
+        grid_y.view(),
+        values.view(),
+        strategy::Step::from(strategy::StepDirection::Lower),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let x = &interp.data.grid[0];
+    let y = &interp.data.grid[1];
+    let f = &interp.data.values;
+    for (i, xi) in x.iter().enumerate() {
+        for (j, yj) in y.iter().enumerate() {
+            assert_eq!(interp.interpolate(&[*xi, *yj]).unwrap(), f[[i, j]]);
+        }
+    }
+    assert_eq!(interp.interpolate(&[0.7, 1.4]).unwrap(), f[[0, 1]]); // floor x→0, floor y→1
+    assert_eq!(interp.interpolate(&[1.9, 0.1]).unwrap(), f[[1, 0]]); // floor x→1, floor y→0
+
+    // Per-dimension: Lower in x, Upper in y
+    let interp_mixed = Interp2D::new(
+        grid_x.view(),
+        grid_y.view(),
+        values.view(),
+        strategy::Step(vec![
+            strategy::StepDirection::Lower,
+            strategy::StepDirection::Upper,
+        ]),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    assert_eq!(interp_mixed.interpolate(&[0.7, 1.4]).unwrap(), f[[0, 2]]); // floor x→0, ceil y→2
+    assert_eq!(interp_mixed.interpolate(&[1.3, 0.8]).unwrap(), f[[1, 1]]); // floor x→1, ceil y→1
+
+    // Invalid: 3 directions for 2-D
+    assert!(Interp2D::new(
+        grid_x.view(),
+        grid_y.view(),
+        values.view(),
+        strategy::Step(vec![
+            strategy::StepDirection::Lower,
+            strategy::StepDirection::Lower,
+            strategy::StepDirection::Lower,
+        ]),
+        Extrapolate::Error,
+    )
+    .is_err());
+}
+
+#[test]
 fn test_extrapolate_inputs() {
     // Extrapolate::Extrapolate
     assert!(matches!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,7 @@
 /// - The [`strategy`] mod, containing pre-defined interpolation strategies:
 ///   - [`strategy::Linear`]
 ///   - [`strategy::Nearest`]
-///   - [`strategy::LeftNearest`]
-///   - [`strategy::RightNearest`]
+///   - [`strategy::Step`] (replaces the former `LeftNearest`/`RightNearest`)
 ///   - `serde`-compatible strategy enums: [`strategy::enums::Strategy1DEnum`]/etc.
 /// - The extrapolation setting enum: [`Extrapolate`]
 pub mod prelude {

--- a/src/strategy/enums/mod.rs
+++ b/src/strategy/enums/mod.rs
@@ -72,7 +72,7 @@ mod tests {
         assert_eq!(interp.interpolate(&[3.75]).unwrap(), 1.0);
         assert_eq!(interp.interpolate(&[4.00]).unwrap(), 1.0);
 
-        interp.set_strategy(strategy::LeftNearest).unwrap();
+        interp.set_strategy(strategy::Step::from(strategy::StepDirection::Lower)).unwrap();
         assert_eq!(interp.interpolate(&[3.00]).unwrap(), 0.8);
         assert_eq!(interp.interpolate(&[3.75]).unwrap(), 0.8);
         assert_eq!(interp.interpolate(&[4.00]).unwrap(), 1.0);

--- a/src/strategy/enums/mod.rs
+++ b/src/strategy/enums/mod.rs
@@ -33,6 +33,13 @@
 //! assert_eq!(interp.interpolate(&[3.00]).unwrap(), 0.8);
 //! assert_eq!(interp.interpolate(&[3.75]).unwrap(), 0.95);
 //! assert_eq!(interp.interpolate(&[4.00]).unwrap(), 1.0);
+//!
+//! // Piecewise-constant: return value at nearest lower grid point
+//! interp
+//!     .set_strategy(strategy::Step::from(strategy::StepDirection::Lower))
+//!     .unwrap();
+//! assert_eq!(interp.interpolate(&[3.75]).unwrap(), 0.8);
+//! assert_eq!(interp.interpolate(&[4.00]).unwrap(), 1.0);
 //! ```
 //! See also: `examples/dynamic_strategy.rs`
 

--- a/src/strategy/enums/n.rs
+++ b/src/strategy/enums/n.rs
@@ -8,6 +8,7 @@ use super::*;
 pub enum StrategyNDEnum {
     Linear(strategy::Linear),
     Nearest(strategy::Nearest),
+    Step(strategy::Step),
 }
 
 impl From<Linear> for StrategyNDEnum {
@@ -24,6 +25,13 @@ impl From<Nearest> for StrategyNDEnum {
     }
 }
 
+impl From<Step> for StrategyNDEnum {
+    #[inline]
+    fn from(strategy: Step) -> Self {
+        StrategyNDEnum::Step(strategy)
+    }
+}
+
 impl<D> StrategyND<D> for StrategyNDEnum
 where
     D: Data + RawDataClone + Clone,
@@ -34,6 +42,7 @@ where
         match self {
             StrategyNDEnum::Linear(strategy) => StrategyND::<D>::init(strategy, data),
             StrategyNDEnum::Nearest(strategy) => StrategyND::<D>::init(strategy, data),
+            StrategyNDEnum::Step(strategy) => StrategyND::<D>::init(strategy, data),
         }
     }
 
@@ -48,6 +57,7 @@ where
             StrategyNDEnum::Nearest(strategy) => {
                 StrategyND::<D>::interpolate(strategy, data, point)
             }
+            StrategyNDEnum::Step(strategy) => StrategyND::<D>::interpolate(strategy, data, point),
         }
     }
 
@@ -56,6 +66,7 @@ where
         match self {
             StrategyNDEnum::Linear(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
             StrategyNDEnum::Nearest(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
+            StrategyNDEnum::Step(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
         }
     }
 }

--- a/src/strategy/enums/one.rs
+++ b/src/strategy/enums/one.rs
@@ -8,8 +8,7 @@ use super::*;
 pub enum Strategy1DEnum {
     Linear(strategy::Linear),
     Nearest(strategy::Nearest),
-    LeftNearest(strategy::LeftNearest),
-    RightNearest(strategy::RightNearest),
+    Step(strategy::Step),
 }
 
 impl From<Linear> for Strategy1DEnum {
@@ -26,17 +25,10 @@ impl From<Nearest> for Strategy1DEnum {
     }
 }
 
-impl From<LeftNearest> for Strategy1DEnum {
+impl From<Step> for Strategy1DEnum {
     #[inline]
-    fn from(strategy: LeftNearest) -> Self {
-        Self::LeftNearest(strategy)
-    }
-}
-
-impl From<RightNearest> for Strategy1DEnum {
-    #[inline]
-    fn from(strategy: RightNearest) -> Self {
-        Self::RightNearest(strategy)
+    fn from(strategy: Step) -> Self {
+        Self::Step(strategy)
     }
 }
 
@@ -50,8 +42,7 @@ where
         match self {
             Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::init(strategy, data),
             Strategy1DEnum::Nearest(strategy) => Strategy1D::<D>::init(strategy, data),
-            Strategy1DEnum::LeftNearest(strategy) => Strategy1D::<D>::init(strategy, data),
-            Strategy1DEnum::RightNearest(strategy) => Strategy1D::<D>::init(strategy, data),
+            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::init(strategy, data),
         }
     }
 
@@ -66,12 +57,7 @@ where
             Strategy1DEnum::Nearest(strategy) => {
                 Strategy1D::<D>::interpolate(strategy, data, point)
             }
-            Strategy1DEnum::LeftNearest(strategy) => {
-                Strategy1D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy1DEnum::RightNearest(strategy) => {
-                Strategy1D::<D>::interpolate(strategy, data, point)
-            }
+            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::interpolate(strategy, data, point),
         }
     }
 
@@ -80,8 +66,7 @@ where
         match self {
             Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
             Strategy1DEnum::Nearest(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-            Strategy1DEnum::LeftNearest(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-            Strategy1DEnum::RightNearest(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
+            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
         }
     }
 }
@@ -101,14 +86,6 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Strategy1DEnum::from(Nearest)).unwrap(),
             serde_json::to_string(&Nearest).unwrap(),
-        );
-        assert_eq!(
-            serde_json::to_string(&Strategy1DEnum::from(LeftNearest)).unwrap(),
-            serde_json::to_string(&LeftNearest).unwrap(),
-        );
-        assert_eq!(
-            serde_json::to_string(&Strategy1DEnum::from(RightNearest)).unwrap(),
-            serde_json::to_string(&RightNearest).unwrap(),
         );
     }
 }

--- a/src/strategy/enums/three.rs
+++ b/src/strategy/enums/three.rs
@@ -8,6 +8,7 @@ use super::*;
 pub enum Strategy3DEnum {
     Linear(strategy::Linear),
     Nearest(strategy::Nearest),
+    Step(strategy::Step),
 }
 
 impl From<Linear> for Strategy3DEnum {
@@ -24,6 +25,13 @@ impl From<Nearest> for Strategy3DEnum {
     }
 }
 
+impl From<Step> for Strategy3DEnum {
+    #[inline]
+    fn from(strategy: Step) -> Self {
+        Self::Step(strategy)
+    }
+}
+
 impl<D> Strategy3D<D> for Strategy3DEnum
 where
     D: Data + RawDataClone + Clone,
@@ -34,6 +42,7 @@ where
         match self {
             Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::init(strategy, data),
             Strategy3DEnum::Nearest(strategy) => Strategy3D::<D>::init(strategy, data),
+            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::init(strategy, data),
         }
     }
 
@@ -48,6 +57,7 @@ where
             Strategy3DEnum::Nearest(strategy) => {
                 Strategy3D::<D>::interpolate(strategy, data, point)
             }
+            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::interpolate(strategy, data, point),
         }
     }
 
@@ -56,6 +66,7 @@ where
         match self {
             Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
             Strategy3DEnum::Nearest(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
+            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
         }
     }
 }

--- a/src/strategy/enums/two.rs
+++ b/src/strategy/enums/two.rs
@@ -8,6 +8,7 @@ use super::*;
 pub enum Strategy2DEnum {
     Linear(strategy::Linear),
     Nearest(strategy::Nearest),
+    Step(strategy::Step),
 }
 
 impl From<Linear> for Strategy2DEnum {
@@ -24,6 +25,13 @@ impl From<Nearest> for Strategy2DEnum {
     }
 }
 
+impl From<Step> for Strategy2DEnum {
+    #[inline]
+    fn from(strategy: Step) -> Self {
+        Self::Step(strategy)
+    }
+}
+
 impl<D> Strategy2D<D> for Strategy2DEnum
 where
     D: Data + RawDataClone + Clone,
@@ -34,6 +42,7 @@ where
         match self {
             Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::init(strategy, data),
             Strategy2DEnum::Nearest(strategy) => Strategy2D::<D>::init(strategy, data),
+            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::init(strategy, data),
         }
     }
 
@@ -48,6 +57,7 @@ where
             Strategy2DEnum::Nearest(strategy) => {
                 Strategy2D::<D>::interpolate(strategy, data, point)
             }
+            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::interpolate(strategy, data, point),
         }
     }
 
@@ -56,6 +66,7 @@ where
         match self {
             Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
             Strategy2DEnum::Nearest(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
+            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
         }
     }
 }

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -95,10 +95,18 @@ pub enum StepDirection {
 /// assert_eq!(interp.interpolate(&[3.00]).unwrap(), 0.8); // exact grid point
 ///
 /// // Per-dimension: floor in x, ceiling in y (2-D interpolator)
-/// let mixed = strategy::Step(vec![
-///     strategy::StepDirection::Lower,
-///     strategy::StepDirection::Upper,
-/// ]);
+/// let interp = Interp2D::new(
+///     array![0., 1., 2.],
+///     array![0., 1., 2.],
+///     array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+///     strategy::Step(vec![
+///         strategy::StepDirection::Lower,
+///         strategy::StepDirection::Upper,
+///     ]),
+///     Extrapolate::Error,
+/// )
+/// .unwrap();
+/// assert_eq!(interp.interpolate(&[0.7, 1.4]).unwrap(), 2.); // floor x→0, ceil y→2
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Step(pub Vec<StepDirection>);

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -24,21 +24,55 @@ pub struct Linear;
 )]
 pub struct Nearest;
 
-/// Left-nearest (previous value) interpolation: <https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation>
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Deserialize_unit_struct, Serialize_unit_struct)
-)]
-pub struct LeftNearest;
+/// Direction used by [`Step`] interpolation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub enum StepDirection {
+    /// Return the value at the nearest **lower** grid point (floor / previous value).
+    Lower,
+    /// Return the value at the nearest **upper** grid point (ceiling / next value).
+    Upper,
+}
 
-/// Right-nearest (next value) interpolation: <https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation>
+/// Piecewise-constant (step) interpolation.
+///
+/// Returns the value at the nearest lower or upper grid point in each dimension.
+/// Construct from a single [`StepDirection`] to broadcast the same direction across all
+/// dimensions, or supply one direction per dimension for mixed behavior.
+///
+/// # Examples
+/// ```
+/// use ninterp::prelude::*;
+/// use ninterp::strategy::{Step, StepDirection};
+///
+/// // All dimensions floor (previous value)
+/// let floor = Step::from(StepDirection::Lower);
+///
+/// // Per-dimension: floor in x, ceiling in y (for a 2-D interpolator)
+/// let mixed = Step(vec![StepDirection::Lower, StepDirection::Upper]);
+/// ```
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Deserialize_unit_struct, Serialize_unit_struct)
-)]
-pub struct RightNearest;
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct Step(pub Vec<StepDirection>);
+
+impl From<StepDirection> for Step {
+    /// Broadcasts `dir` to all dimensions.
+    fn from(dir: StepDirection) -> Self {
+        Step(vec![dir])
+    }
+}
+
+impl Step {
+    /// Returns the direction for dimension `dim`.
+    /// A single stored direction broadcasts to all dimensions.
+    pub(crate) fn dir(&self, dim: usize) -> StepDirection {
+        if self.0.len() == 1 {
+            self.0[0]
+        } else {
+            self.0[dim]
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -29,7 +29,8 @@ pub struct Linear;
 ///     array![0.2, 0.4, 0.6, 0.8, 1.0],
 ///     strategy::LinearUniform,
 ///     Extrapolate::Error,
-/// ).unwrap();
+/// )
+/// .unwrap();
 /// assert_eq!(interp.interpolate(&[2.5]).unwrap(), 0.7);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
@@ -68,17 +69,38 @@ pub enum StepDirection {
 ///
 /// # Examples
 /// ```
+/// use ndarray::prelude::*;
 /// use ninterp::prelude::*;
-/// use ninterp::strategy::{Step, StepDirection};
 ///
-/// // All dimensions floor (previous value)
-/// let floor = Step::from(StepDirection::Lower);
+/// // Floor (previous value): returns the value at the nearest lower grid point
+/// let interp = Interp1D::new(
+///     array![0., 1., 2., 3., 4.],
+///     array![0.2, 0.4, 0.6, 0.8, 1.0],
+///     strategy::Step::from(strategy::StepDirection::Lower),
+///     Extrapolate::Error,
+/// )
+/// .unwrap();
+/// assert_eq!(interp.interpolate(&[3.75]).unwrap(), 0.8); // floor → value at 3.0
+/// assert_eq!(interp.interpolate(&[4.00]).unwrap(), 1.0); // exact grid point
 ///
-/// // Per-dimension: floor in x, ceiling in y (for a 2-D interpolator)
-/// let mixed = Step(vec![StepDirection::Lower, StepDirection::Upper]);
+/// // Ceiling (next value): returns the value at the nearest upper grid point
+/// let interp = Interp1D::new(
+///     array![0., 1., 2., 3., 4.],
+///     array![0.2, 0.4, 0.6, 0.8, 1.0],
+///     strategy::Step::from(strategy::StepDirection::Upper),
+///     Extrapolate::Error,
+/// )
+/// .unwrap();
+/// assert_eq!(interp.interpolate(&[3.25]).unwrap(), 1.0); // ceil → value at 4.0
+/// assert_eq!(interp.interpolate(&[3.00]).unwrap(), 0.8); // exact grid point
+///
+/// // Per-dimension: floor in x, ceiling in y (2-D interpolator)
+/// let mixed = strategy::Step(vec![
+///     strategy::StepDirection::Lower,
+///     strategy::StepDirection::Upper,
+/// ]);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Step(pub Vec<StepDirection>);
 
 impl From<StepDirection> for Step {
@@ -100,6 +122,37 @@ impl Step {
     }
 }
 
+#[cfg(feature = "serde")]
+mod step_serde {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Helper that serializes/deserializes `Step` as `{"Step": [...directions...]}`.
+    /// This makes the strategy type explicit in the output, consistent with how
+    /// `Linear`, `Nearest`, etc. serialize to their type name.
+    #[derive(Serialize, Deserialize)]
+    struct StepHelper {
+        #[serde(rename = "Step")]
+        directions: Vec<StepDirection>,
+    }
+
+    impl Serialize for Step {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            StepHelper {
+                directions: self.0.clone(),
+            }
+            .serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Step {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let helper = StepHelper::deserialize(deserializer)?;
+            Ok(Step(helper.directions))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
@@ -113,16 +166,24 @@ mod tests {
             format!("\"{}\"", stringify!(Linear))
         );
         assert_eq!(
+            serde_json::to_string(&LinearUniform).unwrap(),
+            format!("\"{}\"", stringify!(LinearUniform))
+        );
+        assert_eq!(
             serde_json::to_string(&Nearest).unwrap(),
             format!("\"{}\"", stringify!(Nearest))
         );
         assert_eq!(
-            serde_json::to_string(&LeftNearest).unwrap(),
-            format!("\"{}\"", stringify!(LeftNearest))
+            serde_json::to_string(&Step::from(StepDirection::Lower)).unwrap(),
+            r#"{"Step":["Lower"]}"#
         );
         assert_eq!(
-            serde_json::to_string(&RightNearest).unwrap(),
-            format!("\"{}\"", stringify!(RightNearest))
+            serde_json::to_string(&Step::from(StepDirection::Upper)).unwrap(),
+            r#"{"Step":["Upper"]}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&Step(vec![StepDirection::Lower, StepDirection::Upper])).unwrap(),
+            r#"{"Step":["Lower","Upper"]}"#
         );
     }
 }

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -32,6 +32,40 @@ pub fn find_nearest_index<T: PartialOrd>(arr: ArrayView1<T>, target: &T) -> usiz
     }
 }
 
+/// Returns the step index for `point` in `grid` using the given [`StepDirection`].
+///
+/// Handles all exact grid-point edge cases that arise from [`find_nearest_index`]'s
+/// interval semantics (returning the lower bracket rather than the exact position).
+pub(crate) fn step_index<T: PartialOrd + Copy>(
+    dir: StepDirection,
+    grid: ArrayView1<T>,
+    point: &T,
+) -> usize {
+    match dir {
+        StepDirection::Lower => {
+            let x_l = find_nearest_index(grid, point);
+            // find_nearest_index returns i where grid[i] < point <= grid[i+1] for interior
+            // matches, so an exact match at grid[i+1] gives i instead of i+1. Correct both:
+            if point == grid.last().unwrap() {
+                grid.len() - 1
+            } else if *point == grid[x_l + 1] {
+                x_l + 1
+            } else {
+                x_l
+            }
+        }
+        StepDirection::Upper => {
+            // find_nearest_index returns 0 when point == grid[0], giving x_l+1 = 1
+            // which would skip values[0]. Handle the first-element case explicitly:
+            if point == grid.first().unwrap() {
+                0
+            } else {
+                find_nearest_index(grid, point) + 1
+            }
+        }
+    }
+}
+
 /// 1-D interpolation strategy.
 pub trait Strategy1D<D>: Debug + DynClone
 where


### PR DESCRIPTION
**Replace `LeftNearest`/`RightNearest` with `strategy::Step`**

`LeftNearest` and `RightNearest` were 1D-only unit structs with a fundamental limitation: "left" and "right" have no meaning in higher-dimensional spaces, and implementing them for 2D, 3D, and ND would require four separate structs (one per dimensionality) and duplicate implementations.

This PR replaces both with a single parameterized `Step` strategy that works uniformly across all dimensionalities.

---

**`StepDirection` enum**

```rust
pub enum StepDirection {
    Lower,  // floor / previous value
    Upper,  // ceil / next value
}
```

**`Step` struct**

```rust
pub struct Step(pub Vec<StepDirection>);
```

A single direction broadcasts to all dimensions; a vec of N directions enables per-axis control:

```rust
Step::from(StepDirection::Lower)                              // floor everywhere
Step::from(StepDirection::Upper)                              // ceil everywhere
Step(vec![StepDirection::Lower, StepDirection::Upper])        // per-dim, 2-D
```

**Available for all dimensionalities** — 1D, 2D, 3D, and ND. Included in all strategy enums (`Strategy1DEnum`, etc.) for runtime swapping.

**Validation** — `init()` returns `ValidateError` if the number of directions is neither 1 (broadcast) nor exactly N (per-dimension).

---

**Serde**

`Step` serializes as a tagged object rather than a bare array, keeping the strategy type explicit:

```json
{"Step": ["Lower"]}
{"Step": ["Lower", "Upper"]}
```

YAML:
```yaml
strategy:
  Step:
  - Lower
```

---

**Breaking changes**

- `strategy::LeftNearest` and `strategy::RightNearest` are removed. Migration:
  - `LeftNearest` → `Step::from(StepDirection::Lower)`
  - `RightNearest` → `Step::from(StepDirection::Upper)`
- The strategy enums (`Strategy1DEnum`) now require `D::Elem: Float + Debug` (previously `Num + PartialOrd + Copy + Debug`), consistent with the global `Float` bound introduced in the prerequisite branch.