### PR TITLE
Make crate no_std compatible under `serde` feature

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,13 +41,8 @@ jobs:
       - name: verify no_std build (bare-metal target)
         run: cargo build --lib --no-default-features --target thumbv7m-none-eabi
 
-      # Blocked on an upstream serde-ndim fix (RReverser/serde-ndim#8): serde-ndim
-      # 2.2.1 pulls in serde's default std feature regardless of its own no_std
-      # setting, so this fails until a fixed release ships. "All features" here
-      # means everything except std, which a true no_std target can't build with
-      # anyway. Uncomment once serde-ndim's fix is out.
-      # - name: verify no_std build (bare-metal target, all features)
-      #   run: cargo build --lib --no-default-features --features serde --target thumbv7m-none-eabi
+      - name: verify no_std build (bare-metal target, all features)
+        run: cargo build --lib --no-default-features --features serde --target thumbv7m-none-eabi
 
       - name: run all examples
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.103", optional = true, default-features = false, featur
     "alloc",
 ] }
 serde_unit_struct = { version = "0.1.3", optional = true }
+# TODO: bump serde-ndim when no-std fix is out
 serde-ndim = { version = "2.2.1", optional = true, default-features = false, features = [
     "ndarray",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ serde = { version = "1.0.103", optional = true, default-features = false, featur
     "alloc",
 ] }
 serde_unit_struct = { version = "0.1.3", optional = true }
-# TODO: bump serde-ndim when no-std fix is out
-serde-ndim = { version = "2.2.1", optional = true, default-features = false, features = [
+serde-ndim = { version = "2.2.2", optional = true, default-features = false, features = [
     "ndarray",
 ] }
 thiserror = { version = "2.0.12", default-features = false }


### PR DESCRIPTION
This PR makes the crate no-std compatible with any feature set

Waiting on https://github.com/RReverser/serde-ndim/pull/8 and corresponding release for a merge