### PR TITLE
ValidateError on grid length < 2 & variant cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ Everything below is merged to `main` but not yet tagged/released.
   `Num + PartialOrd`). Other strategies (`Nearest`, `Step`, etc.) keep looser numeric
   bounds after an initial, overly broad `Float` restriction across the whole strategy
   surface was narrowed back down to just the two strategies that actually need it.
+- **Breaking:** `ValidateError` variants renamed for consistency, and no longer read as
+  full sentences: `ExtrapolateSelection` -> `InvalidExtrapolate`, `Monotonicity` ->
+  `NonMonotonic`. `EmptyGrid` is removed outright; a grid dimension with 0 or 1 points
+  is now rejected by the same `InsufficientGridPoints`, since a single point can't
+  bracket a query either.
 - Significant ND performance work: `Linear`/`Nearest` no longer build coordinate
   permutation tables via `itertools::multi_cartesian_product` (removing the `itertools`
   dependency); corner values are now gathered into a flat buffer and reduced with an
@@ -64,6 +69,12 @@ Everything below is merged to `main` but not yet tagged/released.
   dimension without touching it) to `find_nearest_index`, whose binary search calls
   `.first().unwrap()` and panics on an empty dimension. Fixed by skipping empty grid
   dimensions in that loop.
+- A grid dimension with exactly 1 point passed construction and then panicked on the
+  first `interpolate` call (integer underflow in the lower-bracket search, or an
+  out-of-bounds index right after it), for every strategy except when
+  `Extrapolate::Enable` was selected, since the "at least 2 points" check only ran for
+  that one setting. It's now checked unconditionally at construction, so this is a
+  `ValidateError::InsufficientGridPoints` instead of a panic.
 
 ## [0.9.1] - 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Retrieve dimensionality using [`Interpolator::ndim`](https://docs.rs/ninterp/lat
 
 ### Common Errors
 Validation-time (`new` / `validate`):
-- Empty grid coordinates (`ValidateError::EmptyGrid`)
-- Non-monotonic coordinates (`ValidateError::Monotonicity`)
+- Fewer than 2 grid coordinates in a dimension (`ValidateError::InsufficientGridPoints`)
+- Non-monotonic coordinates (`ValidateError::NonMonotonic`)
 - Grid/value shape mismatch (`ValidateError::IncompatibleShapes`)
-- Inapplicable extrapolation setting (`ValidateError::ExtrapolateSelection`)
+- Inapplicable extrapolation setting (`ValidateError::InvalidExtrapolate`)
 
 Interpolation-time (`interpolate`):
 - Query point has wrong dimensionality (`InterpolateError::PointLength`)

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,11 +8,11 @@ use thiserror::Error;
 #[derive(Error, Clone, PartialEq)]
 pub enum ValidateError {
     #[error("selected `Extrapolate` variant ({0}) is unimplemented/inapplicable for interpolator")]
-    ExtrapolateSelection(String),
-    #[error("supplied grid coordinates cannot be empty: dim {0}")]
-    EmptyGrid(usize),
+    InvalidExtrapolate(String),
+    #[error("at least 2 grid points are required per dimension: dim {0}")]
+    InsufficientGridPoints(usize),
     #[error("supplied coordinates must be monotonically increasing: dim {0}")]
-    Monotonicity(usize),
+    NonMonotonic(usize),
     #[error("supplied grid and values are not compatible shapes: dim {0}")]
     IncompatibleShapes(usize),
     #[error("{0}")]

--- a/src/interpolator/data.rs
+++ b/src/interpolator/data.rs
@@ -86,13 +86,13 @@ where
     {
         for i in 0..N {
             let i_grid_len = self.grid[i].len();
-            // Check that each grid dimension has elements
-            if i_grid_len == 0 {
-                return Err(ValidateError::EmptyGrid(i));
+            // Every strategy needs at least 2 points per dimension to bracket a query point
+            if i_grid_len < 2 {
+                return Err(ValidateError::InsufficientGridPoints(i));
             }
             // Check that grid points are monotonically increasing
             if !self.grid[i].windows(2).into_iter().all(|w| w[0] <= w[1]) {
-                return Err(ValidateError::Monotonicity(i));
+                return Err(ValidateError::NonMonotonic(i));
             }
             // Check that grid and values are compatible shapes
             if i_grid_len != self.values.shape()[i] {

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -87,21 +87,10 @@ macro_rules! extrapolate_impl {
                 // Check applicability of strategy and extrapolate setting
                 if matches!(extrapolate, Extrapolate::Enable) && !self.strategy.allow_extrapolate()
                 {
-                    return Err(ValidateError::ExtrapolateSelection(format!(
+                    return Err(ValidateError::InvalidExtrapolate(format!(
                         "{:?}",
                         self.extrapolate
                     )));
-                }
-                // If using Extrapolate::Enable,
-                // check that each grid dimension has at least two elements
-                if matches!(self.extrapolate, Extrapolate::Enable) {
-                    for (i, g) in self.data.grid.iter().enumerate() {
-                        if g.len() < 2 {
-                            return Err(ValidateError::Other(format!(
-                                "at least 2 data points are required for extrapolation: dim {i}",
-                            )));
-                        }
-                    }
                 }
                 Ok(())
             }

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -96,14 +96,13 @@ where
         }
         for i in 0..n {
             let i_grid_len = self.grid[i].len();
-            // Check that each grid dimension has elements
-            // Indexing `grid` directly is okay because empty dimensions are caught at compilation
-            if i_grid_len == 0 {
-                return Err(ValidateError::EmptyGrid(i));
+            // Every strategy needs at least 2 points per dimension to bracket a query point
+            if i_grid_len < 2 {
+                return Err(ValidateError::InsufficientGridPoints(i));
             }
             // Check that grid points are monotonically increasing
             if !self.grid[i].windows(2).into_iter().all(|w| w[0] <= w[1]) {
-                return Err(ValidateError::Monotonicity(i));
+                return Err(ValidateError::NonMonotonic(i));
             }
             // Check that grid and values are compatible shapes
             if i_grid_len != self.values.shape()[i] {

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -366,7 +366,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::ExtrapolateSelection(_)
+        ValidateError::InvalidExtrapolate(_)
     ));
     // Extrapolate::Error
     let interp = InterpND::new(

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -17,6 +17,22 @@ fn test_invalid_args() {
 }
 
 #[test]
+fn test_insufficient_grid_points() {
+    // A single grid point can't bracket anything, regardless of `Extrapolate` setting.
+    // Previously this passed construction and panicked on the first `interpolate` call.
+    assert!(matches!(
+        Interp1D::new(
+            array![5.0],
+            array![10.0],
+            strategy::Linear,
+            Extrapolate::Error
+        )
+        .unwrap_err(),
+        ValidateError::InsufficientGridPoints(0)
+    ));
+}
+
+#[test]
 fn test_linear() {
     let interp = Interp1D::new(
         array![0., 1., 2., 3., 4.],
@@ -224,7 +240,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::ExtrapolateSelection(_)
+        ValidateError::InvalidExtrapolate(_)
     ));
 
     // Extrapolate::Error

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -222,7 +222,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::ExtrapolateSelection(_)
+        ValidateError::InvalidExtrapolate(_)
     ));
     // Extrapolate::Error
     let interp = Interp3D::new(

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -181,7 +181,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::ExtrapolateSelection(_)
+        ValidateError::InvalidExtrapolate(_)
     ));
     // Extrapolate::Error
     let interp = Interp2D::new(


### PR DESCRIPTION
## Summary

- A grid dimension with 0 or 1 points passed construction whenever `Extrapolate::Enable`
  wasn't selected, since the "at least 2 points" check only ran for that one setting.
  Every bundled strategy actually needs 2+ points to bracket a query regardless of
  extrapolation mode, so a 1-point dimension panicked on the first `interpolate` call
  instead (integer underflow in the lower-bracket search, or an out-of-bounds index
  right after it). Reproduced with `Interp1D::new(array![5.0], array![10.0],
  strategy::Linear, Extrapolate::Error).unwrap().interpolate(&[5.0])`.
- The check now runs unconditionally in `InterpData::validate` / `InterpDataND::validate`,
  turning that panic into a `ValidateError::InsufficientGridPoints` at construction time.
- **Breaking:** `ValidateError` variants renamed for consistency, no longer full
  sentences: `ExtrapolateSelection` -> `InvalidExtrapolate`, `Monotonicity` ->
  `NonMonotonic`. `EmptyGrid` is removed outright; `InsufficientGridPoints` now covers
  both the 0-point and 1-point cases with a single check.
- `README.md`'s error list updated to match.

## Test plan

- [x] New regression test `test_insufficient_grid_points` covering the exact panic
      scenario above
- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (69 unit tests, 15 doc tests, all passing)
- [x] `cargo clippy --all-features --all-targets` (clean)
- [x] `cargo fmt --check`
