### PR TITLE
Split Strategy::init into a pure validate and a mutating init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ Everything below is merged to `main` but not yet tagged/released.
   `"LinearUniform:"`, since other strategies can call it directly now too.
 
 ### Changed
+- **Breaking:** `Strategy1D`/`Strategy2D`/`Strategy3D`/`StrategyND::init` is split into
+  a pure `validate(&self, data)` and a mutating `init(&mut self, data)`, both
+  default-no-op (non-breaking for existing custom strategy implementations, which keep
+  compiling unchanged). `validate` is for invariant checks that don't need precomputed
+  state (`LinearUniform`'s grid-uniformity check and `Step`'s direction-count check
+  both moved from `init` to `validate`); `init` stays reserved for real precomputation.
+  `new` and `set_strategy` call both; `Interpolator::validate` now also calls
+  `validate_strategy` (see below), so invariant violations like a non-uniform
+  `LinearUniform` grid are caught there too, not just via `init_strategy`.
+- Each `Interp1D`/`Interp2D`/`Interp3D`/`InterpND` gains a public `validate_strategy()`,
+  mirroring the existing `init_strategy()`: re-runs the strategy's `validate` against
+  the current data, for use after mutating the public `data`/`strategy` fields
+  directly.
 - **Breaking:** `find_nearest_index` is renamed to `locate_lower_index` and, along with
   the other grid/index search helpers (`step_index` -> `locate_step_index`,
   `uniform_lower_index` -> `locate_lower_index_uniform`, `exact_index`,

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -191,6 +191,32 @@ serialize_nested_impl!(InterpND, InterpDataND, StrategyND);
 impl<D, S> InterpND<D, S>
 where
     D: Data + RawDataClone + Clone,
+    D::Elem: PartialEq + Debug,
+    S: StrategyND<D> + Clone,
+{
+    /// Re-run the strategy's [`StrategyND::validate`] against the current data.
+    ///
+    /// `new`, `set_strategy`, and [`Interpolator::validate`] already call this
+    /// internally, so this is only needed after mutating the public `data`/`strategy`
+    /// fields directly.
+    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
+        self.strategy.validate(&self.data)
+    }
+
+    /// Re-run the strategy's [`StrategyND::init`] against the current data.
+    ///
+    /// `new` and `set_strategy` already call this internally, so this is only needed
+    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
+    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
+    /// does not call `init`).
+    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
+        self.strategy.init(&self.data)
+    }
+}
+
+impl<D, S> InterpND<D, S>
+where
+    D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
     S: StrategyND<D> + Clone,
 {
@@ -249,18 +275,9 @@ where
             extrapolate,
         };
         interpolator.check_extrapolate(&interpolator.extrapolate)?;
-        interpolator.strategy.init(&interpolator.data)?;
+        interpolator.validate_strategy()?;
+        interpolator.init_strategy()?;
         Ok(interpolator)
-    }
-
-    /// Re-run the strategy's [`StrategyND::init`] against the current data.
-    ///
-    /// `new` and `set_strategy` already call this internally, so this is only needed
-    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        self.strategy.init(&self.data)
     }
 
     /// Return an interpolator with viewed data.
@@ -304,6 +321,7 @@ where
     fn validate(&self) -> Result<(), ValidateError> {
         self.check_extrapolate(&self.extrapolate)?;
         self.data.validate()?;
+        self.validate_strategy()?;
         Ok(())
     }
 
@@ -383,7 +401,8 @@ where
     pub fn set_strategy(&mut self, strategy: Box<dyn StrategyND<D>>) -> Result<(), ValidateError> {
         self.strategy = strategy;
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }
 
@@ -403,6 +422,7 @@ where
     ) -> Result<(), ValidateError> {
         self.strategy = strategy.into();
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }

--- a/src/interpolator/n/strategies.rs
+++ b/src/interpolator/n/strategies.rs
@@ -92,7 +92,7 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures grid uniformity in all dimensions
-    fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
         for (dim, grid) in data.grid.iter().enumerate() {
             check_uniform_grid(grid.view(), dim)?;
         }
@@ -180,7 +180,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the dimensionality of the interpolator
-    fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
         let n = data.values.ndim();
         if self.0.len() != 1 && self.0.len() != n {
             return Err(ValidateError::Other(format!(

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -75,6 +75,32 @@ serialize_nested_impl!(Interp1D, InterpData1D, Strategy1D);
 impl<D, S> Interp1D<D, S>
 where
     D: Data + RawDataClone + Clone,
+    D::Elem: PartialEq + Debug,
+    S: Strategy1D<D> + Clone,
+{
+    /// Re-run the strategy's [`Strategy1D::validate`] against the current data.
+    ///
+    /// `new`, `set_strategy`, and [`Interpolator::validate`] already call this
+    /// internally, so this is only needed after mutating the public `data`/`strategy`
+    /// fields directly.
+    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
+        self.strategy.validate(&self.data)
+    }
+
+    /// Re-run the strategy's [`Strategy1D::init`] against the current data.
+    ///
+    /// `new` and `set_strategy` already call this internally, so this is only needed
+    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
+    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
+    /// does not call `init`).
+    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
+        self.strategy.init(&self.data)
+    }
+}
+
+impl<D, S> Interp1D<D, S>
+where
+    D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
     S: Strategy1D<D> + Clone,
 {
@@ -110,18 +136,9 @@ where
             extrapolate,
         };
         interpolator.check_extrapolate(&interpolator.extrapolate)?;
-        interpolator.strategy.init(&interpolator.data)?;
+        interpolator.validate_strategy()?;
+        interpolator.init_strategy()?;
         Ok(interpolator)
-    }
-
-    /// Re-run the strategy's [`Strategy1D::init`] against the current data.
-    ///
-    /// `new` and `set_strategy` already call this internally, so this is only needed
-    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        self.strategy.init(&self.data)
     }
 
     /// Return an interpolator with viewed data.
@@ -166,6 +183,7 @@ where
     fn validate(&self) -> Result<(), ValidateError> {
         self.check_extrapolate(&self.extrapolate)?;
         self.data.validate()?;
+        self.validate_strategy()?;
         Ok(())
     }
 
@@ -226,7 +244,8 @@ where
     pub fn set_strategy(&mut self, strategy: Box<dyn Strategy1D<D>>) -> Result<(), ValidateError> {
         self.strategy = strategy;
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }
 
@@ -246,6 +265,7 @@ where
     ) -> Result<(), ValidateError> {
         self.strategy = strategy.into();
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }

--- a/src/interpolator/one/strategies.rs
+++ b/src/interpolator/one/strategies.rs
@@ -34,7 +34,7 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures the grid is uniformly spaced.
-    fn init(&mut self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)
     }
 
@@ -89,7 +89,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
-    fn init(&mut self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 {
             return Err(ValidateError::Other(format!(
                 "Step strategy has {} directions but interpolator is 1-D (expected 1)",

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -80,6 +80,32 @@ serialize_nested_impl!(Interp3D, InterpData3D, Strategy3D);
 impl<D, S> Interp3D<D, S>
 where
     D: Data + RawDataClone + Clone,
+    D::Elem: PartialEq + Debug,
+    S: Strategy3D<D> + Clone,
+{
+    /// Re-run the strategy's [`Strategy3D::validate`] against the current data.
+    ///
+    /// `new`, `set_strategy`, and [`Interpolator::validate`] already call this
+    /// internally, so this is only needed after mutating the public `data`/`strategy`
+    /// fields directly.
+    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
+        self.strategy.validate(&self.data)
+    }
+
+    /// Re-run the strategy's [`Strategy3D::init`] against the current data.
+    ///
+    /// `new` and `set_strategy` already call this internally, so this is only needed
+    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
+    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
+    /// does not call `init`).
+    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
+        self.strategy.init(&self.data)
+    }
+}
+
+impl<D, S> Interp3D<D, S>
+where
+    D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
     S: Strategy3D<D> + Clone,
 {
@@ -136,18 +162,9 @@ where
             extrapolate,
         };
         interpolator.check_extrapolate(&interpolator.extrapolate)?;
-        interpolator.strategy.init(&interpolator.data)?;
+        interpolator.validate_strategy()?;
+        interpolator.init_strategy()?;
         Ok(interpolator)
-    }
-
-    /// Re-run the strategy's [`Strategy3D::init`] against the current data.
-    ///
-    /// `new` and `set_strategy` already call this internally, so this is only needed
-    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        self.strategy.init(&self.data)
     }
 
     /// Return an interpolator with viewed data.
@@ -192,6 +209,7 @@ where
     fn validate(&self) -> Result<(), ValidateError> {
         self.check_extrapolate(&self.extrapolate)?;
         self.data.validate()?;
+        self.validate_strategy()?;
         Ok(())
     }
 
@@ -262,7 +280,8 @@ where
     pub fn set_strategy(&mut self, strategy: Box<dyn Strategy3D<D>>) -> Result<(), ValidateError> {
         self.strategy = strategy;
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }
 
@@ -282,6 +301,7 @@ where
     ) -> Result<(), ValidateError> {
         self.strategy = strategy.into();
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }

--- a/src/interpolator/three/strategies.rs
+++ b/src/interpolator/three/strategies.rs
@@ -164,7 +164,7 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures all grid dimensions are uniformly spaced.
-    fn init(&mut self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)?;
         check_uniform_grid(data.grid[1].view(), 1)?;
         check_uniform_grid(data.grid[2].view(), 2)
@@ -256,7 +256,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
-    fn init(&mut self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 && self.0.len() != 3 {
             return Err(ValidateError::Other(format!(
                 "Step strategy has {} directions but interpolator is 3-D (expected 1 or 3)",

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -79,6 +79,32 @@ serialize_nested_impl!(Interp2D, InterpData2D, Strategy2D);
 impl<D, S> Interp2D<D, S>
 where
     D: Data + RawDataClone + Clone,
+    D::Elem: PartialEq + Debug,
+    S: Strategy2D<D> + Clone,
+{
+    /// Re-run the strategy's [`Strategy2D::validate`] against the current data.
+    ///
+    /// `new`, `set_strategy`, and [`Interpolator::validate`] already call this
+    /// internally, so this is only needed after mutating the public `data`/`strategy`
+    /// fields directly.
+    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
+        self.strategy.validate(&self.data)
+    }
+
+    /// Re-run the strategy's [`Strategy2D::init`] against the current data.
+    ///
+    /// `new` and `set_strategy` already call this internally, so this is only needed
+    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
+    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
+    /// does not call `init`).
+    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
+        self.strategy.init(&self.data)
+    }
+}
+
+impl<D, S> Interp2D<D, S>
+where
+    D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
     S: Strategy2D<D> + Clone,
 {
@@ -124,18 +150,9 @@ where
             extrapolate,
         };
         interpolator.check_extrapolate(&interpolator.extrapolate)?;
-        interpolator.strategy.init(&interpolator.data)?;
+        interpolator.validate_strategy()?;
+        interpolator.init_strategy()?;
         Ok(interpolator)
-    }
-
-    /// Re-run the strategy's [`Strategy2D::init`] against the current data.
-    ///
-    /// `new` and `set_strategy` already call this internally, so this is only needed
-    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        self.strategy.init(&self.data)
     }
 
     /// Return an interpolator with viewed data.
@@ -180,6 +197,7 @@ where
     fn validate(&self) -> Result<(), ValidateError> {
         self.check_extrapolate(&self.extrapolate)?;
         self.data.validate()?;
+        self.validate_strategy()?;
         Ok(())
     }
 
@@ -250,7 +268,8 @@ where
     pub fn set_strategy(&mut self, strategy: Box<dyn Strategy2D<D>>) -> Result<(), ValidateError> {
         self.strategy = strategy;
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }
 
@@ -270,6 +289,7 @@ where
     ) -> Result<(), ValidateError> {
         self.strategy = strategy.into();
         self.check_extrapolate(&self.extrapolate)?;
-        self.strategy.init(&self.data)
+        self.validate_strategy()?;
+        self.init_strategy()
     }
 }

--- a/src/interpolator/two/strategies.rs
+++ b/src/interpolator/two/strategies.rs
@@ -78,7 +78,7 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures all grid dimensions are uniformly spaced.
-    fn init(&mut self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)?;
         check_uniform_grid(data.grid[1].view(), 1)
     }
@@ -151,7 +151,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
-    fn init(&mut self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 && self.0.len() != 2 {
             return Err(ValidateError::Other(format!(
                 "Step strategy has {} directions but interpolator is 2-D (expected 1 or 2)",

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -237,7 +237,7 @@ fn test_dyn_strategy() {
 
 #[test]
 fn test_set_strategy_runs_init() {
-    // `Step`'s `init` validates its direction count against dimensionality,
+    // `Step`'s `validate` checks its direction count against dimensionality,
     // so swapping in a `Step` with the wrong count via `set_strategy` must
     // surface that error rather than silently leaving the strategy unvalidated.
     let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
@@ -256,11 +256,33 @@ fn test_set_strategy_runs_init() {
 }
 
 #[test]
-fn test_init_strategy() {
-    // `validate()` only checks data/extrapolate, not strategy-specific requirements
-    // like `LinearUniform`'s uniform grid, so directly mutating `data` to break that
-    // invariant passes `validate()`. `init_strategy()` is the way to catch it, since
-    // it re-runs the same check `new`/`set_strategy` do internally.
+fn test_set_strategy_runs_validate() {
+    // Same as `test_set_strategy_runs_init`, but for `LinearUniform`'s uniform-grid
+    // check: `Linear` doesn't care about grid spacing, so a non-uniform grid builds
+    // fine, but swapping to `LinearUniform` via `set_strategy` must catch it via
+    // `Strategy2D::validate` rather than silently accepting a strategy that will
+    // produce wrong results at query time.
+    let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
+        array![0., 1., 5.], // non-uniform
+        array![0., 1., 2.],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear.into(),
+        Extrapolate::Error,
+    )
+    .unwrap();
+    assert!(matches!(
+        interp.set_strategy(strategy::LinearUniform).unwrap_err(),
+        ValidateError::Other(_)
+    ));
+}
+
+#[test]
+fn test_validate_strategy() {
+    // `LinearUniform`'s uniform-grid check is a pure invariant check (`Strategy2D::validate`),
+    // not a precomputation (`Strategy2D::init`), so `Interpolator::validate` (which calls
+    // `validate_strategy` internally) catches directly mutating `data` to break that
+    // invariant, while `init_strategy` (a no-op for `LinearUniform`, since it caches
+    // nothing) does not.
     let mut interp = Interp2D::new(
         array![0., 1., 2.],
         array![0., 1., 2.],
@@ -270,8 +292,9 @@ fn test_init_strategy() {
     )
     .unwrap();
     interp.data.grid[0] = array![0., 1., 5.]; // still monotonic, no longer uniform
-    assert!(interp.validate().is_ok());
-    assert!(interp.init_strategy().is_err());
+    assert!(interp.validate().is_err());
+    assert!(interp.validate_strategy().is_err());
+    assert!(interp.init_strategy().is_ok());
 }
 
 #[test]

--- a/src/strategy/enums/n.rs
+++ b/src/strategy/enums/n.rs
@@ -62,6 +62,18 @@ where
     D::Elem: Float + Debug,
 {
     #[inline]
+    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+        match self {
+            StrategyNDEnum::Linear(strategy) => StrategyND::<D>::validate(strategy, data),
+            StrategyNDEnum::LinearUniform(strategy) => StrategyND::<D>::validate(strategy, data),
+            StrategyNDEnum::Nearest(strategy) => StrategyND::<D>::validate(strategy, data),
+            StrategyNDEnum::Step(strategy) => StrategyND::<D>::validate(strategy, data),
+            StrategyNDEnum::StepLower(strategy) => StrategyND::<D>::validate(strategy, data),
+            StrategyNDEnum::StepUpper(strategy) => StrategyND::<D>::validate(strategy, data),
+        }
+    }
+
+    #[inline]
     fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
         match self {
             StrategyNDEnum::Linear(strategy) => StrategyND::<D>::init(strategy, data),

--- a/src/strategy/enums/one.rs
+++ b/src/strategy/enums/one.rs
@@ -62,6 +62,18 @@ where
     D::Elem: Float + Debug,
 {
     #[inline]
+    fn validate(&self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
+        match self {
+            Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::validate(strategy, data),
+            Strategy1DEnum::LinearUniform(strategy) => Strategy1D::<D>::validate(strategy, data),
+            Strategy1DEnum::Nearest(strategy) => Strategy1D::<D>::validate(strategy, data),
+            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::validate(strategy, data),
+            Strategy1DEnum::StepLower(strategy) => Strategy1D::<D>::validate(strategy, data),
+            Strategy1DEnum::StepUpper(strategy) => Strategy1D::<D>::validate(strategy, data),
+        }
+    }
+
+    #[inline]
     fn init(&mut self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
         match self {
             Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::init(strategy, data),

--- a/src/strategy/enums/three.rs
+++ b/src/strategy/enums/three.rs
@@ -62,6 +62,18 @@ where
     D::Elem: Float + Debug,
 {
     #[inline]
+    fn validate(&self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
+        match self {
+            Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::validate(strategy, data),
+            Strategy3DEnum::LinearUniform(strategy) => Strategy3D::<D>::validate(strategy, data),
+            Strategy3DEnum::Nearest(strategy) => Strategy3D::<D>::validate(strategy, data),
+            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::validate(strategy, data),
+            Strategy3DEnum::StepLower(strategy) => Strategy3D::<D>::validate(strategy, data),
+            Strategy3DEnum::StepUpper(strategy) => Strategy3D::<D>::validate(strategy, data),
+        }
+    }
+
+    #[inline]
     fn init(&mut self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
         match self {
             Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::init(strategy, data),

--- a/src/strategy/enums/two.rs
+++ b/src/strategy/enums/two.rs
@@ -62,6 +62,18 @@ where
     D::Elem: Float + Debug,
 {
     #[inline]
+    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
+        match self {
+            Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::validate(strategy, data),
+            Strategy2DEnum::LinearUniform(strategy) => Strategy2D::<D>::validate(strategy, data),
+            Strategy2DEnum::Nearest(strategy) => Strategy2D::<D>::validate(strategy, data),
+            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::validate(strategy, data),
+            Strategy2DEnum::StepLower(strategy) => Strategy2D::<D>::validate(strategy, data),
+            Strategy2DEnum::StepUpper(strategy) => Strategy2D::<D>::validate(strategy, data),
+        }
+    }
+
+    #[inline]
     fn init(&mut self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
         match self {
             Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::init(strategy, data),

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -8,7 +8,19 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Initialize strategy struct, with access to interpolation data.
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    ///
+    /// Default no-op. Override for invariant checks that don't require precomputed
+    /// state (grid uniformity, direction-count matching, etc).
+    fn validate(&self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
+        Ok(())
+    }
+
+    /// Initialize/recompute cached derived state, with access to interpolation data.
+    ///
+    /// Default no-op. Override only when the strategy caches something derived from
+    /// `data` (e.g. precomputed spline coefficients). Unlike [`Strategy1D::validate`],
+    /// this may do real, non-trivial calculation.
     fn init(&mut self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
         Ok(())
     }
@@ -38,6 +50,12 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    #[inline]
+    fn validate(&self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
+        (**self).validate(data)
+    }
+
     /// Initialize strategy struct, with access to interpolation data.
     #[inline]
     fn init(&mut self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
@@ -65,7 +83,19 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Initialize strategy struct, with access to interpolation data.
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    ///
+    /// Default no-op. Override for invariant checks that don't require precomputed
+    /// state (grid uniformity, direction-count matching, etc).
+    fn validate(&self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
+        Ok(())
+    }
+
+    /// Initialize/recompute cached derived state, with access to interpolation data.
+    ///
+    /// Default no-op. Override only when the strategy caches something derived from
+    /// `data` (e.g. precomputed spline coefficients). Unlike [`Strategy2D::validate`],
+    /// this may do real, non-trivial calculation.
     fn init(&mut self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
         Ok(())
     }
@@ -95,6 +125,12 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    #[inline]
+    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
+        (**self).validate(data)
+    }
+
     /// Initialize strategy struct, with access to interpolation data.
     #[inline]
     fn init(&mut self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
@@ -122,7 +158,19 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Initialize strategy struct, with access to interpolation data.
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    ///
+    /// Default no-op. Override for invariant checks that don't require precomputed
+    /// state (grid uniformity, direction-count matching, etc).
+    fn validate(&self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
+        Ok(())
+    }
+
+    /// Initialize/recompute cached derived state, with access to interpolation data.
+    ///
+    /// Default no-op. Override only when the strategy caches something derived from
+    /// `data` (e.g. precomputed spline coefficients). Unlike [`Strategy3D::validate`],
+    /// this may do real, non-trivial calculation.
     fn init(&mut self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
         Ok(())
     }
@@ -152,6 +200,12 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    #[inline]
+    fn validate(&self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
+        (**self).validate(data)
+    }
+
     /// Initialize strategy struct, with access to interpolation data.
     #[inline]
     fn init(&mut self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
@@ -179,7 +233,19 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Initialize strategy struct, with access to interpolation data.
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    ///
+    /// Default no-op. Override for invariant checks that don't require precomputed
+    /// state (grid uniformity, direction-count matching, etc).
+    fn validate(&self, _data: &InterpDataND<D>) -> Result<(), ValidateError> {
+        Ok(())
+    }
+
+    /// Initialize/recompute cached derived state, with access to interpolation data.
+    ///
+    /// Default no-op. Override only when the strategy caches something derived from
+    /// `data` (e.g. precomputed spline coefficients). Unlike [`StrategyND::validate`],
+    /// this may do real, non-trivial calculation.
     fn init(&mut self, _data: &InterpDataND<D>) -> Result<(), ValidateError> {
         Ok(())
     }
@@ -209,6 +275,12 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
+    /// Validate strategy state against interpolation data. Pure check, no mutation.
+    #[inline]
+    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+        (**self).validate(data)
+    }
+
     #[inline]
     fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
         (**self).init(data)


### PR DESCRIPTION
Closes #36. Prerequisite for #17 (validate on deserialize needs to call the cheap
`validate` unconditionally without being forced to also re-run `init`'s
precomputation).

## Summary

`Strategy1D`/`Strategy2D`/`Strategy3D`/`StrategyND::init(&mut self, data)` conflated
two different concerns: pure invariant checking (no mutation needed) and mutating
precomputation. `LinearUniform`'s grid-uniformity check and `Step`'s direction-count
check are both examples of the former, but they lived in `init`, so
`Interpolator::validate` (a pure `&self` check) could never catch them, only
`init_strategy()` could.

This splits `init` into:

```rust
fn validate(&self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
    Ok(())
}

fn init(&mut self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
    Ok(())
}
```

(mirrored on all four dimensionalities), both default no-op.

## What changed

- `LinearUniform`/`Step`'s existing `init` overrides moved to `validate` (bodies
  unchanged, just `&self` instead of `&mut self`) across all four dimensionalities.
- `Box<dyn Strategy*D<D>>` and the `Strategy*DEnum` dispatch impls get a matching
  `validate` passthrough/match-arm alongside the existing `init` one.
- `new()` and `set_strategy()` (all four dimensionalities) call both
  `validate_strategy()` then `init_strategy()`.
- New public `validate_strategy()` inherent method on `Interp1D`/`2D`/`3D`/`ND`,
  mirroring the existing `init_strategy()` but taking `&self` (pure check, no
  mutation needed).
- `Interpolator::validate()` now also calls `self.validate_strategy()`, so invariant
  violations like a non-uniform `LinearUniform` grid are caught there too, not just
  via a separate manual `init_strategy()` call.

## Why

This unblocks validating on deserialize (tracked separately): the safe/checked
deserialize path needs to run the cheap invariant check unconditionally, without
being forced to always re-run precomputation for strategies with real cached derived
state. A single `init` method couldn't express "always run this part, only
conditionally run that part." Splitting the trait method is a prerequisite for that
work, not part of it.

## Breaking change

Yes, to the `Strategy1D`/`Strategy2D`/`Strategy3D`/`StrategyND` trait signatures.
Non-breaking in practice for existing custom strategy implementations: both methods
default to no-op, so anything that only implemented `interpolate`/`allow_extrapolate`
(and possibly `init`) keeps compiling unchanged. Belongs in the next breaking (minor,
pre-1.0) release per this project's versioning convention.

## Testing

- Fixed `interpolator::two::tests::test_init_strategy` (renamed
  `test_validate_strategy`), whose assertions were written for the pre-split
  behavior (`validate()` couldn't catch a mutated non-uniform grid, only
  `init_strategy()` could). Now inverted correctly: `validate()`/`validate_strategy()`
  catch it, `init_strategy()` (now a no-op for `LinearUniform`) does not.
- Added `interpolator::two::tests::test_set_strategy_runs_validate`: switching from
  `Linear` to `LinearUniform` via `set_strategy()` on a non-uniform grid now
  correctly fails with a `ValidateError`.
- `cargo build --all-features`, `cargo clippy --all-features --all-targets`,
  `cargo test --all-features` (70 unit tests, doc tests, serde format tests) all
  clean.
