### PR TITLE
`interpolate_fast`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ Everything below is merged to `main` but not yet tagged/released.
   `StepLower`/`StepUpper` are built from, now reusable from custom strategies instead of
   needing to be reimplemented. `check_uniform_grid`'s error message no longer hardcodes
   `"LinearUniform:"`, since other strategies can call it directly now too.
+- `interpolate_fast` on `Strategy1D`/`2D`/`3D`/`ND` and `Interpolator<T>` (both
+  default-provided, non-breaking): a `Result`-free interpolation path for hot loops
+  where the caller has already checked the point is in-bounds and knows extrapolation
+  isn't needed. `Interp0D`/`1D`/`2D`/`3D`/`ND`, `InterpolatorEnum`, and
+  `Box<dyn Interpolator<T>>` all override it with the real skip-checks path;
+  `Interp1D`/`2D`/`3D` additionally get an inherent `interpolate_fast(&self, &[D::Elem; N])`
+  taking the point as a fixed-size array, so the point length is guaranteed by the type
+  system instead of checked at runtime.
+- `InterpolatorEnum` gains `check_extrapolate`/`validate_strategy`/`init_strategy`
+  forwarding to the current variant, matching what `Interp1D`/`2D`/`3D`/`ND` already
+  expose as public inherent methods.
 
 ### Changed
 - **Breaking:** `Strategy1D`/`Strategy2D`/`Strategy3D`/`StrategyND::init` is split into
@@ -92,6 +103,15 @@ Everything below is merged to `main` but not yet tagged/released.
   (`{"Step": [...]}`) is unchanged and does not accept those aliases.
 - Loosened `Step`/`Nearest` strategy trait bounds back down after the `LinearUniform`
   work had temporarily tightened them further than necessary.
+- Loosened `InterpolatorEnum`'s `PartialEq`/`SerializeNested` impls off `D::Elem: Float`
+  down to `PartialEq + Debug` (`+ Serialize`), matching what those impls actually need:
+  they only compare/serialize fields and never touch the strategy trait. Construction and
+  interpolation still require `Float`, unchanged.
+- **Breaking:** `extrapolate` is now a required field on deserialize instead of silently
+  defaulting to `Extrapolate::Error` when omitted. `data` and `strategy` were already
+  required; this was the only field with that leniency, and nothing pinned the behavior
+  down, so a missing field now fails loudly (`missing field "extrapolate"`) instead of
+  risking a silently different interpolator than intended.
 - Various documentation and README improvements; CI workflow polish.
 
 ### Fixed

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -282,7 +282,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation handling is not needed.
+    /// caller has already checked bounds or knows that extrapolation handling is not needed.
     ///
     /// # Panics
     /// Panics if `point.len()` does not match [`InterpolatorEnum::ndim`].

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -282,7 +282,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation is not needed.
+    /// caller has already checked bounds and knows that extrapolation handling is not needed.
     ///
     /// # Panics
     /// Panics if `point.len()` does not match [`InterpolatorEnum::ndim`].

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -286,7 +286,10 @@ where
     ///
     /// # Panics
     /// Panics if `point.len()` does not match [`InterpolatorEnum::ndim`].
-    pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+    pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem
+    where
+        D::Elem: Euclid,
+    {
         match self {
             InterpolatorEnum::Interp0D(interp) => interp.0,
             InterpolatorEnum::Interp1D(interp) => interp.interpolate_fast(
@@ -356,6 +359,16 @@ where
             InterpolatorEnum::Interp3D(interp) => interp.set_extrapolate(extrapolate),
             InterpolatorEnum::InterpND(interp) => interp.set_extrapolate(extrapolate),
         }
+    }
+
+    /// Forwards to the inherent [`InterpolatorEnum::interpolate_fast`]. Without this
+    /// override, code reaching `InterpolatorEnum` only through the `Interpolator` trait
+    /// (generic code, or `Box<dyn Interpolator<T>>`) would silently fall back to this
+    /// trait's default (the checked `interpolate` path) instead of the real fast path,
+    /// since the inherent method is invisible once the concrete type is erased.
+    #[inline]
+    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        self.interpolate_fast(point)
     }
 }
 

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -236,6 +236,51 @@ where
         }
     }
 
+    /// Check applicability of the current variant's strategy, data, and extrapolate
+    /// setting.
+    pub fn check_extrapolate(
+        &self,
+        extrapolate: &Extrapolate<D::Elem>,
+    ) -> Result<(), ValidateError> {
+        match self {
+            InterpolatorEnum::Interp0D(_) => Ok(()),
+            InterpolatorEnum::Interp1D(interp) => interp.check_extrapolate(extrapolate),
+            InterpolatorEnum::Interp2D(interp) => interp.check_extrapolate(extrapolate),
+            InterpolatorEnum::Interp3D(interp) => interp.check_extrapolate(extrapolate),
+            InterpolatorEnum::InterpND(interp) => interp.check_extrapolate(extrapolate),
+        }
+    }
+
+    /// Re-run the current variant's strategy `validate` against its data.
+    ///
+    /// `new_0d`/`new_1d`/etc. already call this internally, so this is only needed
+    /// after mutating a variant's `data`/`strategy` fields directly (via `match`).
+    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
+        match self {
+            InterpolatorEnum::Interp0D(_) => Ok(()),
+            InterpolatorEnum::Interp1D(interp) => interp.validate_strategy(),
+            InterpolatorEnum::Interp2D(interp) => interp.validate_strategy(),
+            InterpolatorEnum::Interp3D(interp) => interp.validate_strategy(),
+            InterpolatorEnum::InterpND(interp) => interp.validate_strategy(),
+        }
+    }
+
+    /// Re-run the current variant's strategy `init` against its data.
+    ///
+    /// `new_0d`/`new_1d`/etc. already call this internally, so this is only needed
+    /// after bypassing them: mutating a variant's `data`/`strategy` fields directly
+    /// (via `match`), or deserializing an interpolator with a stateful custom strategy
+    /// (`Deserialize` does not call `init`).
+    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
+        match self {
+            InterpolatorEnum::Interp0D(_) => Ok(()),
+            InterpolatorEnum::Interp1D(interp) => interp.init_strategy(),
+            InterpolatorEnum::Interp2D(interp) => interp.init_strategy(),
+            InterpolatorEnum::Interp3D(interp) => interp.init_strategy(),
+            InterpolatorEnum::InterpND(interp) => interp.init_strategy(),
+        }
+    }
+
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
     /// caller has already checked bounds and knows that extrapolation is not needed.
     ///

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -235,6 +235,33 @@ where
             InterpolatorEnum::InterpND(interp) => InterpolatorEnum::InterpND(interp.into_owned()),
         }
     }
+
+    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
+    /// caller has already checked bounds and knows that extrapolation is not needed.
+    ///
+    /// # Panics
+    /// Panics if `point.len()` does not match [`InterpolatorEnum::ndim`].
+    pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        match self {
+            InterpolatorEnum::Interp0D(interp) => interp.0,
+            InterpolatorEnum::Interp1D(interp) => interp.interpolate_fast(
+                point
+                    .try_into()
+                    .expect("interpolate_fast: point length mismatch"),
+            ),
+            InterpolatorEnum::Interp2D(interp) => interp.interpolate_fast(
+                point
+                    .try_into()
+                    .expect("interpolate_fast: point length mismatch"),
+            ),
+            InterpolatorEnum::Interp3D(interp) => interp.interpolate_fast(
+                point
+                    .try_into()
+                    .expect("interpolate_fast: point length mismatch"),
+            ),
+            InterpolatorEnum::InterpND(interp) => interp.interpolate_fast(point),
+        }
+    }
 }
 
 impl<D> Interpolator<D::Elem> for InterpolatorEnum<D>

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -78,7 +78,7 @@ use strategy::enums::*;
 pub enum InterpolatorEnum<D>
 where
     D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
+    D::Elem: PartialEq + Debug,
 {
     Interp0D(Interp0D<D::Elem>),
     Interp1D(Interp1D<D, Strategy1DEnum>),
@@ -95,7 +95,7 @@ pub type InterpolatorEnumOwned<T> = InterpolatorEnum<OwnedRepr<T>>;
 impl<D> SerializeNested for InterpolatorEnum<D>
 where
     D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug + Serialize,
+    D::Elem: PartialEq + Debug + Serialize,
 {
     /// `#[serde(untagged)]`, so each variant serializes as its inner value.
     fn serialize_nested<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -115,7 +115,7 @@ where
 impl<D> PartialEq for InterpolatorEnum<D>
 where
     D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
+    D::Elem: PartialEq + Debug,
     ArrayBase<D, Ix1>: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -105,7 +105,7 @@ macro_rules! partialeq_impl {
         where
             D: Data + RawDataClone + Clone,
             D::Elem: PartialEq + Debug,
-            S: $Strategy<D> + Clone + PartialEq,
+            S: Clone + PartialEq,
             $Data<D>: PartialEq,
         {
             fn eq(&self, other: &Self) -> bool {
@@ -125,7 +125,7 @@ macro_rules! serialize_nested_impl {
         where
             D: Data + RawDataClone + Clone,
             D::Elem: PartialEq + Debug + Serialize,
-            S: $Strategy<D> + Clone + Serialize,
+            S: Clone + Serialize,
             $Data<D>: SerializeNested + Serialize,
         {
             fn serialize_nested<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -31,6 +31,23 @@ pub trait Interpolator<T>: DynClone {
     fn interpolate(&self, point: &[T]) -> Result<T, InterpolateError>;
     /// Set [`Extrapolate`] variant, checking validity.
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<T>) -> Result<(), ValidateError>;
+    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
+    /// caller has already checked bounds and knows that extrapolation is not needed.
+    ///
+    /// Default just unwraps [`Interpolator::interpolate`] — non-breaking for existing
+    /// implementors. `Interp1D`/`2D`/`3D`/`ND` override this to actually skip the checks
+    /// instead of just discarding the `Result`; through `Box<dyn Interpolator<T>>` this
+    /// still pays vtable dispatch either way, so the win is smaller than calling a
+    /// concrete `InterpXD<D, S>::interpolate_fast` directly.
+    ///
+    /// # Panics
+    /// Panics if `point.len()` doesn't match [`Interpolator::ndim`], or if `point` is out
+    /// of bounds and the strategy's checked path would have errored for a reason beyond
+    /// bounds (e.g. `CubicSpline`'s boundary-condition validation).
+    fn interpolate_fast(&self, point: &[T]) -> T {
+        self.interpolate(point)
+            .expect("interpolate_fast: invalid point or data")
+    }
 }
 
 clone_trait_object!(<T> Interpolator<T>);
@@ -47,6 +64,9 @@ impl<T> Interpolator<T> for Box<dyn Interpolator<T>> {
     }
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<T>) -> Result<(), ValidateError> {
         (**self).set_extrapolate(extrapolate)
+    }
+    fn interpolate_fast(&self, point: &[T]) -> T {
+        (**self).interpolate_fast(point)
     }
 }
 

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -34,16 +34,19 @@ pub trait Interpolator<T>: DynClone {
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
     /// caller has already checked bounds and knows that extrapolation is not needed.
     ///
-    /// Default just unwraps [`Interpolator::interpolate`] — non-breaking for existing
+    /// Default just unwraps [`Interpolator::interpolate`], non-breaking for existing
     /// implementors. `Interp1D`/`2D`/`3D`/`ND` override this to actually skip the checks
     /// instead of just discarding the `Result`; through `Box<dyn Interpolator<T>>` this
     /// still pays vtable dispatch either way, so the win is smaller than calling a
     /// concrete `InterpXD<D, S>::interpolate_fast` directly.
     ///
     /// # Panics
-    /// Panics if `point.len()` doesn't match [`Interpolator::ndim`], or if `point` is out
-    /// of bounds and the strategy's checked path would have errored for a reason beyond
-    /// bounds (e.g. `CubicSpline`'s boundary-condition validation).
+    /// Panics if `point.len()` doesn't match [`Interpolator::ndim`], or if the strategy's
+    /// checked `interpolate` would have returned `Err` for a reason other than length or
+    /// the outer bounds/extrapolation check. No strategy shipped in this crate does that
+    /// today; it would only apply to a strategy with real per-point fallible work inside
+    /// its own `interpolate`, distinct from anything already catchable once via
+    /// `validate`/`init` at construction time.
     fn interpolate_fast(&self, point: &[T]) -> T {
         self.interpolate(point)
             .expect("interpolate_fast: invalid point or data")

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -168,7 +168,7 @@ pub struct InterpND<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
-    S: StrategyND<D> + Clone,
+    S: Clone,
 {
     /// Interpolator data.
     pub data: InterpDataND<D>,

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -212,6 +212,12 @@ where
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }
+
+    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
+    /// caller has already checked bounds and knows that extrapolation is not needed.
+    pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        self.strategy.interpolate_fast(&self.data, point)
+    }
 }
 
 impl<D, S> InterpND<D, S>

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -387,6 +387,11 @@ where
     }
 
     fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        assert_eq!(
+            point.len(),
+            self.ndim(),
+            "interpolate_fast: point length mismatch"
+        );
         self.strategy.interpolate_fast(&self.data, point)
     }
 }

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -175,7 +175,6 @@ where
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
-    #[cfg_attr(feature = "serde", serde(default))]
     pub extrapolate: Extrapolate<D::Elem>,
 }
 /// [`InterpND`] that views data.

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -211,12 +211,6 @@ where
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }
-
-    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds or knows that extrapolation handling is not needed.
-    pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
-        self.strategy.interpolate_fast(&self.data, point)
-    }
 }
 
 impl<D, S> InterpND<D, S>
@@ -390,6 +384,10 @@ where
         self.check_extrapolate(&extrapolate)?;
         self.extrapolate = extrapolate;
         Ok(())
+    }
+
+    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        self.strategy.interpolate_fast(&self.data, point)
     }
 }
 

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -213,7 +213,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation handling is not needed.
+    /// caller has already checked bounds or knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -213,7 +213,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation is not needed.
+    /// caller has already checked bounds and knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -460,6 +460,47 @@ fn test_extrapolate_wrap() {
 }
 
 #[test]
+fn test_interpolate_fast() {
+    let interp = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    assert_eq!(
+        interp.interpolate_fast(&[0.25, 0.65, 0.9]),
+        interp.interpolate(&[0.25, 0.65, 0.9]).unwrap()
+    );
+}
+
+#[test]
+#[should_panic(expected = "interpolate_fast: point length mismatch")]
+fn test_interpolate_fast_point_too_short() {
+    let interp = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    interp.interpolate_fast(&[0.5, 0.5]);
+}
+
+#[test]
+#[should_panic(expected = "interpolate_fast: point length mismatch")]
+fn test_interpolate_fast_point_too_long() {
+    let interp = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    interp.interpolate_fast(&[0.5, 0.5, 0.5, 0.5]);
+}
+
+#[test]
 fn test_mismatched_grid() {
     assert!(matches!(
         InterpND::new(

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -96,6 +96,12 @@ where
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }
+
+    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
+    /// caller has already checked bounds and knows that extrapolation is not needed.
+    pub fn interpolate_fast(&self, point: &[D::Elem; 1]) -> D::Elem {
+        self.strategy.interpolate_fast(&self.data, point)
+    }
 }
 
 impl<D, S> Interp1D<D, S>

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -59,7 +59,6 @@ where
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
-    #[cfg_attr(feature = "serde", serde(default))]
     pub extrapolate: Extrapolate<D::Elem>,
 }
 /// [`Interp1D`] that views data.

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -97,7 +97,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation is not needed.
+    /// caller has already checked bounds and knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem; 1]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -234,6 +234,13 @@ where
         self.extrapolate = extrapolate;
         Ok(())
     }
+
+    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        let point: &[D::Elem; N] = point
+            .try_into()
+            .expect("interpolate_fast: point length mismatch");
+        self.interpolate_fast(point)
+    }
 }
 
 impl<D> Interp1D<D, Box<dyn Strategy1D<D>>>

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -97,7 +97,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation handling is not needed.
+    /// caller has already checked bounds or knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem; 1]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -52,7 +52,7 @@ pub struct Interp1D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
-    S: Strategy1D<D> + Clone,
+    S: Clone,
 {
     /// Interpolator data.
     pub data: InterpData1D<D>,

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -101,6 +101,12 @@ where
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }
+
+    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
+    /// caller has already checked bounds and knows that extrapolation is not needed.
+    pub fn interpolate_fast(&self, point: &[D::Elem; 3]) -> D::Elem {
+        self.strategy.interpolate_fast(&self.data, point)
+    }
 }
 
 impl<D, S> Interp3D<D, S>

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -102,7 +102,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation is not needed.
+    /// caller has already checked bounds and knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem; 3]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -57,7 +57,7 @@ pub struct Interp3D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
-    S: Strategy3D<D> + Clone,
+    S: Clone,
 {
     /// Interpolator data.
     pub data: InterpData3D<D>,

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -102,7 +102,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation handling is not needed.
+    /// caller has already checked bounds or knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem; 3]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -270,6 +270,13 @@ where
         self.extrapolate = extrapolate;
         Ok(())
     }
+
+    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        let point: &[D::Elem; N] = point
+            .try_into()
+            .expect("interpolate_fast: point length mismatch");
+        self.interpolate_fast(point)
+    }
 }
 
 impl<D> Interp3D<D, Box<dyn Strategy3D<D>>>

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -64,7 +64,6 @@ where
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
-    #[cfg_attr(feature = "serde", serde(default))]
     pub extrapolate: Extrapolate<D::Elem>,
 }
 /// [`Interp3D`] that views data.

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -101,7 +101,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation handling is not needed.
+    /// caller has already checked bounds or knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem; 2]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -258,6 +258,13 @@ where
         self.extrapolate = extrapolate;
         Ok(())
     }
+
+    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+        let point: &[D::Elem; N] = point
+            .try_into()
+            .expect("interpolate_fast: point length mismatch");
+        self.interpolate_fast(point)
+    }
 }
 
 impl<D> Interp2D<D, Box<dyn Strategy2D<D>>>

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -100,6 +100,12 @@ where
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }
+
+    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
+    /// caller has already checked bounds and knows that extrapolation is not needed.
+    pub fn interpolate_fast(&self, point: &[D::Elem; 2]) -> D::Elem {
+        self.strategy.interpolate_fast(&self.data, point)
+    }
 }
 
 impl<D, S> Interp2D<D, S>

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -56,7 +56,7 @@ pub struct Interp2D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
-    S: Strategy2D<D> + Clone,
+    S: Clone,
 {
     /// Interpolator data.
     pub data: InterpData2D<D>,

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -101,7 +101,7 @@ where
     }
 
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds and knows that extrapolation is not needed.
+    /// caller has already checked bounds and knows that extrapolation handling is not needed.
     pub fn interpolate_fast(&self, point: &[D::Elem; 2]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -63,7 +63,6 @@ where
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
-    #[cfg_attr(feature = "serde", serde(default))]
     pub extrapolate: Extrapolate<D::Elem>,
 }
 /// [`Interp2D`] that views data.

--- a/src/interpolator/zero/mod.rs
+++ b/src/interpolator/zero/mod.rs
@@ -75,6 +75,12 @@ where
     fn set_extrapolate(&mut self, _extrapolate: Extrapolate<T>) -> Result<(), ValidateError> {
         Ok(())
     }
+
+    /// Returns the contained value [`Interp0D::0`].
+    #[inline]
+    fn interpolate_fast(&self, _point: &[T]) -> T {
+        self.0.clone()
+    }
 }
 #[cfg(test)]
 mod tests {

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -39,6 +39,18 @@ where
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError>;
 
+    /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
+    /// already valid.
+    ///
+    /// Default just unwraps [`Strategy1D::interpolate`]. Override only if this
+    /// strategy's checked path does real internal fallible work beyond producing
+    /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpData1D<D>, point: &[D::Elem; 1]) -> D::Elem {
+        self.interpolate(data, point)
+            .expect("interpolate_fast: invalid point or data")
+    }
+
     /// Does this type's [`Strategy1D::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -69,6 +81,11 @@ where
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
         (**self).interpolate(data, point)
+    }
+
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpData1D<D>, point: &[D::Elem; 1]) -> D::Elem {
+        (**self).interpolate_fast(data, point)
     }
 
     #[inline]
@@ -114,6 +131,18 @@ where
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError>;
 
+    /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
+    /// already valid.
+    ///
+    /// Default just unwraps [`Strategy2D::interpolate`]. Override only if this
+    /// strategy's checked path does real internal fallible work beyond producing
+    /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpData2D<D>, point: &[D::Elem; 2]) -> D::Elem {
+        self.interpolate(data, point)
+            .expect("interpolate_fast: invalid point or data")
+    }
+
     /// Does this type's [`Strategy2D::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -144,6 +173,11 @@ where
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError> {
         (**self).interpolate(data, point)
+    }
+
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpData2D<D>, point: &[D::Elem; 2]) -> D::Elem {
+        (**self).interpolate_fast(data, point)
     }
 
     #[inline]
@@ -189,6 +223,18 @@ where
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError>;
 
+    /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
+    /// already valid.
+    ///
+    /// Default just unwraps [`Strategy3D::interpolate`]. Override only if this
+    /// strategy's checked path does real internal fallible work beyond producing
+    /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpData3D<D>, point: &[D::Elem; 3]) -> D::Elem {
+        self.interpolate(data, point)
+            .expect("interpolate_fast: invalid point or data")
+    }
+
     /// Does this type's [`Strategy3D::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -219,6 +265,11 @@ where
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError> {
         (**self).interpolate(data, point)
+    }
+
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpData3D<D>, point: &[D::Elem; 3]) -> D::Elem {
+        (**self).interpolate_fast(data, point)
     }
 
     #[inline]
@@ -264,6 +315,18 @@ where
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError>;
 
+    /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
+    /// already valid.
+    ///
+    /// Default just unwraps [`StrategyND::interpolate`]. Override only if this
+    /// strategy's checked path does real internal fallible work beyond producing
+    /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpDataND<D>, point: &[D::Elem]) -> D::Elem {
+        self.interpolate(data, point)
+            .expect("interpolate_fast: invalid point or data")
+    }
+
     /// Does this type's [`StrategyND::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -298,5 +361,10 @@ where
     #[inline]
     fn allow_extrapolate(&self) -> bool {
         (**self).allow_extrapolate()
+    }
+
+    #[inline]
+    fn interpolate_fast(&self, data: &InterpDataND<D>, point: &[D::Elem]) -> D::Elem {
+        (**self).interpolate_fast(data, point)
     }
 }


### PR DESCRIPTION
Closes #18

## `interpolate_fast`

- `Strategy1D`/`2D`/`3D`/`ND` gain a default-provided `interpolate_fast` that unwraps the
  checked `interpolate`. Override only if a strategy's checked path does real fallible
  work beyond the final `Ok(...)`.
- `Interpolator<T>` gains the same default-provided `interpolate_fast`, non-breaking for
  existing implementors. `Interp0D`/`1D`/`2D`/`3D`/`ND` and `Box<dyn Interpolator<T>>`
  override it for the real skip-checks path; `Interp1D`/`2D`/`3D` additionally get an
  inherent `interpolate_fast` taking `&[D::Elem; N]` (no length check possible at all),
  which the trait override delegates to after converting from a slice. `InterpND`'s point
  is already a slice, so it only has the trait-level version, no separate inherent twin.
- `Extrapolate` handling is entirely the caller's responsibility on this path; none of
  the `Enable`/`Fill`/`Clamp`/`Wrap`/`Error` branching runs.
- `InterpND::interpolate_fast` asserts `point.len() == self.ndim()` before delegating to
  the strategy, panicking with the same message `Interp1D`/`2D`/`3D` use on a mismatch.
  Those three get the check for free from converting to a fixed-size array; `InterpND`
  has no fixed `N` to convert to, so it's asserted explicitly instead.

## Loosened `InterpolatorEnum` bounds

`Interp1D`/`2D`/`3D`/`ND`'s struct definitions and the shared `partialeq_impl!`/
`serialize_nested_impl!` macros required `S: Strategy1D<D>` (etc.) even though neither
`PartialEq::eq` nor `SerializeNested::serialize_nested` calls into the strategy trait;
they only compare/serialize fields. That forced `InterpolatorEnum`'s `PartialEq` and
`SerializeNested` impls to require `D::Elem: Float`, since `Strategy1DEnum`/`2D`/`3D`/`ND`
only implement their strategy trait for `Float` (owing to the `Linear`/`LinearUniform`
variants), even though equality and serialization never touch `Linear`.

Loosened to `D::Elem: PartialEq + Debug` (`+ Serialize` where applicable), matching what
the impls actually need. Construction and interpolation still require `Float` via
`Strategy1DEnum`, unchanged.

## `InterpolatorEnum` forwarding parity

`InterpolatorEnum` forwards `check_extrapolate`/`validate_strategy`/`init_strategy`/
`interpolate_fast` to the current variant, matching what `Interp1D`/`2D`/`3D`/`ND`
already expose as pub inherent methods. Its `Interpolator` trait impl also overrides
`interpolate_fast` to forward to that same inherent method, so code reaching it only
through the trait (generic code, `Box<dyn Interpolator<T>>`) still gets the real fast
path instead of the trait's checked-path default.

## Breaking: `extrapolate` is now required on deserialize

Previously `#[serde(default)]` on `extrapolate` silently fell back to `Extrapolate::Error`
when the field was omitted, the only field on these structs with that leniency (`data`
and `strategy` were already required). Removed: a missing `extrapolate` field now fails
deserialization immediately (`missing field "extrapolate"`) instead of risking a silently
different interpolator than intended if whatever produced the data had a bug. No existing
test relied on omitting it.

## Test plan
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo build --all-features --examples`
