### PR TITLE
Mark strategy enums as non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Everything below is merged to `main` but not yet tagged/released.
   expose as public inherent methods.
 
 ### Changed
+- **Breaking:** `Strategy1DEnum`/`Strategy2DEnum`/`Strategy3DEnum`/`StrategyNDEnum` are
+  now `#[non_exhaustive]`, since every new built-in strategy adds a variant. Any
+  existing exhaustive `match` over one without a `_` arm now needs one; construction
+  (`strategy::Linear.into()`, `set_strategy(...)`, etc.) is unaffected.
 - **Breaking:** `Strategy1D`/`Strategy2D`/`Strategy3D`/`StrategyND::init` is split into
   a pure `validate(&self, data)` and a mutating `init(&mut self, data)`, both
   default-no-op (non-breaking for existing custom strategy implementations, which keep
@@ -58,10 +62,6 @@ Everything below is merged to `main` but not yet tagged/released.
   `new` and `set_strategy` call both; `Interpolator::validate` now also calls
   `validate_strategy` (see below), so invariant violations like a non-uniform
   `LinearUniform` grid are caught there too, not just via `init_strategy`.
-- Each `Interp1D`/`Interp2D`/`Interp3D`/`InterpND` gains a public `validate_strategy()`,
-  mirroring the existing `init_strategy()`: re-runs the strategy's `validate` against
-  the current data, for use after mutating the public `data`/`strategy` fields
-  directly.
 - **Breaking:** `find_nearest_index` is renamed to `locate_lower_index` and, along with
   the other grid/index search helpers (`step_index` -> `locate_step_index`,
   `uniform_lower_index` -> `locate_lower_index_uniform`, `exact_index`,
@@ -90,6 +90,15 @@ Everything below is merged to `main` but not yet tagged/released.
   Migrate to wrapping values in `Nested` (or `serialize_with = "serialize_nested"` on a
   field) at the specific call site that wants it. Reading already accepted either format
   and continues to, so data written by prior versions still loads fine.
+- **Breaking:** `extrapolate` is now a required field on deserialize instead of silently
+  defaulting to `Extrapolate::Error` when omitted. `data` and `strategy` were already
+  required; this was the only field with that leniency, and nothing pinned the behavior
+  down, so a missing field now fails loudly (`missing field "extrapolate"`) instead of
+  risking a silently different interpolator than intended.
+- Each `Interp1D`/`Interp2D`/`Interp3D`/`InterpND` gains a public `validate_strategy()`,
+  mirroring the existing `init_strategy()`: re-runs the strategy's `validate` against
+  the current data, for use after mutating the public `data`/`strategy` fields
+  directly.
 - Significant ND performance work: `Linear`/`Nearest` no longer build coordinate
   permutation tables via `itertools::multi_cartesian_product` (removing the `itertools`
   dependency); corner values are now gathered into a flat buffer and reduced with an
@@ -107,11 +116,6 @@ Everything below is merged to `main` but not yet tagged/released.
   down to `PartialEq + Debug` (`+ Serialize`), matching what those impls actually need:
   they only compare/serialize fields and never touch the strategy trait. Construction and
   interpolation still require `Float`, unchanged.
-- **Breaking:** `extrapolate` is now a required field on deserialize instead of silently
-  defaulting to `Extrapolate::Error` when omitted. `data` and `strategy` were already
-  required; this was the only field with that leniency, and nothing pinned the behavior
-  down, so a missing field now fails loudly (`missing field "extrapolate"`) instead of
-  risking a silently different interpolator than intended.
 - Various documentation and README improvements; CI workflow polish.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Everything below is merged to `main` but not yet tagged/released.
   the other grid/index search helpers (`step_index` -> `locate_step_index`,
   `uniform_lower_index` -> `locate_lower_index_uniform`, `exact_index`,
   `check_uniform_grid`), moves from `strategy::traits` to a new `strategy::utils`
-  module — `traits` now holds only the `Strategy1D`/`2D`/`3D`/`ND` trait definitions.
+  module; `traits` now holds only the `Strategy1D`/`2D`/`3D`/`ND` trait definitions.
   No deprecation shim, matching the other breaking renames in this release.
   `locate_lower_index` also now clamps out-of-range points to `[0, len - 2]` itself,
   rather than relying on each `Linear` call site to inline the same clamp before

--- a/src/interpolator/n/strategies.rs
+++ b/src/interpolator/n/strategies.rs
@@ -153,7 +153,7 @@ where
         let n = data.values.ndim();
         // Nearest-neighbor on a rectilinear grid factorizes: select the nearest index
         // independently per dimension, then do a single lookup. No corner extraction or
-        // dimensionality reduction needed — the distance comparison handles exact matches correctly.
+        // dimensionality reduction needed; the distance comparison handles exact matches correctly.
         let mut idx = vec![0usize; n];
         for dim in 0..n {
             let lower_idx = locate_lower_index(data.grid[dim].view(), &point[dim]);

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -271,7 +271,7 @@ fn test_integer_nearest_with_clamp() {
 
 #[test]
 fn test_step() {
-    // Uniform Lower (floor) — same grid as test_nearest
+    // Uniform Lower (floor), same grid as test_nearest
     let interp = InterpND::new(
         vec![array![0., 1.], array![0., 1.], array![0., 1.]],
         array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),

--- a/src/strategy/enums/mod.rs
+++ b/src/strategy/enums/mod.rs
@@ -30,7 +30,7 @@
 //! assert_eq!(interp.interpolate(&[3.25]).unwrap(), 0.8);
 //! assert_eq!(interp.interpolate(&[3.50]).unwrap(), 1.0);
 //!
-//! // Swap to LinearUniform — O(1) index lookup for this uniform grid
+//! // Swap to LinearUniform: O(1) index lookup for this uniform grid
 //! interp.set_strategy(strategy::LinearUniform).unwrap();
 //! assert_eq!(interp.interpolate(&[3.00]).unwrap(), 0.8);
 //! assert_eq!(interp.interpolate(&[3.75]).unwrap(), 0.95);

--- a/src/strategy/enums/n.rs
+++ b/src/strategy/enums/n.rs
@@ -5,6 +5,7 @@ use super::*;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
+#[non_exhaustive]
 pub enum StrategyNDEnum {
     Linear(strategy::Linear),
     LinearUniform(strategy::LinearUniform),

--- a/src/strategy/enums/one.rs
+++ b/src/strategy/enums/one.rs
@@ -5,6 +5,7 @@ use super::*;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
+#[non_exhaustive]
 pub enum Strategy1DEnum {
     Linear(strategy::Linear),
     LinearUniform(strategy::LinearUniform),

--- a/src/strategy/enums/three.rs
+++ b/src/strategy/enums/three.rs
@@ -5,6 +5,7 @@ use super::*;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
+#[non_exhaustive]
 pub enum Strategy3DEnum {
     Linear(strategy::Linear),
     LinearUniform(strategy::LinearUniform),

--- a/src/strategy/enums/two.rs
+++ b/src/strategy/enums/two.rs
@@ -5,6 +5,7 @@ use super::*;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
+#[non_exhaustive]
 pub enum Strategy2DEnum {
     Linear(strategy::Linear),
     LinearUniform(strategy::LinearUniform),

--- a/src/strategy/utils.rs
+++ b/src/strategy/utils.rs
@@ -121,7 +121,7 @@ pub fn exact_index<T: PartialOrd>(grid: ArrayView1<T>, lower: usize, point: &T) 
 /// Computes the lower bracket index for a uniformly-spaced grid in O(1).
 ///
 /// Equivalent to [`locate_lower_index`] but replaces binary search with direct arithmetic.
-/// Only valid when the grid spacing is uniform — validate with [`check_uniform_grid`] first.
+/// Only valid when the grid spacing is uniform; validate with [`check_uniform_grid`] first.
 pub fn locate_lower_index_uniform<T: Float>(grid0: T, step: T, n: usize, point: T) -> usize {
     let t = (point - grid0) / step;
     if t < T::zero() {
@@ -138,7 +138,7 @@ pub fn locate_lower_index_uniform<T: Float>(grid0: T, step: T, n: usize, point: 
 /// for the matching O(1) lookup.
 pub fn check_uniform_grid<T: Float>(grid: ArrayView1<T>, dim: usize) -> Result<(), ValidateError> {
     let step = grid[1] - grid[0];
-    // 1024 * epsilon via 10 doublings — avoids numeric literal casting
+    // 1024 * epsilon via 10 doublings, avoids numeric literal casting
     let tolerance = {
         let mut tol = T::epsilon();
         for _ in 0..10 {


### PR DESCRIPTION
## Summary

Marks `Strategy1DEnum`/`Strategy2DEnum`/`Strategy3DEnum`/`StrategyNDEnum` as `#[non_exhaustive]`. Every new built-in strategy adds a variant, so without this any downstream exhaustive `match` (no `_` arm) breaks the moment a variant is added; `#[non_exhaustive]` is the standard fix for this shape of enum (see `std::io::ErrorKind`).

Only affects external match exhaustiveness; construction (`strategy::Linear.into()`, `set_strategy(...)`, etc.) is unchanged.

`InterpolatorEnum` is out of scope: its variants are dimensionality (1D/2D/3D/ND), not an open-ended set like strategies.

## Breaking Changes

`#[non_exhaustive]` is itself breaking: any existing exhaustive `match` on these enums without a `_` arm now fails to compile, independent of whether a new variant has actually landed. Grouped into the same unreleased breaking batch as the other pending 0.10 changes.

Closes #40
