### PR TITLE
Add inherent array-based interpolate to Interp1D/2D/3D (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,17 @@ Everything below is merged to `main` but not yet tagged/released.
   required; this was the only field with that leniency, and nothing pinned the behavior
   down, so a missing field now fails loudly (`missing field "extrapolate"`) instead of
   risking a silently different interpolator than intended.
+- **Breaking:** `Interp1D`/`Interp2D`/`Interp3D` gain an inherent
+  `interpolate(&self, point: &[D::Elem; N])`, taking the point as a fixed-size array so a
+  wrong-length point is a compile error instead of a runtime `InterpolateError::PointLength`.
+  `Interpolator::interpolate(&self, point: &[T])` remains available (now a thin
+  length-checking wrapper around the inherent method) for `InterpND`, `InterpolatorEnum`,
+  `Box<dyn Interpolator<T>>`, and other generic/trait-object callers, all unaffected.
+  Because Rust inherent methods unconditionally shadow trait methods of the same name,
+  any call site holding a genuine runtime-length slice for a concretely-typed
+  `Interp1D`/`2D`/`3D` (e.g. from a `Vec<f64>`, not an array literal) stops compiling;
+  migrate with `let point: &[D::Elem; N] = slice.try_into()?;` at the call site.
+  `InterpND` is unaffected (no fixed `N`).
 - Each `Interp1D`/`Interp2D`/`Interp3D`/`InterpND` gains a public `validate_strategy()`,
   mirroring the existing `init_strategy()`: re-runs the strategy's `validate` against
   the current data, for use after mutating the public `data`/`strategy` fields

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -87,8 +87,8 @@ fn benchmark_2D() {
     )
     .unwrap();
     // Sample 1,000 points
-    let points: Vec<Vec<f64>> = (0..1_000)
-        .map(|_| vec![rng.random::<f64>() * 99., rng.random::<f64>() * 99.])
+    let points: Vec<[f64; 2]> = (0..1_000)
+        .map(|_| [rng.random::<f64>() * 99., rng.random::<f64>() * 99.])
         .collect();
     for point in points {
         interp_2d.interpolate(black_box(&point)).unwrap();
@@ -139,9 +139,9 @@ fn benchmark_3D() {
     )
     .unwrap();
     // Sample 1,000 points
-    let points: Vec<Vec<f64>> = (0..1_000)
+    let points: Vec<[f64; 3]> = (0..1_000)
         .map(|_| {
-            vec![
+            [
                 rng.random::<f64>() * 99.,
                 rng.random::<f64>() * 99.,
                 rng.random::<f64>() * 99.,
@@ -232,8 +232,8 @@ fn benchmark_2D_uniform() {
         Extrapolate::Error,
     )
     .unwrap();
-    let points: Vec<Vec<f64>> = (0..1_000)
-        .map(|_| vec![rng.random::<f64>() * 99., rng.random::<f64>() * 99.])
+    let points: Vec<[f64; 2]> = (0..1_000)
+        .map(|_| [rng.random::<f64>() * 99., rng.random::<f64>() * 99.])
         .collect();
     for point in points {
         interp.interpolate(black_box(&point)).unwrap();
@@ -276,9 +276,9 @@ fn benchmark_3D_uniform() {
         Extrapolate::Error,
     )
     .unwrap();
-    let points: Vec<Vec<f64>> = (0..1_000)
+    let points: Vec<[f64; 3]> = (0..1_000)
         .map(|_| {
-            vec![
+            [
                 rng.random::<f64>() * 99.,
                 rng.random::<f64>() * 99.,
                 rng.random::<f64>() * 99.,

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -281,36 +281,6 @@ where
         }
     }
 
-    /// Interpolate at the supplied point.
-    ///
-    /// # Errors
-    /// Returns [`InterpolateError::PointLength`] if `point.len()` does not match
-    /// [`InterpolatorEnum::ndim`].
-    pub fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError>
-    where
-        D::Elem: Euclid,
-    {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => interp.interpolate(point),
-            InterpolatorEnum::Interp1D(interp) => interp.interpolate(
-                point
-                    .try_into()
-                    .map_err(|_| InterpolateError::PointLength(1))?,
-            ),
-            InterpolatorEnum::Interp2D(interp) => interp.interpolate(
-                point
-                    .try_into()
-                    .map_err(|_| InterpolateError::PointLength(2))?,
-            ),
-            InterpolatorEnum::Interp3D(interp) => interp.interpolate(
-                point
-                    .try_into()
-                    .map_err(|_| InterpolateError::PointLength(3))?,
-            ),
-            InterpolatorEnum::InterpND(interp) => interp.interpolate(point),
-        }
-    }
-
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
     /// caller has already checked bounds or knows that extrapolation handling is not needed.
     ///
@@ -371,7 +341,25 @@ where
 
     #[inline]
     fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        self.interpolate(point)
+        match self {
+            InterpolatorEnum::Interp0D(interp) => interp.interpolate(point),
+            InterpolatorEnum::Interp1D(interp) => interp.interpolate(
+                point
+                    .try_into()
+                    .map_err(|_| InterpolateError::PointLength(1))?,
+            ),
+            InterpolatorEnum::Interp2D(interp) => interp.interpolate(
+                point
+                    .try_into()
+                    .map_err(|_| InterpolateError::PointLength(2))?,
+            ),
+            InterpolatorEnum::Interp3D(interp) => interp.interpolate(
+                point
+                    .try_into()
+                    .map_err(|_| InterpolateError::PointLength(3))?,
+            ),
+            InterpolatorEnum::InterpND(interp) => interp.interpolate(point),
+        }
     }
 
     #[inline]

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -281,6 +281,36 @@ where
         }
     }
 
+    /// Interpolate at the supplied point.
+    ///
+    /// # Errors
+    /// Returns [`InterpolateError::PointLength`] if `point.len()` does not match
+    /// [`InterpolatorEnum::ndim`].
+    pub fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError>
+    where
+        D::Elem: Euclid,
+    {
+        match self {
+            InterpolatorEnum::Interp0D(interp) => interp.interpolate(point),
+            InterpolatorEnum::Interp1D(interp) => interp.interpolate(
+                point
+                    .try_into()
+                    .map_err(|_| InterpolateError::PointLength(1))?,
+            ),
+            InterpolatorEnum::Interp2D(interp) => interp.interpolate(
+                point
+                    .try_into()
+                    .map_err(|_| InterpolateError::PointLength(2))?,
+            ),
+            InterpolatorEnum::Interp3D(interp) => interp.interpolate(
+                point
+                    .try_into()
+                    .map_err(|_| InterpolateError::PointLength(3))?,
+            ),
+            InterpolatorEnum::InterpND(interp) => interp.interpolate(point),
+        }
+    }
+
     /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
     /// caller has already checked bounds or knows that extrapolation handling is not needed.
     ///
@@ -339,15 +369,14 @@ where
         }
     }
 
+    /// Forwards to the inherent [`InterpolatorEnum::interpolate`]. Without this
+    /// override, this would try to call each variant's `interpolate` with the raw
+    /// `&[D::Elem]` slice, which no longer compiles for `Interp1D`/`2D`/`3D` once they
+    /// have an inherent `interpolate(&self, point: &[D::Elem; N])` (inherent methods
+    /// unconditionally shadow trait methods of the same name).
     #[inline]
     fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => interp.interpolate(point),
-            InterpolatorEnum::Interp1D(interp) => interp.interpolate(point),
-            InterpolatorEnum::Interp2D(interp) => interp.interpolate(point),
-            InterpolatorEnum::Interp3D(interp) => interp.interpolate(point),
-            InterpolatorEnum::InterpND(interp) => interp.interpolate(point),
-        }
+        self.interpolate(point)
     }
 
     #[inline]
@@ -436,6 +465,51 @@ mod tests {
         #[derive(PartialEq)]
         #[allow(unused)]
         struct MyStruct(InterpolatorEnumOwned<f64>);
+    }
+
+    #[test]
+    fn test_point_length() {
+        // `InterpolatorEnum::interpolate` takes a real slice (not an inherent
+        // fixed-size array), so a wrong-length point is still a runtime `Err` here,
+        // for every variant with a fixed `N`.
+        let interp_1d = InterpolatorEnum::new_1d(
+            array![0., 1., 2., 3., 4.],
+            array![0.2, 0.4, 0.6, 0.8, 1.0],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap();
+        assert!(matches!(
+            interp_1d.interpolate(&[]).unwrap_err(),
+            InterpolateError::PointLength(1)
+        ));
+
+        let interp_2d = InterpolatorEnum::new_2d(
+            array![0.05, 0.10, 0.15],
+            array![0.10, 0.20, 0.30],
+            array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap();
+        assert!(matches!(
+            interp_2d.interpolate(&[]).unwrap_err(),
+            InterpolateError::PointLength(2)
+        ));
+
+        let interp_3d = InterpolatorEnum::new_3d(
+            array![0.05, 0.10],
+            array![0.10, 0.20],
+            array![0.20, 0.40],
+            array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap();
+        assert!(matches!(
+            interp_3d.interpolate(&[]).unwrap_err(),
+            InterpolateError::PointLength(3)
+        ));
     }
 
     #[test]

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -369,11 +369,6 @@ where
         }
     }
 
-    /// Forwards to the inherent [`InterpolatorEnum::interpolate`]. Without this
-    /// override, this would try to call each variant's `interpolate` with the raw
-    /// `&[D::Elem]` slice, which no longer compiles for `Interp1D`/`2D`/`3D` once they
-    /// have an inherent `interpolate(&self, point: &[D::Elem; N])` (inherent methods
-    /// unconditionally shadow trait methods of the same name).
     #[inline]
     fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
         self.interpolate(point)

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -122,6 +122,31 @@ macro_rules! extrapolate_impl {
 }
 pub(crate) use extrapolate_impl;
 
+/// Generates the [`Interpolator::interpolate`]/[`Interpolator::interpolate_fast`]
+/// bodies shared by `Interp1D`/`2D`/`3D`'s trait impls: convert the incoming slice to
+/// the fixed-size `[D::Elem; N]` the type's own inherent method of the same name
+/// expects (a length-checked `?` for `interpolate`, a length-asserting `.expect(...)`
+/// for `interpolate_fast`), then call it. `InterpND` has no fixed `N`, so it can't use
+/// this and implements both methods by hand instead.
+macro_rules! checked_interpolate_impl {
+    () => {
+        fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
+            let point: &[D::Elem; N] = point
+                .try_into()
+                .map_err(|_| InterpolateError::PointLength(N))?;
+            self.interpolate(point)
+        }
+
+        fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+            let point: &[D::Elem; N] = point
+                .try_into()
+                .expect("interpolate_fast: point length mismatch");
+            self.interpolate_fast(point)
+        }
+    };
+}
+pub(crate) use checked_interpolate_impl;
+
 macro_rules! partialeq_impl {
     ($InterpType:ident, $Data:ident, $Strategy:ident) => {
         impl<D, S> PartialEq for $InterpType<D, S>

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -173,29 +173,17 @@ where
     }
 }
 
-impl<D, S> Interpolator<D::Elem> for Interp1D<D, S>
+impl<D, S> Interp1D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
     S: Strategy1D<D> + Clone,
 {
-    /// Returns `1`.
-    #[inline]
-    fn ndim(&self) -> usize {
-        N
-    }
-
-    fn validate(&self) -> Result<(), ValidateError> {
-        self.check_extrapolate(&self.extrapolate)?;
-        self.data.validate()?;
-        self.validate_strategy()?;
-        Ok(())
-    }
-
-    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .map_err(|_| InterpolateError::PointLength(N))?;
+    /// Interpolate at the supplied point.
+    ///
+    /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
+    /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
+    pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
         if !(self.data.grid[0].first().unwrap()..=self.data.grid[0].last().unwrap())
             .contains(&&point[0])
         {
@@ -227,6 +215,33 @@ where
             }
         };
         self.strategy.interpolate(&self.data, point)
+    }
+}
+
+impl<D, S> Interpolator<D::Elem> for Interp1D<D, S>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
+    S: Strategy1D<D> + Clone,
+{
+    /// Returns `1`.
+    #[inline]
+    fn ndim(&self) -> usize {
+        N
+    }
+
+    fn validate(&self) -> Result<(), ValidateError> {
+        self.check_extrapolate(&self.extrapolate)?;
+        self.data.validate()?;
+        self.validate_strategy()?;
+        Ok(())
+    }
+
+    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
+        let point: &[D::Elem; N] = point
+            .try_into()
+            .map_err(|_| InterpolateError::PointLength(N))?;
+        self.interpolate(point)
     }
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -237,24 +237,12 @@ where
         Ok(())
     }
 
-    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .map_err(|_| InterpolateError::PointLength(N))?;
-        self.interpolate(point)
-    }
+    checked_interpolate_impl!();
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
         self.check_extrapolate(&extrapolate)?;
         self.extrapolate = extrapolate;
         Ok(())
-    }
-
-    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .expect("interpolate_fast: point length mismatch");
-        self.interpolate_fast(point)
     }
 }
 

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -9,6 +9,29 @@ fn test_invalid_args() {
         Extrapolate::Error,
     )
     .unwrap();
+    // Wrong-length points on a concretely-typed `Interp1D` are caught at compile time
+    // via the inherent `interpolate(&[D::Elem; N])`; the trait's checked path (used by
+    // generic/`dyn` callers passing a real slice) still catches it at runtime.
+    assert!(matches!(
+        Interpolator::interpolate(&interp, &[]).unwrap_err(),
+        InterpolateError::PointLength(_)
+    ));
+    assert_eq!(interp.interpolate(&[1.0]).unwrap(), 0.4);
+}
+
+#[test]
+fn test_invalid_args_dyn() {
+    let interp: Box<dyn Interpolator<f64>> = Box::new(
+        Interp1D::new(
+            array![0., 1., 2., 3., 4.],
+            array![0.2, 0.4, 0.6, 0.8, 1.0],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap(),
+    );
+    // Through `Box<dyn Interpolator<T>>`, only the trait's slice-taking method is ever
+    // reachable, so a wrong-length point still fails at runtime, not compile time.
     assert!(matches!(
         interp.interpolate(&[]).unwrap_err(),
         InterpolateError::PointLength(_)

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -199,29 +199,17 @@ where
     }
 }
 
-impl<D, S> Interpolator<D::Elem> for Interp3D<D, S>
+impl<D, S> Interp3D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
     S: Strategy3D<D> + Clone,
 {
-    /// Returns `3`.
-    #[inline]
-    fn ndim(&self) -> usize {
-        N
-    }
-
-    fn validate(&self) -> Result<(), ValidateError> {
-        self.check_extrapolate(&self.extrapolate)?;
-        self.data.validate()?;
-        self.validate_strategy()?;
-        Ok(())
-    }
-
-    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .map_err(|_| InterpolateError::PointLength(N))?;
+    /// Interpolate at the supplied point.
+    ///
+    /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
+    /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
+    pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
         let mut errors = Vec::new();
         for dim in 0..N {
             if !(self.data.grid[dim].first().unwrap()..=self.data.grid[dim].last().unwrap())
@@ -263,6 +251,33 @@ where
             return Err(InterpolateError::ExtrapolateError(errors.join("")));
         }
         self.strategy.interpolate(&self.data, point)
+    }
+}
+
+impl<D, S> Interpolator<D::Elem> for Interp3D<D, S>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
+    S: Strategy3D<D> + Clone,
+{
+    /// Returns `3`.
+    #[inline]
+    fn ndim(&self) -> usize {
+        N
+    }
+
+    fn validate(&self) -> Result<(), ValidateError> {
+        self.check_extrapolate(&self.extrapolate)?;
+        self.data.validate()?;
+        self.validate_strategy()?;
+        Ok(())
+    }
+
+    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
+        let point: &[D::Elem; N] = point
+            .try_into()
+            .map_err(|_| InterpolateError::PointLength(N))?;
+        self.interpolate(point)
     }
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -273,24 +273,12 @@ where
         Ok(())
     }
 
-    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .map_err(|_| InterpolateError::PointLength(N))?;
-        self.interpolate(point)
-    }
+    checked_interpolate_impl!();
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
         self.check_extrapolate(&extrapolate)?;
         self.extrapolate = extrapolate;
         Ok(())
-    }
-
-    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .expect("interpolate_fast: point length mismatch");
-        self.interpolate_fast(point)
     }
 }
 

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -1,6 +1,30 @@
 use super::*;
 
 #[test]
+fn test_invalid_args() {
+    let interp = Interp3D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![0.20, 0.40, 0.60],
+        array![
+            [[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+            [[9., 10., 11.], [12., 13., 14.], [15., 16., 17.]],
+            [[18., 19., 20.], [21., 22., 23.], [24., 25., 26.],],
+        ],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    // Wrong-length points on a concretely-typed `Interp3D` are caught at compile time
+    // via the inherent `interpolate(&[D::Elem; N])`; the trait's checked path (used by
+    // generic/`dyn` callers passing a real slice) still catches it at runtime.
+    assert!(matches!(
+        Interpolator::interpolate(&interp, &[]).unwrap_err(),
+        InterpolateError::PointLength(_)
+    ));
+}
+
+#[test]
 fn test_linear() {
     let interp = Interp3D::new(
         array![0.05, 0.10, 0.15],

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -187,29 +187,17 @@ where
     }
 }
 
-impl<D, S> Interpolator<D::Elem> for Interp2D<D, S>
+impl<D, S> Interp2D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
     S: Strategy2D<D> + Clone,
 {
-    /// Returns `2`.
-    #[inline]
-    fn ndim(&self) -> usize {
-        N
-    }
-
-    fn validate(&self) -> Result<(), ValidateError> {
-        self.check_extrapolate(&self.extrapolate)?;
-        self.data.validate()?;
-        self.validate_strategy()?;
-        Ok(())
-    }
-
-    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .map_err(|_| InterpolateError::PointLength(N))?;
+    /// Interpolate at the supplied point.
+    ///
+    /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
+    /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
+    pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
         let mut errors = Vec::new();
         for dim in 0..N {
             if !(self.data.grid[dim].first().unwrap()..=self.data.grid[dim].last().unwrap())
@@ -251,6 +239,33 @@ where
             return Err(InterpolateError::ExtrapolateError(errors.join("")));
         }
         self.strategy.interpolate(&self.data, point)
+    }
+}
+
+impl<D, S> Interpolator<D::Elem> for Interp2D<D, S>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
+    S: Strategy2D<D> + Clone,
+{
+    /// Returns `2`.
+    #[inline]
+    fn ndim(&self) -> usize {
+        N
+    }
+
+    fn validate(&self) -> Result<(), ValidateError> {
+        self.check_extrapolate(&self.extrapolate)?;
+        self.data.validate()?;
+        self.validate_strategy()?;
+        Ok(())
+    }
+
+    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
+        let point: &[D::Elem; N] = point
+            .try_into()
+            .map_err(|_| InterpolateError::PointLength(N))?;
+        self.interpolate(point)
     }
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -261,24 +261,12 @@ where
         Ok(())
     }
 
-    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .map_err(|_| InterpolateError::PointLength(N))?;
-        self.interpolate(point)
-    }
+    checked_interpolate_impl!();
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
         self.check_extrapolate(&extrapolate)?;
         self.extrapolate = extrapolate;
         Ok(())
-    }
-
-    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
-        let point: &[D::Elem; N] = point
-            .try_into()
-            .expect("interpolate_fast: point length mismatch");
-        self.interpolate_fast(point)
     }
 }
 

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -1,6 +1,26 @@
 use super::*;
 
 #[test]
+fn test_invalid_args() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    // Wrong-length points on a concretely-typed `Interp2D` are caught at compile time
+    // via the inherent `interpolate(&[D::Elem; N])`; the trait's checked path (used by
+    // generic/`dyn` callers passing a real slice) still catches it at runtime.
+    assert!(matches!(
+        Interpolator::interpolate(&interp, &[]).unwrap_err(),
+        InterpolateError::PointLength(_)
+    ));
+    assert_eq!(interp.interpolate(&[0.075, 0.25]).unwrap(), 3.);
+}
+
+#[test]
 fn test_linear() {
     let interp = Interp2D::new(
         array![0.05, 0.10, 0.15],


### PR DESCRIPTION
## Summary

- `Interp1D`/`Interp2D`/`Interp3D` gain an inherent `interpolate(&self, point: &[D::Elem; N])`, taking the point as a fixed-size array so a wrong-length point is a compile error instead of a runtime `InterpolateError::PointLength`.
- `Interpolator::interpolate(&self, point: &[T])` becomes a thin length-checking wrapper around the inherent method. `InterpND`, `InterpolatorEnum`, and `Box<dyn Interpolator<T>>` are unaffected (no fixed `N`), and keep runtime-checking a real slice.
- **Breaking**: Rust inherent methods unconditionally shadow trait methods of the same name, so any call site holding a genuine runtime-length slice for a concretely-typed `Interp1D`/`2D`/`3D` (e.g. from a `Vec<f64>`, not an array literal) stops compiling. Migrate with `let point: &[D::Elem; N] = slice.try_into()?;` at the call site.

Closes #39.

## Test plan

- [x] `cargo test --all-features` — all existing tests pass; added `test_invalid_args`/`test_invalid_args_dyn` (1D) and `test_invalid_args` (2D/3D) covering the trait's still-checked path via explicit `Interpolator::interpolate(...)` and `Box<dyn Interpolator<T>>`; added `InterpolatorEnum::test_point_length` covering per-variant `PointLength` errors.
- [x] `cargo check --benches --all-features` — updated the 4 hardcoded (non-`InterpND`) bench functions that passed `Vec`-backed slices into concrete `Interp2D`/`Interp3D` to use array-typed points instead.
- [x] `cargo doc --all-features --no-deps`
- [x] `cargo clippy --all-features --all-targets`