### PR TITLE
Fix stale/misleading comments and doc gaps in examples, README, and init_strategy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,6 @@ Each approach has trade-offs:
 | `Box<dyn Interpolator<_>>` | Highest | Interpolator + strategy | Yes | No |
 
 ## Core Concepts
-### Validation Lifecycle
-After editing interpolator data, call the InterpData `validate` method or
-[`Interpolator::validate`](https://docs.rs/ninterp/latest/ninterp/interpolator/trait.Interpolator.html#tymethod.validate)
-to rerun data/extrapolate validation checks.
-
-`validate` only checks the data (shape, monotonicity) and extrapolate setting; it does
-not re-run a strategy's own `init`. If editing `data` directly could violate a strategy's
-own requirements (for example `LinearUniform`'s uniform-grid requirement, or `Step`'s
-per-dimension direction count), or after deserializing an interpolator with a stateful
-custom strategy, call `init_strategy` to re-run it.
-
 ### Data Shape Contract
 Grid and values shapes must match by axis order:
 for every dimension `n`, `grid[n].len() == values.shape()[n]`.
@@ -175,6 +164,8 @@ An interpolation strategy must be specified. Provided strategies:
 | [`Step`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.Step.html) | Step interpolation with per-dimension directions or a direction chosen at runtime |
 | [`StepLower`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.StepLower.html) | Step interpolation to the previous grid value in each dimension |
 | [`StepUpper`](https://docs.rs/ninterp/latest/ninterp/strategy/struct.StepUpper.html) | Step interpolation to the next grid value in each dimension |
+
+More strategies will be added in the future.
 
 To change the interpolation strategy, supply a `Strategy*DEnum` or `Box<dyn Strategy*D>` at instantiation and call `set_strategy`.
 Custom strategies can be defined, see [`examples/custom_strategy.rs`](https://github.com/NatLabRockies/ninterp/blob/main/examples/custom_strategy.rs).
@@ -196,19 +187,48 @@ If you are unsure which variant to choose, `Extrapolate::Error` is a good defaul
 To change extrapolation behavior after construction, call `set_extrapolate`.
 
 ### Interpolation Calls
-Interpolation is executed by calling [`Interpolator::interpolate`](https://docs.rs/ninterp/latest/ninterp/interpolator/trait.Interpolator.html#tymethod.interpolate).
+Call `interpolate` with one coordinate per dimension:
+- 1-D interpolator: `interp.interpolate(&[x])`
+- 2-D interpolator: `interp.interpolate(&[x, y])`
+- 3-D interpolator: `interp.interpolate(&[x, y, z])`
+- N-D interpolator: `interp.interpolate(&[x0, x1, ..., x_{N-1}])`
 
-The query point must contain one coordinate per dimension.
-For example:
-- 1-D interpolator: `&[x]`
-- 2-D interpolator: `&[x, y]`
-- 3-D interpolator: `&[x, y, z]`
-- N-D interpolator: `&[x0, x1, ..., x_{N-1}]`
-
-If the number of coordinates does not match dimensionality, interpolation returns an error.
-Retrieve dimensionality using
+For `Interp1D`/`Interp2D`/`Interp3D`, a wrong-length point is a compile error. For
+`InterpND`, `InterpolatorEnum`, and `Box<dyn Interpolator<T>>`, it's instead a runtime
+`InterpolateError::PointLength`. Retrieve dimensionality using
 [`Interpolator::ndim`](https://docs.rs/ninterp/latest/ninterp/interpolator/trait.Interpolator.html#tymethod.ndim)
 if necessary.
+
+For hot loops where the point is already known to be in-bounds and extrapolation isn't
+needed, [`interpolate_fast`](https://docs.rs/ninterp/latest/ninterp/interpolator/trait.Interpolator.html#method.interpolate_fast)
+skips the bounds check and extrapolation handling that `interpolate` does, returning
+`D::Elem` directly instead of a `Result` (panicking, instead of erroring, on an invalid
+point). It takes the same point argument as `interpolate` above.
+
+### Validation Lifecycle
+After editing interpolator data, call
+[`Interpolator::validate`](https://docs.rs/ninterp/latest/ninterp/interpolator/trait.Interpolator.html#tymethod.validate)
+to rerun data, extrapolate, and strategy validation checks together, or `interp.data.validate()`
+directly for just the narrower shape/monotonicity check on the grid and values.
+
+`validate` checks the data (shape, monotonicity), the extrapolate setting, and runs the
+strategy's own `validate`, a pure check for invariants that don't need precomputed state
+(for example `LinearUniform`'s uniform-grid requirement, or `Step`'s per-dimension
+direction count). It does not re-run the strategy's `init`, the mutating counterpart that
+only strategies caching derived state (such as precomputed spline coefficients) need to
+override.
+
+`new` and `set_strategy` call both `validate` and `init` on the strategy. If you mutate
+the public `data`/`strategy` fields directly instead, call `validate_strategy`/
+`init_strategy` to re-run just those steps.
+
+Deserialization does not call `validate` or `init`. Call `validate` afterward regardless:
+deserialized data isn't guaranteed to satisfy grid/strategy invariants (hand-edited JSON,
+a foreign writer, etc.), and the check is cheap. Whether you also need `init_strategy`
+depends on the strategy: if its cached state is stored in its own serialized fields,
+deserialize restores it as-is and `init` doesn't need to rerun; if that state is instead
+skipped from serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format
+with a large derived array), call `init_strategy` to rebuild it.
 
 ### Errors
 Validation-time (`new` / `validate`):

--- a/examples/custom_strategy.rs
+++ b/examples/custom_strategy.rs
@@ -28,10 +28,28 @@ where
     // the same primitives the built-in strategies use.
     D: Data<Elem = f32> + RawDataClone + Clone,
 {
-    // We can optionally define an initialization step, useful for strategies that need precalculation.
-    // This is called on construction (`new`) and whenever the strategy is swapped (`set_strategy`),
-    // for all interpolators. It takes a mutable reference, so you can edit any data contained in
-    // `CustomStrategy`.
+    // We can optionally define a validation step for invariants that don't require
+    // precomputed state (e.g. grid uniformity, direction-count matching). It's a pure
+    // `&self` check, no mutation allowed, and runs before `init` below: on construction
+    // (`new`), whenever the strategy is swapped (`set_strategy`), and whenever
+    // `Interpolator::validate` is called on the interpolator directly.
+    //
+    // There is a default implementation that just returns `Ok(())`, so leave this out if not needed.
+    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ninterp::error::ValidateError> {
+        // Dummy invariant: reject non-uniformly-spaced grids. `strategy::utils` has a
+        // ready-made helper for exactly this, used by the built-in `LinearUniform` strategy.
+        ninterp::strategy::utils::check_uniform_grid(data.grid[0].view(), 0)?;
+        ninterp::strategy::utils::check_uniform_grid(data.grid[1].view(), 1)?;
+        println!("validated!");
+        Ok(())
+    }
+
+    // We can also optionally define an initialization step, useful for strategies that need
+    // precalculation. It takes a mutable reference, so unlike `validate`, you can edit any
+    // data contained in `CustomStrategy` (e.g. cache something derived from `data`, such as
+    // spline coefficients). It runs after `validate` above, at the same two points: on
+    // construction (`new`) and whenever the strategy is swapped (`set_strategy`). Unlike
+    // `validate`, it is not re-run by a standalone `Interpolator::validate` call.
     //
     // There is a default implementation that just returns `Ok(())`, so leave this out if not needed.
     fn init(&mut self, _data: &InterpData2D<D>) -> Result<(), ninterp::error::ValidateError> {
@@ -60,7 +78,9 @@ where
     // Only set this to `true` if the `interpolate` implementation provisions for extrapolation.
     //
     // All extrapolation settings besides `Extrapolate::Enable` are handled before the strategy `interpolate` call.
-    // If you need different options for extrapolation beyond 'Enable', use an enum in your `CustomStrategy`.
+    // `Extrapolate::Enable` itself carries no configuration, so if your strategy needs multiple
+    // extrapolation behaviors, model them as a field on `CustomStrategy` (e.g. an enum) and
+    // branch on it inside `interpolate`.
     fn allow_extrapolate(&self) -> bool {
         false
     }

--- a/examples/swap_interpolator.rs
+++ b/examples/swap_interpolator.rs
@@ -34,7 +34,9 @@ fn using_enum() {
     .into(); // `.into()` converts the `Interp1D` into an `InterpolatorEnum::Interp1D(...)`
     assert_eq!(interp.interpolate(&[1.75]).unwrap(), 8.);
 
-    // Change interpolator variant again, using alternate syntax
+    // Change interpolator variant again, this time constructing the
+    // `InterpolatorEnum::Interp3D(...)` variant directly instead of
+    // building an `Interp3D` and calling `.into()`
     interp = InterpolatorEnum::new_3d(
         array![0., 1.],
         array![0., 1.],
@@ -43,7 +45,7 @@ fn using_enum() {
         strategy::Nearest,
         Extrapolate::Error,
     )
-    .unwrap(); // `.into()` converts the `Interp1D` into an `InterpolatorEnum::Interp1D(...)`
+    .unwrap();
     assert_eq!(interp.interpolate(&[0.8, 0.7, 0.6]).unwrap(), 1.3);
 }
 

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -206,8 +206,11 @@ where
     ///
     /// `new` and `set_strategy` already call this internally, so this is only needed
     /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
+    /// deserializing an interpolator whose strategy skips its cached state from
+    /// serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with
+    /// a large derived array). `Deserialize` does not call `init`; if the cached state
+    /// is instead stored in ordinary serialized fields, it comes back as-is and this
+    /// isn't needed.
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -90,8 +90,11 @@ where
     ///
     /// `new` and `set_strategy` already call this internally, so this is only needed
     /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
+    /// deserializing an interpolator whose strategy skips its cached state from
+    /// serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with
+    /// a large derived array). `Deserialize` does not call `init`; if the cached state
+    /// is instead stored in ordinary serialized fields, it comes back as-is and this
+    /// isn't needed.
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -95,8 +95,11 @@ where
     ///
     /// `new` and `set_strategy` already call this internally, so this is only needed
     /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
+    /// deserializing an interpolator whose strategy skips its cached state from
+    /// serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with
+    /// a large derived array). `Deserialize` does not call `init`; if the cached state
+    /// is instead stored in ordinary serialized fields, it comes back as-is and this
+    /// isn't needed.
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -94,8 +94,11 @@ where
     ///
     /// `new` and `set_strategy` already call this internally, so this is only needed
     /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator with a stateful custom strategy (`Deserialize`
-    /// does not call `init`).
+    /// deserializing an interpolator whose strategy skips its cached state from
+    /// serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with
+    /// a large derived array). `Deserialize` does not call `init`; if the cached state
+    /// is instead stored in ordinary serialized fields, it comes back as-is and this
+    /// isn't needed.
     pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
         self.strategy.init(&self.data)
     }


### PR DESCRIPTION
## Summary
- `examples/swap_interpolator.rs`: drop a copy-pasted `.into()` comment left over from an earlier code block that no longer calls `.into()`
- `examples/custom_strategy.rs`: demonstrate the `validate`/`init` split (pure invariant check vs. mutating precompute step) alongside `init`, and clarify the extrapolation comment
- `README.md`: fix a Validation Lifecycle section still describing pre-split `validate`/`init` behavior, document the previously-unmentioned array-based `interpolate`/`interpolate_fast` API, and reorder Core Concepts to follow actual construct-then-use flow instead of forward-referencing strategies before they're introduced
- `init_strategy` docs (`one`/`two`/`three`/`n`): the "call this after deserializing a stateful strategy" advice was unconditional; only strategies that skip their derived state from serialization actually need it rerun

Relates to #17, #36, #22 — documents today's manual validate/init-on-deserialize behavior that #17 proposes automating, and demonstrates the `validate`/`init` split from #36 in the custom strategy example.

## Test plan
- [x] `cargo build --examples --all-features`
- [x] `cargo test --doc --all-features` (18 passed)
- [x] `cargo run --example custom_strategy --all-features` (prints `validated!` then `initialized!`)
