### PR TITLE
Add batch_interpolate/batch_interpolate_fast (closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,28 @@ Everything below is merged to `main` but not yet tagged/released.
 - `InterpolatorEnum` gains `check_extrapolate`/`validate_strategy`/`init_strategy`
   forwarding to the current variant, matching what `Interp1D`/`2D`/`3D`/`ND` already
   expose as public inherent methods.
+- `batch_interpolate`/`batch_interpolate_fast` on `Interpolator<T>` and
+  `Strategy1D`/`2D`/`3D`/`ND` (both default-provided, non-breaking, mirroring
+  `interpolate_fast`'s own default): interpolate at several points while sharing one
+  grid, instead of re-locating the grid once per point. `Interp1D`/`2D`/`3D` gain
+  inherent versions taking `&[[D::Elem; N]]`, the same fixed-size-array split as
+  `interpolate`/`interpolate_fast`. `InterpND` and `InterpolatorEnum` implement both
+  directly in their `Interpolator` impls instead (no separate inherent versions):
+  `InterpND` has no fixed `N` to give an inherent version a distinct, more specific
+  signature, matching how its own `interpolate`/`interpolate_fast` already work;
+  `InterpolatorEnum`'s `interpolate_fast` override is simplified the same way in this
+  release, since its inherent signature was never more specific than the trait's
+  either. The checked `batch_interpolate` resolves `self.extrapolate` once for the
+  whole batch and funnels every point into at most one call to the strategy; under
+  `Extrapolate::Error`, it now reports every out-of-range point in one
+  `ExtrapolateError`, not just the first one found. No strategy overrides the
+  default per-point loop yet, so the seam is ready for a future strategy that
+  amortizes its locate step across a batch. `Box<dyn Interpolator<T>>` and
+  `Box<dyn Strategy1D/2D/3D/ND<D>>` forward both methods to the wrapped concrete
+  type, the same way `interpolate_fast` already is, so a future batching strategy's
+  real implementation isn't silently lost behind type erasure.
+- `ExtrapolateError`'s message now reads "point(s)" instead of "point", since a batch
+  error can name more than one offending point.
 
 ### Changed
 - **Breaking:** `Strategy1DEnum`/`Strategy2DEnum`/`Strategy3DEnum`/`StrategyNDEnum` are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,15 @@ Everything below is merged to `main` but not yet tagged/released.
   interpolating `m` points against a type-erased interpolator previously cost `m`
   virtual dispatches, one per `.interpolate()` call; `batch_interpolate` collapses
   that to a single dispatch that reaches the concrete type once, which then loops
-  internally via ordinary static calls. `Box<dyn Interpolator<T>>` and
-  `Box<dyn Strategy1D/2D/3D/ND<D>>` forward both methods to the wrapped concrete
-  type (the same way `interpolate_fast` already is) specifically so this collapse
-  actually happens: without the forward, the boxed type would inherit the trait's
-  own default loop operating on the box itself, one dispatch per point again. No
+  internally via ordinary static calls: this holds independently at both erasure
+  points, a boxed interpolator reaches its concrete type in one hop, and (for an
+  interpolator holding a boxed strategy, e.g. `Interp2D<D, Box<dyn Strategy2D<D>>>`)
+  the strategy call inside it reaches its own concrete type in a separate one hop.
+  `Box<dyn Interpolator<T>>` and `Box<dyn Strategy1D/2D/3D/ND<D>>` forward both
+  methods to the wrapped concrete type (the same way `interpolate_fast` already is)
+  specifically so this collapse actually happens: without the forward, the boxed
+  type would inherit the trait's own default loop operating on the box itself, one
+  dispatch per point again. No
   strategy overrides the default per-point loop yet either, so the same seam is
   also ready for a future strategy that amortizes its own locate step across a
   batch (sorting points once, SIMD-packing the blend step, etc.), independent of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,24 +49,31 @@ Everything below is merged to `main` but not yet tagged/released.
   expose as public inherent methods.
 - `batch_interpolate`/`batch_interpolate_fast` on `Interpolator<T>` and
   `Strategy1D`/`2D`/`3D`/`ND` (both default-provided, non-breaking, mirroring
-  `interpolate_fast`'s own default): interpolate at several points while sharing one
-  grid, instead of re-locating the grid once per point. `Interp1D`/`2D`/`3D` gain
-  inherent versions taking `&[[D::Elem; N]]`, the same fixed-size-array split as
-  `interpolate`/`interpolate_fast`. `InterpND` and `InterpolatorEnum` implement both
-  directly in their `Interpolator` impls instead (no separate inherent versions):
-  `InterpND` has no fixed `N` to give an inherent version a distinct, more specific
-  signature, matching how its own `interpolate`/`interpolate_fast` already work;
-  `InterpolatorEnum`'s `interpolate_fast` override is simplified the same way in this
-  release, since its inherent signature was never more specific than the trait's
-  either. The checked `batch_interpolate` resolves `self.extrapolate` once for the
-  whole batch and funnels every point into at most one call to the strategy; under
-  `Extrapolate::Error`, it now reports every out-of-range point in one
-  `ExtrapolateError`, not just the first one found. No strategy overrides the
-  default per-point loop yet, so the seam is ready for a future strategy that
-  amortizes its locate step across a batch. `Box<dyn Interpolator<T>>` and
+  `interpolate_fast`'s own default): interpolate at several points in one call. A
+  big motivator is `Box<dyn Interpolator<T>>`/`Box<dyn Strategy1D/2D/3D/ND<D>>`:
+  interpolating `m` points against a type-erased interpolator previously cost `m`
+  virtual dispatches, one per `.interpolate()` call; `batch_interpolate` collapses
+  that to a single dispatch that reaches the concrete type once, which then loops
+  internally via ordinary static calls. `Box<dyn Interpolator<T>>` and
   `Box<dyn Strategy1D/2D/3D/ND<D>>` forward both methods to the wrapped concrete
-  type, the same way `interpolate_fast` already is, so a future batching strategy's
-  real implementation isn't silently lost behind type erasure.
+  type (the same way `interpolate_fast` already is) specifically so this collapse
+  actually happens: without the forward, the boxed type would inherit the trait's
+  own default loop operating on the box itself, one dispatch per point again. No
+  strategy overrides the default per-point loop yet either, so the same seam is
+  also ready for a future strategy that amortizes its own locate step across a
+  batch (sorting points once, SIMD-packing the blend step, etc.), independent of
+  the dispatch-collapsing benefit above. `Interp1D`/`2D`/`3D` gain inherent
+  versions taking `&[[D::Elem; N]]`, the same fixed-size-array split as
+  `interpolate`/`interpolate_fast`. `InterpND` and `InterpolatorEnum` implement
+  both directly in their `Interpolator` impls instead (no separate inherent
+  versions): `InterpND` has no fixed `N` to give an inherent version a distinct,
+  more specific signature, matching how its own `interpolate`/`interpolate_fast`
+  already work; `InterpolatorEnum`'s `interpolate_fast` override is simplified the
+  same way in this release, since its inherent signature was never more specific
+  than the trait's either. The checked `batch_interpolate` resolves
+  `self.extrapolate` once for the whole batch and funnels every point into at most
+  one call to the strategy; under `Extrapolate::Error`, it now reports every
+  out-of-range point in one `ExtrapolateError`, not just the first one found.
 - `ExtrapolateError`'s message now reads "point(s)" instead of "point", since a batch
   error can name more than one offending point.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ impl fmt::Debug for ValidateError {
 #[allow(missing_docs)]
 #[derive(Error, Clone, PartialEq)]
 pub enum InterpolateError {
-    #[error("attempted to interpolate at point beyond grid data: {0}")]
+    #[error("attempted to interpolate at point(s) beyond grid data: {0}")]
     ExtrapolateError(String),
     #[error("supplied point slice should have length {0} for {0}-D interpolation")]
     PointLength(usize),

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -343,10 +343,6 @@ where
         }
     }
 
-    /// `Interpolator::interpolate_fast` has a default body (unlike `interpolate`
-    /// above, a required method with none), so this override is what keeps
-    /// `InterpolatorEnum` from silently falling back to it: the default just
-    /// unwraps the checked `interpolate` path instead of really skipping checks.
     #[inline]
     fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
         match self {
@@ -370,9 +366,6 @@ where
         }
     }
 
-    /// Same reason as [`Self::interpolate_fast`] above: `batch_interpolate` also has
-    /// a default body (a naive per-point loop) that this override exists to replace
-    /// with the real per-variant batch call.
     fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
         match self {
             InterpolatorEnum::Interp0D(interp) => Interpolator::batch_interpolate(interp, points),
@@ -413,7 +406,6 @@ where
         }
     }
 
-    /// Same reason as [`Self::batch_interpolate`] above.
     fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
         match self {
             InterpolatorEnum::Interp0D(interp) => vec![interp.0; points.len()],

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -280,36 +280,6 @@ where
             InterpolatorEnum::InterpND(interp) => interp.init_strategy(),
         }
     }
-
-    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds or knows that extrapolation handling is not needed.
-    ///
-    /// # Panics
-    /// Panics if `point.len()` does not match [`InterpolatorEnum::ndim`].
-    pub fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem
-    where
-        D::Elem: Euclid,
-    {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => interp.0,
-            InterpolatorEnum::Interp1D(interp) => interp.interpolate_fast(
-                point
-                    .try_into()
-                    .expect("interpolate_fast: point length mismatch"),
-            ),
-            InterpolatorEnum::Interp2D(interp) => interp.interpolate_fast(
-                point
-                    .try_into()
-                    .expect("interpolate_fast: point length mismatch"),
-            ),
-            InterpolatorEnum::Interp3D(interp) => interp.interpolate_fast(
-                point
-                    .try_into()
-                    .expect("interpolate_fast: point length mismatch"),
-            ),
-            InterpolatorEnum::InterpND(interp) => interp.interpolate_fast(point),
-        }
-    }
 }
 
 impl<D> Interpolator<D::Elem> for InterpolatorEnum<D>
@@ -373,14 +343,115 @@ where
         }
     }
 
-    /// Forwards to the inherent [`InterpolatorEnum::interpolate_fast`]. Without this
-    /// override, code reaching `InterpolatorEnum` only through the `Interpolator` trait
-    /// (generic code, or `Box<dyn Interpolator<T>>`) would silently fall back to this
-    /// trait's default (the checked `interpolate` path) instead of the real fast path,
-    /// since the inherent method is invisible once the concrete type is erased.
+    /// `Interpolator::interpolate_fast` has a default body (unlike `interpolate`
+    /// above, a required method with none), so this override is what keeps
+    /// `InterpolatorEnum` from silently falling back to it: the default just
+    /// unwraps the checked `interpolate` path instead of really skipping checks.
     #[inline]
     fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
-        self.interpolate_fast(point)
+        match self {
+            InterpolatorEnum::Interp0D(interp) => interp.0,
+            InterpolatorEnum::Interp1D(interp) => interp.interpolate_fast(
+                point
+                    .try_into()
+                    .expect("interpolate_fast: point length mismatch"),
+            ),
+            InterpolatorEnum::Interp2D(interp) => interp.interpolate_fast(
+                point
+                    .try_into()
+                    .expect("interpolate_fast: point length mismatch"),
+            ),
+            InterpolatorEnum::Interp3D(interp) => interp.interpolate_fast(
+                point
+                    .try_into()
+                    .expect("interpolate_fast: point length mismatch"),
+            ),
+            InterpolatorEnum::InterpND(interp) => interp.interpolate_fast(point),
+        }
+    }
+
+    /// Same reason as [`Self::interpolate_fast`] above: `batch_interpolate` also has
+    /// a default body (a naive per-point loop) that this override exists to replace
+    /// with the real per-variant batch call.
+    fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
+        match self {
+            InterpolatorEnum::Interp0D(interp) => Interpolator::batch_interpolate(interp, points),
+            InterpolatorEnum::Interp1D(interp) => {
+                let points: Vec<[D::Elem; 1]> = points
+                    .iter()
+                    .map(|&point| {
+                        point
+                            .try_into()
+                            .map_err(|_| InterpolateError::PointLength(1))
+                    })
+                    .collect::<Result<_, _>>()?;
+                interp.batch_interpolate(&points)
+            }
+            InterpolatorEnum::Interp2D(interp) => {
+                let points: Vec<[D::Elem; 2]> = points
+                    .iter()
+                    .map(|&point| {
+                        point
+                            .try_into()
+                            .map_err(|_| InterpolateError::PointLength(2))
+                    })
+                    .collect::<Result<_, _>>()?;
+                interp.batch_interpolate(&points)
+            }
+            InterpolatorEnum::Interp3D(interp) => {
+                let points: Vec<[D::Elem; 3]> = points
+                    .iter()
+                    .map(|&point| {
+                        point
+                            .try_into()
+                            .map_err(|_| InterpolateError::PointLength(3))
+                    })
+                    .collect::<Result<_, _>>()?;
+                interp.batch_interpolate(&points)
+            }
+            InterpolatorEnum::InterpND(interp) => interp.batch_interpolate(points),
+        }
+    }
+
+    /// Same reason as [`Self::batch_interpolate`] above.
+    fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
+        match self {
+            InterpolatorEnum::Interp0D(interp) => vec![interp.0; points.len()],
+            InterpolatorEnum::Interp1D(interp) => {
+                let points: Vec<[D::Elem; 1]> = points
+                    .iter()
+                    .map(|&point| {
+                        point
+                            .try_into()
+                            .expect("batch_interpolate_fast: point length mismatch")
+                    })
+                    .collect();
+                interp.batch_interpolate_fast(&points)
+            }
+            InterpolatorEnum::Interp2D(interp) => {
+                let points: Vec<[D::Elem; 2]> = points
+                    .iter()
+                    .map(|&point| {
+                        point
+                            .try_into()
+                            .expect("batch_interpolate_fast: point length mismatch")
+                    })
+                    .collect();
+                interp.batch_interpolate_fast(&points)
+            }
+            InterpolatorEnum::Interp3D(interp) => {
+                let points: Vec<[D::Elem; 3]> = points
+                    .iter()
+                    .map(|&point| {
+                        point
+                            .try_into()
+                            .expect("batch_interpolate_fast: point length mismatch")
+                    })
+                    .collect();
+                interp.batch_interpolate_fast(&points)
+            }
+            InterpolatorEnum::InterpND(interp) => interp.batch_interpolate_fast(points),
+        }
     }
 }
 
@@ -492,6 +563,66 @@ mod tests {
         assert!(matches!(
             interp_3d.interpolate(&[]).unwrap_err(),
             InterpolateError::PointLength(3)
+        ));
+    }
+
+    #[test]
+    fn test_batch_interpolate() {
+        let interp = InterpolatorEnum::new_1d(
+            array![0., 1., 2., 3., 4.],
+            array![0.2, 0.4, 0.6, 0.8, 1.0],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap();
+        let points: [&[f64]; 2] = [&[1.0], &[3.0]];
+        assert_eq!(interp.batch_interpolate(&points).unwrap(), vec![0.4, 0.8]);
+        assert_eq!(interp.batch_interpolate_fast(&points), vec![0.4, 0.8]);
+    }
+
+    #[test]
+    fn test_batch_interpolate_0d() {
+        let interp: InterpolatorEnumOwned<f64> = InterpolatorEnum::new_0d(0.5);
+        let points: [&[f64]; 3] = [&[], &[], &[]];
+        assert_eq!(
+            interp.batch_interpolate(&points).unwrap(),
+            vec![0.5, 0.5, 0.5]
+        );
+        assert_eq!(interp.batch_interpolate_fast(&points), vec![0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn test_batch_interpolate_nd() {
+        let interp = InterpolatorEnum::new_nd(
+            vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+            array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]].into_dyn(),
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap();
+        let points: [&[f64]; 2] = [&[0.25, 0.65, 0.9], &[0.5, 0.5, 0.5]];
+        let batched = interp.batch_interpolate(&points).unwrap();
+        let looped: Vec<_> = points
+            .iter()
+            .map(|point| interp.interpolate(point).unwrap())
+            .collect();
+        assert_eq!(batched, looped);
+    }
+
+    #[test]
+    fn test_batch_interpolate_point_length_mismatch() {
+        let interp = InterpolatorEnum::new_2d(
+            array![0.05, 0.10, 0.15],
+            array![0.10, 0.20, 0.30],
+            array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap();
+        let points: [&[f64]; 1] = [&[0.075]];
+        assert!(matches!(
+            interp.batch_interpolate(&points).unwrap_err(),
+            InterpolateError::PointLength(2)
         ));
     }
 

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -51,6 +51,27 @@ pub trait Interpolator<T>: DynClone {
         self.interpolate(point)
             .expect("interpolate_fast: invalid point or data")
     }
+
+    /// Interpolate at each of several points, sharing one grid across all of them.
+    ///
+    /// Default just loops [`Interpolator::interpolate`]. `Interp1D`/`2D`/`3D`/`ND`
+    /// override this to funnel the whole batch into a single call to the strategy,
+    /// rather than repeating a per-point grid search for every point.
+    fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError> {
+        points.iter().map(|point| self.interpolate(point)).collect()
+    }
+
+    /// Batched [`Interpolator::interpolate_fast`], assuming every point is already
+    /// valid.
+    ///
+    /// Default just loops [`Interpolator::interpolate_fast`]. `Interp1D`/`2D`/`3D`/
+    /// `ND` override this the same way as [`Interpolator::batch_interpolate`].
+    fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T> {
+        points
+            .iter()
+            .map(|point| self.interpolate_fast(point))
+            .collect()
+    }
 }
 
 clone_trait_object!(<T> Interpolator<T>);
@@ -70,6 +91,12 @@ impl<T> Interpolator<T> for Box<dyn Interpolator<T>> {
     }
     fn interpolate_fast(&self, point: &[T]) -> T {
         (**self).interpolate_fast(point)
+    }
+    fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError> {
+        (**self).batch_interpolate(points)
+    }
+    fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T> {
+        (**self).batch_interpolate_fast(points)
     }
 }
 
@@ -122,13 +149,33 @@ macro_rules! extrapolate_impl {
 }
 pub(crate) use extrapolate_impl;
 
-/// Generates the [`Interpolator::interpolate`]/[`Interpolator::interpolate_fast`]
-/// bodies shared by `Interp1D`/`2D`/`3D`'s trait impls: convert the incoming slice to
-/// the fixed-size `[D::Elem; N]` the type's own inherent method of the same name
-/// expects (a length-checked `?` for `interpolate`, a length-asserting `.expect(...)`
-/// for `interpolate_fast`), then call it. `InterpND` has no fixed `N`, so it can't use
-/// this and implements both methods by hand instead.
-macro_rules! checked_interpolate_impl {
+/// Is `point` out of `grid`'s bounds in any dimension?
+///
+/// Shared by `Interp1D`/`2D`/`3D`/`ND`'s `batch_interpolate`: both `grid` and `point`
+/// are taken as slices, so one function covers `Interp1D`/`2D`/`3D`'s fixed-size
+/// `[ArrayBase<D, Ix1>; N]` grid (via array-to-slice coercion) and `InterpND`'s
+/// `Vec<ArrayBase<D, Ix1>>` alike.
+pub(crate) fn out_of_bounds<D>(grid: &[ArrayBase<D, Ix1>], point: &[D::Elem]) -> bool
+where
+    D: Data,
+    D::Elem: PartialOrd,
+{
+    grid.iter()
+        .zip(point)
+        .any(|(axis, coord)| !(axis.first().unwrap()..=axis.last().unwrap()).contains(&coord))
+}
+
+/// Generates the [`Interpolator::interpolate`]/[`Interpolator::interpolate_fast`]/
+/// [`Interpolator::batch_interpolate`]/[`Interpolator::batch_interpolate_fast`]
+/// bodies shared by `Interp1D`/`2D`/`3D`'s trait impls. The trait's slice-based
+/// signature can't fix the point length at compile time the way the type's own
+/// inherent `[D::Elem; N]`-based method can, so each body converts the incoming
+/// slice(s) to that fixed size first, via `?` for the two `Result`-returning
+/// methods, via `.expect(...)` for their `_fast` counterparts, then calls straight
+/// through to the inherent method, which owns all bounds/extrapolation handling from
+/// there. `InterpND` has no fixed `N`, so it can't use this and implements all four
+/// methods by hand instead.
+macro_rules! sized_interpolate_impl {
     () => {
         fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
             let point: &[D::Elem; N] = point
@@ -143,9 +190,156 @@ macro_rules! checked_interpolate_impl {
                 .expect("interpolate_fast: point length mismatch");
             self.interpolate_fast(point)
         }
+
+        fn batch_interpolate(
+            &self,
+            points: &[&[D::Elem]],
+        ) -> Result<Vec<D::Elem>, InterpolateError> {
+            let points: Vec<[D::Elem; N]> = points
+                .iter()
+                .map(|&point| {
+                    <&[D::Elem; N]>::try_from(point)
+                        .map(|arr| *arr)
+                        .map_err(|_| InterpolateError::PointLength(N))
+                })
+                .collect::<Result<_, _>>()?;
+            self.batch_interpolate(&points)
+        }
+
+        fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
+            let points: Vec<[D::Elem; N]> = points
+                .iter()
+                .map(|&point| {
+                    *<&[D::Elem; N]>::try_from(point)
+                        .expect("batch_interpolate_fast: point length mismatch")
+                })
+                .collect();
+            self.batch_interpolate_fast(&points)
+        }
     };
 }
-pub(crate) use checked_interpolate_impl;
+pub(crate) use sized_interpolate_impl;
+
+/// Generates the inherent `batch_interpolate_fast` shared by `Interp1D`/`2D`/`3D`:
+/// forwards straight to the strategy, same as the existing hand-written
+/// `interpolate_fast` does.
+macro_rules! batch_interpolate_fast_impl {
+    () => {
+        /// Batched [`Self::interpolate_fast`], for use in hot loops where the caller
+        /// has already checked bounds or knows that extrapolation handling is not
+        /// needed.
+        pub fn batch_interpolate_fast(&self, points: &[[D::Elem; N]]) -> Vec<D::Elem> {
+            self.strategy.batch_interpolate_fast(&self.data, points)
+        }
+    };
+}
+pub(crate) use batch_interpolate_fast_impl;
+
+/// Generates the inherent `batch_interpolate` shared by `Interp1D`/`2D`/`3D`:
+/// resolves `self.extrapolate` once for the whole batch (see the extrapolate-mode
+/// partitioning table in issue #21), then funnels every point into at most one call
+/// to the strategy, rather than calling the existing hand-written `interpolate` once
+/// per point.
+macro_rules! batch_interpolate_impl {
+    () => {
+        /// Interpolate at each of several points, sharing one grid across all of
+        /// them.
+        ///
+        /// `self.extrapolate` is one setting for the whole call, not resolved per
+        /// point: every point still funnels into at most one call to the strategy,
+        /// rather than calling [`Self::interpolate`] once per point.
+        pub fn batch_interpolate(
+            &self,
+            points: &[[D::Elem; N]],
+        ) -> Result<Vec<D::Elem>, InterpolateError> {
+            match &self.extrapolate {
+                Extrapolate::Enable => self.strategy.batch_interpolate(&self.data, points),
+                Extrapolate::Clamp => {
+                    // Clamping an in-bounds point is already identity, so every point
+                    // can be clamped unconditionally.
+                    let clamped: Vec<[D::Elem; N]> = points
+                        .iter()
+                        .map(|point| {
+                            std::array::from_fn(|i| {
+                                *clamp(
+                                    &point[i],
+                                    self.data.grid[i].first().unwrap(),
+                                    self.data.grid[i].last().unwrap(),
+                                )
+                            })
+                        })
+                        .collect();
+                    self.strategy.batch_interpolate(&self.data, &clamped)
+                }
+                Extrapolate::Wrap => {
+                    // Unlike `Clamp`, `wrap()` isn't identity exactly at the
+                    // boundary, so only out-of-bounds points get wrapped.
+                    let wrapped: Vec<[D::Elem; N]> = points
+                        .iter()
+                        .map(|point| {
+                            if out_of_bounds(&self.data.grid, point) {
+                                std::array::from_fn(|i| {
+                                    wrap(
+                                        point[i],
+                                        *self.data.grid[i].first().unwrap(),
+                                        *self.data.grid[i].last().unwrap(),
+                                    )
+                                })
+                            } else {
+                                *point
+                            }
+                        })
+                        .collect();
+                    self.strategy.batch_interpolate(&self.data, &wrapped)
+                }
+                Extrapolate::Fill(value) => {
+                    let mut results = vec![*value; points.len()];
+                    let (in_bounds_indices, in_bounds_points): (Vec<usize>, Vec<[D::Elem; N]>) =
+                        points
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, point)| !out_of_bounds(&self.data.grid, *point))
+                            .map(|(i, point)| (i, *point))
+                            .unzip();
+                    let interpolated =
+                        self.strategy.batch_interpolate(&self.data, &in_bounds_points)?;
+                    for (i, value) in in_bounds_indices.into_iter().zip(interpolated) {
+                        results[i] = value;
+                    }
+                    Ok(results)
+                }
+                Extrapolate::Error => {
+                    let mut errors = Vec::new();
+                    let mut in_bounds_points = Vec::new();
+                    for (i, point) in points.iter().enumerate() {
+                        let mut point_errors = Vec::new();
+                        for dim in 0..N {
+                            if !(self.data.grid[dim].first().unwrap()
+                                ..=self.data.grid[dim].last().unwrap())
+                                .contains(&&point[dim])
+                            {
+                                point_errors.push(format!(
+                                    "\n    point[{i}][{dim}] = {:?} is out of bounds for grid[{dim}] = {:?}",
+                                    point[dim], self.data.grid[dim],
+                                ));
+                            }
+                        }
+                        if point_errors.is_empty() {
+                            in_bounds_points.push(*point);
+                        } else {
+                            errors.extend(point_errors);
+                        }
+                    }
+                    if !errors.is_empty() {
+                        return Err(InterpolateError::ExtrapolateError(errors.join("")));
+                    }
+                    self.strategy.batch_interpolate(&self.data, &in_bounds_points)
+                }
+            }
+        }
+    };
+}
+pub(crate) use batch_interpolate_impl;
 
 macro_rules! partialeq_impl {
     ($InterpType:ident, $Data:ident, $Strategy:ident) => {

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -54,9 +54,10 @@ pub trait Interpolator<T>: DynClone {
 
     /// Interpolate at each of several points, sharing one grid across all of them.
     ///
-    /// Default just loops [`Interpolator::interpolate`]. `Interp1D`/`2D`/`3D`/`ND`
-    /// override this to funnel the whole batch into a single call to the strategy,
-    /// rather than repeating a per-point grid search for every point.
+    /// `self.extrapolate` is one setting for the whole call, not resolved per
+    /// point. Default just loops [`Interpolator::interpolate`]; `Interp1D`/`2D`/
+    /// `3D`/`ND` override this to funnel every point into at most one call to the
+    /// strategy instead.
     fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError> {
         points.iter().map(|point| self.interpolate(point)).collect()
     }

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -398,14 +398,6 @@ where
         self.strategy.interpolate_fast(&self.data, point)
     }
 
-    /// Interpolate at each of several points, sharing one grid across all of them.
-    ///
-    /// `self.extrapolate` is one setting for the whole call, not resolved per point:
-    /// every point still funnels into at most one call to the strategy, rather than
-    /// calling [`Interpolator::interpolate`] once per point. Unlike `Interp1D`/`2D`/
-    /// `3D`, there's no fixed-size array to route this through: the partitioning
-    /// below is hand-written here, the same way [`InterpND`]'s own `interpolate`
-    /// (above) is hand-written instead of using `sized_interpolate_impl!`.
     fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
         let n = self.ndim();
         for point in points {

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -397,6 +397,129 @@ where
         );
         self.strategy.interpolate_fast(&self.data, point)
     }
+
+    /// Interpolate at each of several points, sharing one grid across all of them.
+    ///
+    /// `self.extrapolate` is one setting for the whole call, not resolved per point:
+    /// every point still funnels into at most one call to the strategy, rather than
+    /// calling [`Interpolator::interpolate`] once per point. Unlike `Interp1D`/`2D`/
+    /// `3D`, there's no fixed-size array to route this through: the partitioning
+    /// below is hand-written here, the same way [`InterpND`]'s own `interpolate`
+    /// (above) is hand-written instead of using `sized_interpolate_impl!`.
+    fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
+        let n = self.ndim();
+        for point in points {
+            if point.len() != n {
+                return Err(InterpolateError::PointLength(n));
+            }
+        }
+        match &self.extrapolate {
+            Extrapolate::Enable => self.strategy.batch_interpolate(&self.data, points),
+            Extrapolate::Clamp => {
+                // Clamping an in-bounds point is already identity, so every point
+                // can be clamped unconditionally.
+                let clamped: Vec<Vec<D::Elem>> = points
+                    .iter()
+                    .map(|&point| {
+                        point
+                            .iter()
+                            .enumerate()
+                            .map(|(dim, pt)| {
+                                *clamp(
+                                    pt,
+                                    self.data.grid[dim].first().unwrap(),
+                                    self.data.grid[dim].last().unwrap(),
+                                )
+                            })
+                            .collect()
+                    })
+                    .collect();
+                let clamped: Vec<&[D::Elem]> = clamped.iter().map(Vec::as_slice).collect();
+                self.strategy.batch_interpolate(&self.data, &clamped)
+            }
+            Extrapolate::Wrap => {
+                // Unlike `Clamp`, `wrap()` isn't identity exactly at the boundary,
+                // so only out-of-bounds points get wrapped.
+                let wrapped: Vec<Vec<D::Elem>> = points
+                    .iter()
+                    .map(|&point| {
+                        if out_of_bounds(&self.data.grid, point) {
+                            point
+                                .iter()
+                                .enumerate()
+                                .map(|(dim, pt)| {
+                                    wrap(
+                                        *pt,
+                                        *self.data.grid[dim].first().unwrap(),
+                                        *self.data.grid[dim].last().unwrap(),
+                                    )
+                                })
+                                .collect()
+                        } else {
+                            point.to_vec()
+                        }
+                    })
+                    .collect();
+                let wrapped: Vec<&[D::Elem]> = wrapped.iter().map(Vec::as_slice).collect();
+                self.strategy.batch_interpolate(&self.data, &wrapped)
+            }
+            Extrapolate::Fill(value) => {
+                let mut results = vec![*value; points.len()];
+                let mut in_bounds_indices = Vec::new();
+                let mut in_bounds_points: Vec<&[D::Elem]> = Vec::new();
+                for (i, &point) in points.iter().enumerate() {
+                    if !out_of_bounds(&self.data.grid, point) {
+                        in_bounds_indices.push(i);
+                        in_bounds_points.push(point);
+                    }
+                }
+                let interpolated = self
+                    .strategy
+                    .batch_interpolate(&self.data, &in_bounds_points)?;
+                for (i, value) in in_bounds_indices.into_iter().zip(interpolated) {
+                    results[i] = value;
+                }
+                Ok(results)
+            }
+            Extrapolate::Error => {
+                let mut errors = Vec::new();
+                let mut in_bounds_points: Vec<&[D::Elem]> = Vec::new();
+                for (i, &point) in points.iter().enumerate() {
+                    let mut point_errors = Vec::new();
+                    for (dim, (axis, &coord)) in self.data.grid.iter().zip(point.iter()).enumerate()
+                    {
+                        if !(axis.first().unwrap()..=axis.last().unwrap()).contains(&&coord) {
+                            point_errors.push(format!(
+                                "\n    point[{i}][{dim}] = {coord:?} is out of bounds for grid[{dim}] = {axis:?}",
+                            ));
+                        }
+                    }
+                    if point_errors.is_empty() {
+                        in_bounds_points.push(point);
+                    } else {
+                        errors.extend(point_errors);
+                    }
+                }
+                if !errors.is_empty() {
+                    return Err(InterpolateError::ExtrapolateError(errors.join("")));
+                }
+                self.strategy
+                    .batch_interpolate(&self.data, &in_bounds_points)
+            }
+        }
+    }
+
+    fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
+        let n = self.ndim();
+        for point in points {
+            assert_eq!(
+                point.len(),
+                n,
+                "batch_interpolate_fast: point length mismatch"
+            );
+        }
+        self.strategy.batch_interpolate_fast(&self.data, points)
+    }
 }
 
 impl<D> InterpND<D, Box<dyn StrategyND<D>>>

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -501,6 +501,96 @@ fn test_interpolate_fast_point_too_long() {
 }
 
 #[test]
+fn test_batch_interpolate_matches_interpolate() {
+    let interp = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Enable,
+    )
+    .unwrap();
+    let points: [&[f64]; 3] = [&[0.25, 0.65, 0.9], &[0., 0., 0.], &[2., 2., 2.]];
+    let batched = interp.batch_interpolate(&points).unwrap();
+    let looped: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate(point).unwrap())
+        .collect();
+    assert_eq!(batched, looped);
+
+    let batched_fast = interp.batch_interpolate_fast(&points);
+    let looped_fast: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate_fast(point))
+        .collect();
+    assert_eq!(batched_fast, looped_fast);
+}
+
+#[test]
+fn test_batch_interpolate_clamp() {
+    let interp = InterpND::new(
+        vec![array![0.1, 1.1], array![0.2, 1.2], array![0.3, 1.3]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Clamp,
+    )
+    .unwrap();
+    let points: [&[f64]; 2] = [&[-1., -1., -1.], &[2., 2., 2.]];
+    assert_eq!(
+        interp.batch_interpolate(&points).unwrap(),
+        vec![interp.data.values[[0, 0, 0]], interp.data.values[[1, 1, 1]]]
+    );
+}
+
+#[test]
+fn test_batch_interpolate_error_aggregates_all_points() {
+    let interp = InterpND::new(
+        vec![array![0.1, 1.1], array![0.2, 1.2], array![0.3, 1.3]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let points: [&[f64]; 3] = [&[0.4, 0.4, 0.4], &[-1., -1., -1.], &[2., 2., 2.]];
+    let err = interp.batch_interpolate(&points).unwrap_err();
+    let InterpolateError::ExtrapolateError(message) = err else {
+        panic!("expected ExtrapolateError");
+    };
+    assert!(message.contains("point[1]"));
+    assert!(message.contains("point[2]"));
+    assert!(!message.contains("point[0]"));
+}
+
+#[test]
+fn test_batch_interpolate_point_length_mismatch() {
+    let interp = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let points: [&[f64]; 2] = [&[0.25, 0.65, 0.9], &[0.5, 0.5]];
+    assert!(matches!(
+        interp.batch_interpolate(&points).unwrap_err(),
+        InterpolateError::PointLength(3)
+    ));
+}
+
+#[test]
+#[should_panic(expected = "batch_interpolate_fast: point length mismatch")]
+fn test_batch_interpolate_fast_point_length_mismatch() {
+    let interp = InterpND::new(
+        vec![array![0., 1.], array![0., 1.], array![0., 1.]],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],].into_dyn(),
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let points: [&[f64]; 2] = [&[0.25, 0.65, 0.9], &[0.5, 0.5]];
+    interp.batch_interpolate_fast(&points);
+}
+
+#[test]
 fn test_mismatched_grid() {
     assert!(matches!(
         InterpND::new(

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -104,6 +104,8 @@ where
     pub fn interpolate_fast(&self, point: &[D::Elem; 1]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }
+
+    batch_interpolate_fast_impl!();
 }
 
 impl<D, S> Interp1D<D, S>
@@ -219,6 +221,8 @@ where
         };
         self.strategy.interpolate(&self.data, point)
     }
+
+    batch_interpolate_impl!();
 }
 
 impl<D, S> Interpolator<D::Elem> for Interp1D<D, S>
@@ -240,7 +244,7 @@ where
         Ok(())
     }
 
-    checked_interpolate_impl!();
+    sized_interpolate_impl!();
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
         self.check_extrapolate(&extrapolate)?;

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -329,6 +329,119 @@ fn test_extrapolate() {
 }
 
 #[test]
+fn test_batch_interpolate_matches_interpolate() {
+    let interp = Interp1D::new(
+        array![0., 1., 2., 3., 4.],
+        array![0.2, 0.4, 0.6, 0.8, 1.0],
+        strategy::Linear,
+        Extrapolate::Enable,
+    )
+    .unwrap();
+    let points = [[-1.], [0.5], [1.5], [3.75], [5.]];
+    let batched = interp.batch_interpolate(&points).unwrap();
+    let looped: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate(point).unwrap())
+        .collect();
+    assert_eq!(batched, looped);
+
+    let batched_fast = interp.batch_interpolate_fast(&points);
+    let looped_fast: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate_fast(point))
+        .collect();
+    assert_eq!(batched_fast, looped_fast);
+}
+
+#[test]
+fn test_batch_interpolate_clamp() {
+    let interp = Interp1D::new(
+        array![0., 1., 2., 3., 4.],
+        array![0.2, 0.4, 0.6, 0.8, 1.0],
+        strategy::Linear,
+        Extrapolate::Clamp,
+    )
+    .unwrap();
+    assert_eq!(
+        interp.batch_interpolate(&[[-1.], [2.], [5.]]).unwrap(),
+        vec![0.2, 0.6, 1.0]
+    );
+}
+
+#[test]
+fn test_batch_interpolate_fill() {
+    let interp = Interp1D::new(
+        array![0., 1., 2., 3., 4.],
+        array![0.2, 0.4, 0.6, 0.8, 1.0],
+        strategy::Linear,
+        Extrapolate::Fill(f64::NAN),
+    )
+    .unwrap();
+    let results = interp.batch_interpolate(&[[-1.], [2.], [5.]]).unwrap();
+    assert!(results[0].is_nan());
+    assert_eq!(results[1], 0.6);
+    assert!(results[2].is_nan());
+}
+
+#[test]
+fn test_batch_interpolate_wrap_boundary() {
+    // `wrap()` isn't identity exactly at the boundary (`wrap(max, min, max) == min`),
+    // so an in-bounds point sitting exactly on the upper edge must not get wrapped,
+    // while a genuinely out-of-bounds point still does.
+    let interp = Interp1D::new(
+        array![0., 1., 2., 3., 4.],
+        array![0.2, 0.4, 0.6, 0.8, 1.0],
+        strategy::Linear,
+        Extrapolate::Wrap,
+    )
+    .unwrap();
+    let results = interp.batch_interpolate(&[[4.], [5.]]).unwrap();
+    assert_eq!(results[0], interp.interpolate(&[4.]).unwrap());
+    assert_eq!(results[1], interp.interpolate(&[5.]).unwrap());
+    assert_eq!(results[0], 1.0); // untouched boundary point
+    assert_eq!(results[1], 0.4); // wrap(5, 0, 4) == 1 -> f(1) == 0.4
+}
+
+#[test]
+fn test_batch_interpolate_error_aggregates_all_points() {
+    let interp = Interp1D::new(
+        array![0., 1., 2., 3., 4.],
+        array![0.2, 0.4, 0.6, 0.8, 1.0],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    // Two bad points among good ones: the batch error must mention both, not just
+    // the first one it finds.
+    let err = interp
+        .batch_interpolate(&[[1.], [-1.], [2.], [5.]])
+        .unwrap_err();
+    let InterpolateError::ExtrapolateError(message) = err else {
+        panic!("expected ExtrapolateError");
+    };
+    assert!(message.contains("point[1]"));
+    assert!(message.contains("point[3]"));
+    assert!(!message.contains("point[0]"));
+    assert!(!message.contains("point[2]"));
+}
+
+#[test]
+fn test_batch_interpolate_dyn() {
+    let interp: Box<dyn Interpolator<f64>> = Box::new(
+        Interp1D::new(
+            array![0., 1., 2., 3., 4.],
+            array![0.2, 0.4, 0.6, 0.8, 1.0],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap(),
+    );
+    let points: [&[f64]; 2] = [&[1.0], &[3.0]];
+    assert_eq!(interp.batch_interpolate(&points).unwrap(), vec![0.4, 0.8]);
+    assert_eq!(interp.batch_interpolate_fast(&points), vec![0.4, 0.8]);
+}
+
+#[test]
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -109,6 +109,8 @@ where
     pub fn interpolate_fast(&self, point: &[D::Elem; 3]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }
+
+    batch_interpolate_fast_impl!();
 }
 
 impl<D, S> Interp3D<D, S>
@@ -255,6 +257,8 @@ where
         }
         self.strategy.interpolate(&self.data, point)
     }
+
+    batch_interpolate_impl!();
 }
 
 impl<D, S> Interpolator<D::Elem> for Interp3D<D, S>
@@ -276,7 +280,7 @@ where
         Ok(())
     }
 
-    checked_interpolate_impl!();
+    sized_interpolate_impl!();
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
         self.check_extrapolate(&extrapolate)?;

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -307,6 +307,78 @@ fn test_extrapolate_clamp() {
 }
 
 #[test]
+fn test_batch_interpolate_matches_interpolate() {
+    let interp = Interp3D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![0.20, 0.40, 0.60],
+        array![
+            [[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+            [[9., 10., 11.], [12., 13., 14.], [15., 16., 17.]],
+            [[18., 19., 20.], [21., 22., 23.], [24., 25., 26.],],
+        ],
+        strategy::Linear,
+        Extrapolate::Enable,
+    )
+    .unwrap();
+    let points = [[0.075, 0.25, 0.3], [0.05, 0.10, 0.20], [0.2, 0.4, 0.8]];
+    let batched = interp.batch_interpolate(&points).unwrap();
+    let looped: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate(point).unwrap())
+        .collect();
+    assert_eq!(batched, looped);
+
+    let batched_fast = interp.batch_interpolate_fast(&points);
+    let looped_fast: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate_fast(point))
+        .collect();
+    assert_eq!(batched_fast, looped_fast);
+}
+
+#[test]
+fn test_batch_interpolate_clamp() {
+    let interp = Interp3D::new(
+        array![0.1, 1.1],
+        array![0.2, 1.2],
+        array![0.3, 1.3],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],],
+        strategy::Linear,
+        Extrapolate::Clamp,
+    )
+    .unwrap();
+    assert_eq!(
+        interp
+            .batch_interpolate(&[[-1., -1., -1.], [2., 2., 2.]])
+            .unwrap(),
+        vec![0., 7.]
+    );
+}
+
+#[test]
+fn test_batch_interpolate_error_aggregates_all_points() {
+    let interp = Interp3D::new(
+        array![0.1, 1.1],
+        array![0.2, 1.2],
+        array![0.3, 1.3],
+        array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]],],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let err = interp
+        .batch_interpolate(&[[0.4, 0.4, 0.4], [-1., -1., -1.], [2., 2., 2.]])
+        .unwrap_err();
+    let InterpolateError::ExtrapolateError(message) = err else {
+        panic!("expected ExtrapolateError");
+    };
+    assert!(message.contains("point[1]"));
+    assert!(message.contains("point[2]"));
+    assert!(!message.contains("point[0]"));
+}
+
+#[test]
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -108,6 +108,8 @@ where
     pub fn interpolate_fast(&self, point: &[D::Elem; 2]) -> D::Elem {
         self.strategy.interpolate_fast(&self.data, point)
     }
+
+    batch_interpolate_fast_impl!();
 }
 
 impl<D, S> Interp2D<D, S>
@@ -243,6 +245,8 @@ where
         }
         self.strategy.interpolate(&self.data, point)
     }
+
+    batch_interpolate_impl!();
 }
 
 impl<D, S> Interpolator<D::Elem> for Interp2D<D, S>
@@ -264,7 +268,7 @@ where
         Ok(())
     }
 
-    checked_interpolate_impl!();
+    sized_interpolate_impl!();
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
         self.check_extrapolate(&extrapolate)?;

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -332,6 +332,86 @@ fn test_extrapolate_clamp() {
 }
 
 #[test]
+fn test_batch_interpolate_matches_interpolate() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Enable,
+    )
+    .unwrap();
+    let points = [[0.075, 0.25], [0.05, 0.10], [0.2, 0.4]];
+    let batched = interp.batch_interpolate(&points).unwrap();
+    let looped: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate(point).unwrap())
+        .collect();
+    assert_eq!(batched, looped);
+
+    let batched_fast = interp.batch_interpolate_fast(&points);
+    let looped_fast: Vec<_> = points
+        .iter()
+        .map(|point| interp.interpolate_fast(point))
+        .collect();
+    assert_eq!(batched_fast, looped_fast);
+}
+
+#[test]
+fn test_batch_interpolate_clamp() {
+    let interp = Interp2D::new(
+        array![0.1, 1.1],
+        array![0.2, 1.2],
+        array![[0., 1.], [2., 3.]],
+        strategy::Linear,
+        Extrapolate::Clamp,
+    )
+    .unwrap();
+    assert_eq!(
+        interp.batch_interpolate(&[[-1., -1.], [2., 2.]]).unwrap(),
+        vec![0., 3.]
+    );
+}
+
+#[test]
+fn test_batch_interpolate_error_aggregates_all_points() {
+    let interp = Interp2D::new(
+        array![0.1, 1.1],
+        array![0.2, 1.2],
+        array![[0., 1.], [2., 3.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let err = interp
+        .batch_interpolate(&[[0.5, 0.5], [-1., -1.], [2., 2.]])
+        .unwrap_err();
+    let InterpolateError::ExtrapolateError(message) = err else {
+        panic!("expected ExtrapolateError");
+    };
+    assert!(message.contains("point[1]"));
+    assert!(message.contains("point[2]"));
+    assert!(!message.contains("point[0]"));
+}
+
+#[test]
+fn test_batch_interpolate_dyn() {
+    let interp: Box<dyn Interpolator<f64>> = Box::new(
+        Interp2D::new(
+            array![0.05, 0.10, 0.15],
+            array![0.10, 0.20, 0.30],
+            array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+            strategy::Linear,
+            Extrapolate::Error,
+        )
+        .unwrap(),
+    );
+    let points: [&[f64]; 2] = [&[0.075, 0.25], &[0.05, 0.10]];
+    assert_eq!(interp.batch_interpolate(&points).unwrap(), vec![3., 0.]);
+    assert_eq!(interp.batch_interpolate_fast(&points), vec![3., 0.]);
+}
+
+#[test]
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -256,6 +256,24 @@ fn test_dyn_strategy() {
 }
 
 #[test]
+fn test_dyn_strategy_batch_interpolate() {
+    // Strategy2D<D>'s batch_interpolate/batch_interpolate_fast for
+    // Box<dyn Strategy2D<D>> forward to the wrapped concrete strategy; confirm that
+    // forward actually produces correct output, not just that it compiles.
+    let interp = Interp2D::new(
+        array![0., 1.],
+        array![0., 1.],
+        array![[0., 1.], [2., 3.]],
+        Box::new(strategy::Linear) as Box<dyn Strategy2D<_>>,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let points = [[0.2, 0.], [1., 1.]];
+    assert_eq!(interp.batch_interpolate(&points).unwrap(), vec![0.4, 3.]);
+    assert_eq!(interp.batch_interpolate_fast(&points), vec![0.4, 3.]);
+}
+
+#[test]
 fn test_set_strategy_runs_init() {
     // `Step`'s `validate` checks its direction count against dimensionality,
     // so swapping in a `Step` with the wrong count via `set_strategy` must

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -51,6 +51,39 @@ where
             .expect("interpolate_fast: invalid point or data")
     }
 
+    /// Interpolate at each of several points, sharing one grid across all of them.
+    ///
+    /// Default just loops [`Strategy1D::interpolate`]. Override only if locating a
+    /// point in the grid can be amortized across the batch (e.g. sorting points once
+    /// for a locate sweep instead of one binary search per point); no strategy
+    /// shipped in this crate does that today.
+    fn batch_interpolate(
+        &self,
+        data: &InterpData1D<D>,
+        points: &[[D::Elem; 1]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        points
+            .iter()
+            .map(|point| self.interpolate(data, point))
+            .collect()
+    }
+
+    /// Batched [`Strategy1D::interpolate_fast`], assuming every point and `data` are
+    /// already valid.
+    ///
+    /// Default just loops [`Strategy1D::interpolate_fast`]. Override under the same
+    /// condition as [`Strategy1D::batch_interpolate`].
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpData1D<D>,
+        points: &[[D::Elem; 1]],
+    ) -> Vec<D::Elem> {
+        points
+            .iter()
+            .map(|point| self.interpolate_fast(data, point))
+            .collect()
+    }
+
     /// Does this type's [`Strategy1D::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -86,6 +119,24 @@ where
     #[inline]
     fn interpolate_fast(&self, data: &InterpData1D<D>, point: &[D::Elem; 1]) -> D::Elem {
         (**self).interpolate_fast(data, point)
+    }
+
+    #[inline]
+    fn batch_interpolate(
+        &self,
+        data: &InterpData1D<D>,
+        points: &[[D::Elem; 1]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        (**self).batch_interpolate(data, points)
+    }
+
+    #[inline]
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpData1D<D>,
+        points: &[[D::Elem; 1]],
+    ) -> Vec<D::Elem> {
+        (**self).batch_interpolate_fast(data, points)
     }
 
     #[inline]
@@ -143,6 +194,39 @@ where
             .expect("interpolate_fast: invalid point or data")
     }
 
+    /// Interpolate at each of several points, sharing one grid across all of them.
+    ///
+    /// Default just loops [`Strategy2D::interpolate`]. Override only if locating a
+    /// point in the grid can be amortized across the batch (e.g. sorting points once
+    /// for a locate sweep instead of one binary search per point); no strategy
+    /// shipped in this crate does that today.
+    fn batch_interpolate(
+        &self,
+        data: &InterpData2D<D>,
+        points: &[[D::Elem; 2]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        points
+            .iter()
+            .map(|point| self.interpolate(data, point))
+            .collect()
+    }
+
+    /// Batched [`Strategy2D::interpolate_fast`], assuming every point and `data` are
+    /// already valid.
+    ///
+    /// Default just loops [`Strategy2D::interpolate_fast`]. Override under the same
+    /// condition as [`Strategy2D::batch_interpolate`].
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpData2D<D>,
+        points: &[[D::Elem; 2]],
+    ) -> Vec<D::Elem> {
+        points
+            .iter()
+            .map(|point| self.interpolate_fast(data, point))
+            .collect()
+    }
+
     /// Does this type's [`Strategy2D::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -178,6 +262,24 @@ where
     #[inline]
     fn interpolate_fast(&self, data: &InterpData2D<D>, point: &[D::Elem; 2]) -> D::Elem {
         (**self).interpolate_fast(data, point)
+    }
+
+    #[inline]
+    fn batch_interpolate(
+        &self,
+        data: &InterpData2D<D>,
+        points: &[[D::Elem; 2]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        (**self).batch_interpolate(data, points)
+    }
+
+    #[inline]
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpData2D<D>,
+        points: &[[D::Elem; 2]],
+    ) -> Vec<D::Elem> {
+        (**self).batch_interpolate_fast(data, points)
     }
 
     #[inline]
@@ -235,6 +337,39 @@ where
             .expect("interpolate_fast: invalid point or data")
     }
 
+    /// Interpolate at each of several points, sharing one grid across all of them.
+    ///
+    /// Default just loops [`Strategy3D::interpolate`]. Override only if locating a
+    /// point in the grid can be amortized across the batch (e.g. sorting points once
+    /// for a locate sweep instead of one binary search per point); no strategy
+    /// shipped in this crate does that today.
+    fn batch_interpolate(
+        &self,
+        data: &InterpData3D<D>,
+        points: &[[D::Elem; 3]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        points
+            .iter()
+            .map(|point| self.interpolate(data, point))
+            .collect()
+    }
+
+    /// Batched [`Strategy3D::interpolate_fast`], assuming every point and `data` are
+    /// already valid.
+    ///
+    /// Default just loops [`Strategy3D::interpolate_fast`]. Override under the same
+    /// condition as [`Strategy3D::batch_interpolate`].
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpData3D<D>,
+        points: &[[D::Elem; 3]],
+    ) -> Vec<D::Elem> {
+        points
+            .iter()
+            .map(|point| self.interpolate_fast(data, point))
+            .collect()
+    }
+
     /// Does this type's [`Strategy3D::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -270,6 +405,24 @@ where
     #[inline]
     fn interpolate_fast(&self, data: &InterpData3D<D>, point: &[D::Elem; 3]) -> D::Elem {
         (**self).interpolate_fast(data, point)
+    }
+
+    #[inline]
+    fn batch_interpolate(
+        &self,
+        data: &InterpData3D<D>,
+        points: &[[D::Elem; 3]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        (**self).batch_interpolate(data, points)
+    }
+
+    #[inline]
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpData3D<D>,
+        points: &[[D::Elem; 3]],
+    ) -> Vec<D::Elem> {
+        (**self).batch_interpolate_fast(data, points)
     }
 
     #[inline]
@@ -327,6 +480,39 @@ where
             .expect("interpolate_fast: invalid point or data")
     }
 
+    /// Interpolate at each of several points, sharing one grid across all of them.
+    ///
+    /// Default just loops [`StrategyND::interpolate`]. Override only if locating a
+    /// point in the grid can be amortized across the batch (e.g. sorting points once
+    /// for a locate sweep instead of one binary search per point); no strategy
+    /// shipped in this crate does that today.
+    fn batch_interpolate(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        points
+            .iter()
+            .map(|point| self.interpolate(data, point))
+            .collect()
+    }
+
+    /// Batched [`StrategyND::interpolate_fast`], assuming every point and `data` are
+    /// already valid.
+    ///
+    /// Default just loops [`StrategyND::interpolate_fast`]. Override under the same
+    /// condition as [`StrategyND::batch_interpolate`].
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+    ) -> Vec<D::Elem> {
+        points
+            .iter()
+            .map(|point| self.interpolate_fast(data, point))
+            .collect()
+    }
+
     /// Does this type's [`StrategyND::interpolate`] provision for extrapolation?
     fn allow_extrapolate(&self) -> bool;
 }
@@ -366,5 +552,23 @@ where
     #[inline]
     fn interpolate_fast(&self, data: &InterpDataND<D>, point: &[D::Elem]) -> D::Elem {
         (**self).interpolate_fast(data, point)
+    }
+
+    #[inline]
+    fn batch_interpolate(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+    ) -> Result<Vec<D::Elem>, InterpolateError> {
+        (**self).batch_interpolate(data, points)
+    }
+
+    #[inline]
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+    ) -> Vec<D::Elem> {
+        (**self).batch_interpolate_fast(data, points)
     }
 }

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -95,13 +95,11 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Validate strategy state against interpolation data. Pure check, no mutation.
     #[inline]
     fn validate(&self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
         (**self).validate(data)
     }
 
-    /// Initialize strategy struct, with access to interpolation data.
     #[inline]
     fn init(&mut self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
         (**self).init(data)
@@ -238,13 +236,11 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Validate strategy state against interpolation data. Pure check, no mutation.
     #[inline]
     fn validate(&self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
         (**self).validate(data)
     }
 
-    /// Initialize strategy struct, with access to interpolation data.
     #[inline]
     fn init(&mut self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
         (**self).init(data)
@@ -381,13 +377,11 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Validate strategy state against interpolation data. Pure check, no mutation.
     #[inline]
     fn validate(&self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
         (**self).validate(data)
     }
 
-    /// Initialize strategy struct, with access to interpolation data.
     #[inline]
     fn init(&mut self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
         (**self).init(data)
@@ -524,7 +518,6 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
-    /// Validate strategy state against interpolation data. Pure check, no mutation.
     #[inline]
     fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
         (**self).validate(data)


### PR DESCRIPTION
Closes #21.

## Summary

Adds `batch_interpolate`/`batch_interpolate_fast`: interpolate at several points in
one call.

A big motivator is `Box<dyn Interpolator<T>>` (and `Box<dyn Strategy1D/2D/3D/ND<D>>`):
today, interpolating `m` points against a type-erased interpolator costs `m` virtual
dispatches, one per `.interpolate()` call. `batch_interpolate` collapses that to a
single virtual dispatch that reaches the concrete type once, which then loops
internally via ordinary static calls, no vtable involved past that first hop. This
holds at both erasure points independently: a boxed `Interp2D` reaches the concrete
interpolator in one hop, and (separately) an `Interp2D<D, Box<dyn Strategy2D<D>>>`
reaches the concrete *strategy* in one hop too, since the strategy-level forward
below gets the exact same treatment. This is real and already true with today's
default per-point-loop body, independent of whether any strategy also amortizes its
own locate step, which no strategy shipped here does yet, that's a separate,
future-facing seam this also opens up (sort points once for a locate sweep,
SIMD-pack the blend step, etc.) without another API change.

- `Interpolator<T>` and `Strategy1D`/`2D`/`3D`/`ND` get both methods with a
  default-provided per-point-loop body (non-breaking), mirroring `interpolate_fast`'s
  own default.
- `Interp1D`/`2D`/`3D` get inherent, fixed-size-array versions
  (`&[[D::Elem; N]]`), generated by two new macros
  (`batch_interpolate_impl!`/`batch_interpolate_fast_impl!`) alongside the renamed
  `sized_interpolate_impl!` (was `checked_interpolate_impl!`, extended to cover the
  new trait-level batch methods too).
- The checked `batch_interpolate` resolves `self.extrapolate` once for the whole
  batch, then funnels every point into at most one call to the strategy:
  - `Enable`: no preprocessing.
  - `Clamp`: every point clamped unconditionally (clamping an in-bounds point is
    already identity).
  - `Wrap`: only out-of-bounds points get wrapped (`wrap()` isn't identity exactly
    at the boundary).
  - `Fill`: in-bounds points batch-called, out-of-bounds points filled directly,
    recombined by original index.
  - `Error`: now aggregates every out-of-range point into one `ExtrapolateError`,
    instead of bailing on the first. `ExtrapolateError`'s message is reworded from
    "point beyond" to "point(s) beyond" to match.
- `InterpND` implements both directly in its `Interpolator` impl (no inherent
  version): there's no fixed `N` to give one a more specific signature, matching how
  its own `interpolate`/`interpolate_fast` already work.
- `InterpolatorEnum` implements both directly in its `Interpolator` impl too. Its
  pre-existing `interpolate_fast` override is simplified the same way in this PR
  (dropping its separate inherent method): that inherent copy never had a signature
  more specific than the trait's, so it wasn't buying anything `interpolate` itself
  doesn't already do without one.
- `Box<dyn Interpolator<T>>` and `Box<dyn Strategy1D/2D/3D/ND<D>>` forward both new
  methods to the wrapped concrete type, the same way `interpolate_fast` already is.
  Without this, `batch_interpolate` on a boxed interpolator (or an interpolator
  holding a boxed strategy) would inherit the trait's own default loop operating on
  the box itself, one vtable dispatch per point, exactly the cost this feature
  exists to collapse to one. Concretely, for `Interp2D<D, Box<dyn Strategy2D<D>>>`:
  `Interp2D::batch_interpolate` calls `self.strategy.batch_interpolate(...)`, which
  hits the `Box<dyn Strategy2D<D>>` forward once to reach the concrete strategy
  (e.g. `Linear`); everything after that, including the concrete strategy's own
  (currently just inherited-default) per-point loop, runs as ordinary static calls,
  since that function is monomorphized for the concrete strategy type, not the box.
  Skip the forward and that per-point loop would instead call back through the
  box's `interpolate` once per point. It also means a future batching strategy's
  real implementation won't be silently lost behind type erasure once one exists.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (99 unit + 7 integration + 18 doc-tests)
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo fmt --check`
- New tests across `one`/`two`/`three`/`n`/`enums`: all five `Extrapolate` modes,
  the wrap-boundary edge case, multi-point `Error` aggregation, length-mismatch
  errors/panics, and `Box<dyn Interpolator<f64>>` dispatch.
