### PR TITLE
Macro-based boilerplate consolidation across 1D/2D/3D/ND interpolators

### DIFF
--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -8,66 +8,6 @@ use super::*;
 
 use strategy::enums::*;
 
-/// Generates all five `From` impls for InterpolatorEnum variants.
-macro_rules! from_impls {
-    () => {
-        impl<D> From<Interp0D<D::Elem>> for InterpolatorEnum<D>
-        where
-            D: Data + RawDataClone + Clone,
-            D::Elem: Float + Debug,
-        {
-            #[inline]
-            fn from(interpolator: Interp0D<D::Elem>) -> Self {
-                InterpolatorEnum::Interp0D(interpolator)
-            }
-        }
-
-        impl<D> From<Interp1D<D, Strategy1DEnum>> for InterpolatorEnum<D>
-        where
-            D: Data + RawDataClone + Clone,
-            D::Elem: Float + Debug,
-        {
-            #[inline]
-            fn from(interpolator: Interp1D<D, Strategy1DEnum>) -> Self {
-                InterpolatorEnum::Interp1D(interpolator)
-            }
-        }
-
-        impl<D> From<Interp2D<D, Strategy2DEnum>> for InterpolatorEnum<D>
-        where
-            D: Data + RawDataClone + Clone,
-            D::Elem: Float + Debug,
-        {
-            #[inline]
-            fn from(interpolator: Interp2D<D, Strategy2DEnum>) -> Self {
-                InterpolatorEnum::Interp2D(interpolator)
-            }
-        }
-
-        impl<D> From<Interp3D<D, Strategy3DEnum>> for InterpolatorEnum<D>
-        where
-            D: Data + RawDataClone + Clone,
-            D::Elem: Float + Debug,
-        {
-            #[inline]
-            fn from(interpolator: Interp3D<D, Strategy3DEnum>) -> Self {
-                InterpolatorEnum::Interp3D(interpolator)
-            }
-        }
-
-        impl<D> From<InterpND<D, StrategyNDEnum>> for InterpolatorEnum<D>
-        where
-            D: Data + RawDataClone + Clone,
-            D::Elem: Float + Debug,
-        {
-            #[inline]
-            fn from(interpolator: InterpND<D, StrategyNDEnum>) -> Self {
-                InterpolatorEnum::InterpND(interpolator)
-            }
-        }
-    };
-}
-
 /// Generates simple forwarding methods where Interp0D returns Ok(()), others forward to variant.
 macro_rules! enum_method_forward {
     (validate_strategy) => {
@@ -175,57 +115,6 @@ macro_rules! enum_trait_method {
                 Self::Interp2D(i) => i.$method($param),
                 Self::Interp3D(i) => i.$method($param),
                 Self::InterpND(i) => i.$method($param),
-            }
-        }
-    };
-}
-
-/// Generates full PartialEq impl for enum variants. Takes enum type as argument for reusability
-/// with InterpolatorMultiEnum and others.
-macro_rules! enum_partialeq_impl {
-    ($enum_type:ident) => {
-        impl<D> PartialEq for $enum_type<D>
-        where
-            D: Data + RawDataClone + Clone,
-            D::Elem: PartialEq + Debug,
-            ArrayBase<D, Ix1>: PartialEq,
-        {
-            fn eq(&self, other: &Self) -> bool {
-                match (self, other) {
-                    (Self::Interp0D(l), Self::Interp0D(r)) => l == r,
-                    (Self::Interp1D(l), Self::Interp1D(r)) => l == r,
-                    (Self::Interp2D(l), Self::Interp2D(r)) => l == r,
-                    (Self::Interp3D(l), Self::Interp3D(r)) => l == r,
-                    (Self::InterpND(l), Self::InterpND(r)) => l == r,
-                    _ => false,
-                }
-            }
-        }
-    };
-}
-
-/// Generates full SerializeNested impl for enum variants. Takes enum type as argument for reusability
-/// with InterpolatorMultiEnum and others.
-#[cfg(feature = "serde")]
-macro_rules! enum_serialize_nested_impl {
-    ($enum_type:ident) => {
-        impl<D> SerializeNested for $enum_type<D>
-        where
-            D: Data + RawDataClone + Clone,
-            D::Elem: PartialEq + Debug + Serialize,
-        {
-            #[doc = "`#[serde(untagged)]`, so each variant serializes as its inner value."]
-            fn serialize_nested<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: Serializer,
-            {
-                match self {
-                    Self::Interp0D(interp) => Nested(interp).serialize(serializer),
-                    Self::Interp1D(interp) => Nested(interp).serialize(serializer),
-                    Self::Interp2D(interp) => Nested(interp).serialize(serializer),
-                    Self::Interp3D(interp) => Nested(interp).serialize(serializer),
-                    Self::InterpND(interp) => Nested(interp).serialize(serializer),
-                }
             }
         }
     };
@@ -452,9 +341,98 @@ pub type InterpolatorEnumViewed<T> = InterpolatorEnum<ViewRepr<T>>;
 pub type InterpolatorEnumOwned<T> = InterpolatorEnum<OwnedRepr<T>>;
 
 #[cfg(feature = "serde")]
-enum_serialize_nested_impl!(InterpolatorEnum);
+impl<D> SerializeNested for InterpolatorEnum<D>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: PartialEq + Debug + Serialize,
+{
+    /// `#[serde(untagged)]`, so each variant serializes as its inner value.
+    fn serialize_nested<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Interp0D(interp) => Nested(interp).serialize(serializer),
+            Self::Interp1D(interp) => Nested(interp).serialize(serializer),
+            Self::Interp2D(interp) => Nested(interp).serialize(serializer),
+            Self::Interp3D(interp) => Nested(interp).serialize(serializer),
+            Self::InterpND(interp) => Nested(interp).serialize(serializer),
+        }
+    }
+}
 
-enum_partialeq_impl!(InterpolatorEnum);
+impl<D> PartialEq for InterpolatorEnum<D>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: PartialEq + Debug,
+    ArrayBase<D, Ix1>: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Interp0D(l), Self::Interp0D(r)) => l == r,
+            (Self::Interp1D(l), Self::Interp1D(r)) => l == r,
+            (Self::Interp2D(l), Self::Interp2D(r)) => l == r,
+            (Self::Interp3D(l), Self::Interp3D(r)) => l == r,
+            (Self::InterpND(l), Self::InterpND(r)) => l == r,
+            _ => false,
+        }
+    }
+}
+
+impl<D> From<Interp0D<D::Elem>> for InterpolatorEnum<D>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Float + Debug,
+{
+    #[inline]
+    fn from(interpolator: Interp0D<D::Elem>) -> Self {
+        InterpolatorEnum::Interp0D(interpolator)
+    }
+}
+
+impl<D> From<Interp1D<D, Strategy1DEnum>> for InterpolatorEnum<D>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Float + Debug,
+{
+    #[inline]
+    fn from(interpolator: Interp1D<D, Strategy1DEnum>) -> Self {
+        InterpolatorEnum::Interp1D(interpolator)
+    }
+}
+
+impl<D> From<Interp2D<D, Strategy2DEnum>> for InterpolatorEnum<D>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Float + Debug,
+{
+    #[inline]
+    fn from(interpolator: Interp2D<D, Strategy2DEnum>) -> Self {
+        InterpolatorEnum::Interp2D(interpolator)
+    }
+}
+
+impl<D> From<Interp3D<D, Strategy3DEnum>> for InterpolatorEnum<D>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Float + Debug,
+{
+    #[inline]
+    fn from(interpolator: Interp3D<D, Strategy3DEnum>) -> Self {
+        InterpolatorEnum::Interp3D(interpolator)
+    }
+}
+
+impl<D> From<InterpND<D, StrategyNDEnum>> for InterpolatorEnum<D>
+where
+    D: Data + RawDataClone + Clone,
+    D::Elem: Float + Debug,
+{
+    #[inline]
+    fn from(interpolator: InterpND<D, StrategyNDEnum>) -> Self {
+        InterpolatorEnum::InterpND(interpolator)
+    }
+}
 
 impl<D> InterpolatorEnum<D>
 where
@@ -557,8 +535,6 @@ where
     slice_to_array_forward!(batch_interpolate);
     slice_to_array_forward!(batch_interpolate_fast);
 }
-
-from_impls!();
 
 mod tests {
     #[allow(unused_imports)]

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -68,6 +68,169 @@ macro_rules! from_impls {
     };
 }
 
+/// Generates simple forwarding methods where Interp0D returns Ok(()), others forward to variant.
+macro_rules! enum_method_forward {
+    (validate_strategy) => {
+        #[doc = "Re-run the current variant's strategy `validate` against its data.\n\n`new_0d`/`new_1d`/etc. already call this internally, so this is only needed\nafter mutating a variant's `data`/`strategy` fields directly (via `match`)."]
+        pub fn validate_strategy(&self) -> Result<(), ValidateError> {
+            match self {
+                InterpolatorEnum::Interp0D(_) => Ok(()),
+                InterpolatorEnum::Interp1D(interp) => interp.validate_strategy(),
+                InterpolatorEnum::Interp2D(interp) => interp.validate_strategy(),
+                InterpolatorEnum::Interp3D(interp) => interp.validate_strategy(),
+                InterpolatorEnum::InterpND(interp) => interp.validate_strategy(),
+            }
+        }
+    };
+    (check_extrapolate) => {
+        #[doc = "Check applicability of the current variant's strategy, data, and extrapolate setting."]
+        pub fn check_extrapolate(
+            &self,
+            extrapolate: &Extrapolate<D::Elem>,
+        ) -> Result<(), ValidateError> {
+            match self {
+                InterpolatorEnum::Interp0D(_) => Ok(()),
+                InterpolatorEnum::Interp1D(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnum::Interp2D(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnum::Interp3D(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnum::InterpND(interp) => interp.check_extrapolate(extrapolate),
+            }
+        }
+    };
+    (mut init_strategy) => {
+        #[doc = "Re-run the current variant's strategy `init` against its data.\n\n`new_0d`/`new_1d`/etc. already call this internally, so this is only needed\nafter bypassing them: mutating a variant's `data`/`strategy` fields directly\n(via `match`), or deserializing an interpolator with a stateful custom strategy\n(`Deserialize` does not call `init`)."]
+        pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
+            match self {
+                InterpolatorEnum::Interp0D(_) => Ok(()),
+                InterpolatorEnum::Interp1D(interp) => interp.init_strategy(),
+                InterpolatorEnum::Interp2D(interp) => interp.init_strategy(),
+                InterpolatorEnum::Interp3D(interp) => interp.init_strategy(),
+                InterpolatorEnum::InterpND(interp) => interp.init_strategy(),
+            }
+        }
+    };
+}
+
+/// Generates enum-wrapping forwarding methods (view, into_owned).
+macro_rules! enum_method_wrap {
+    (view) => {
+        #[doc = "Return an interpolator with viewed data."]
+        pub fn view(&self) -> InterpolatorEnumViewed<&D::Elem> {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => InterpolatorEnum::Interp0D(interp.clone()),
+                InterpolatorEnum::Interp1D(interp) => InterpolatorEnum::Interp1D(interp.view()),
+                InterpolatorEnum::Interp2D(interp) => InterpolatorEnum::Interp2D(interp.view()),
+                InterpolatorEnum::Interp3D(interp) => InterpolatorEnum::Interp3D(interp.view()),
+                InterpolatorEnum::InterpND(interp) => InterpolatorEnum::InterpND(interp.view()),
+            }
+        }
+    };
+    (into_owned) => {
+        #[doc = "Turn the interpolator into an [`InterpolatorEnumOwned`], cloning the array elements if necessary."]
+        pub fn into_owned(self) -> InterpolatorEnumOwned<D::Elem>
+        where
+            D::Elem: Clone,
+        {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => InterpolatorEnum::Interp0D(interp.clone()),
+                InterpolatorEnum::Interp1D(interp) => InterpolatorEnum::Interp1D(interp.into_owned()),
+                InterpolatorEnum::Interp2D(interp) => InterpolatorEnum::Interp2D(interp.into_owned()),
+                InterpolatorEnum::Interp3D(interp) => InterpolatorEnum::Interp3D(interp.into_owned()),
+                InterpolatorEnum::InterpND(interp) => InterpolatorEnum::InterpND(interp.into_owned()),
+            }
+        }
+    };
+}
+
+/// Generates trait forwarding methods for Interpolator impl.
+macro_rules! enum_trait_method {
+    (ndim) => {
+        #[inline]
+        fn ndim(&self) -> usize {
+            match self {
+                InterpolatorEnum::Interp0D(_) => 0,
+                InterpolatorEnum::Interp1D(_) => 1,
+                InterpolatorEnum::Interp2D(_) => 2,
+                InterpolatorEnum::Interp3D(_) => 3,
+                InterpolatorEnum::InterpND(interp) => interp.ndim(),
+            }
+        }
+    };
+    ($method:ident) => {
+        fn $method(&self) -> Result<(), ValidateError> {
+            match self {
+                Self::Interp0D(_) => Ok(()),
+                Self::Interp1D(i) => i.$method(),
+                Self::Interp2D(i) => i.$method(),
+                Self::Interp3D(i) => i.$method(),
+                Self::InterpND(i) => i.$method(),
+            }
+        }
+    };
+    (mut $method:ident, $param:ident: $param_ty:ty) => {
+        fn $method(&mut self, $param: $param_ty) -> Result<(), ValidateError> {
+            match self {
+                Self::Interp0D(_) => Ok(()),
+                Self::Interp1D(i) => i.$method($param),
+                Self::Interp2D(i) => i.$method($param),
+                Self::Interp3D(i) => i.$method($param),
+                Self::InterpND(i) => i.$method($param),
+            }
+        }
+    };
+}
+
+/// Generates full PartialEq impl for enum variants. Takes enum type as argument for reusability
+/// with InterpolatorMultiEnum and others.
+macro_rules! enum_partialeq_impl {
+    ($enum_type:ident) => {
+        impl<D> PartialEq for $enum_type<D>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: PartialEq + Debug,
+            ArrayBase<D, Ix1>: PartialEq,
+        {
+            fn eq(&self, other: &Self) -> bool {
+                match (self, other) {
+                    (Self::Interp0D(l), Self::Interp0D(r)) => l == r,
+                    (Self::Interp1D(l), Self::Interp1D(r)) => l == r,
+                    (Self::Interp2D(l), Self::Interp2D(r)) => l == r,
+                    (Self::Interp3D(l), Self::Interp3D(r)) => l == r,
+                    (Self::InterpND(l), Self::InterpND(r)) => l == r,
+                    _ => false,
+                }
+            }
+        }
+    };
+}
+
+/// Generates full SerializeNested impl for enum variants. Takes enum type as argument for reusability
+/// with InterpolatorMultiEnum and others.
+#[cfg(feature = "serde")]
+macro_rules! enum_serialize_nested_impl {
+    ($enum_type:ident) => {
+        impl<D> SerializeNested for $enum_type<D>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: PartialEq + Debug + Serialize,
+        {
+            #[doc = "`#[serde(untagged)]`, so each variant serializes as its inner value."]
+            fn serialize_nested<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                match self {
+                    Self::Interp0D(interp) => Nested(interp).serialize(serializer),
+                    Self::Interp1D(interp) => Nested(interp).serialize(serializer),
+                    Self::Interp2D(interp) => Nested(interp).serialize(serializer),
+                    Self::Interp3D(interp) => Nested(interp).serialize(serializer),
+                    Self::InterpND(interp) => Nested(interp).serialize(serializer),
+                }
+            }
+        }
+    };
+}
+
 /// Generates trait impl methods with slice-to-array conversion and doc comments built in.
 macro_rules! slice_to_array_forward {
     (interpolate) => {
@@ -289,43 +452,9 @@ pub type InterpolatorEnumViewed<T> = InterpolatorEnum<ViewRepr<T>>;
 pub type InterpolatorEnumOwned<T> = InterpolatorEnum<OwnedRepr<T>>;
 
 #[cfg(feature = "serde")]
-impl<D> SerializeNested for InterpolatorEnum<D>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug + Serialize,
-{
-    /// `#[serde(untagged)]`, so each variant serializes as its inner value.
-    fn serialize_nested<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            Self::Interp0D(interp) => Nested(interp).serialize(serializer),
-            Self::Interp1D(interp) => Nested(interp).serialize(serializer),
-            Self::Interp2D(interp) => Nested(interp).serialize(serializer),
-            Self::Interp3D(interp) => Nested(interp).serialize(serializer),
-            Self::InterpND(interp) => Nested(interp).serialize(serializer),
-        }
-    }
-}
+enum_serialize_nested_impl!(InterpolatorEnum);
 
-impl<D> PartialEq for InterpolatorEnum<D>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-    ArrayBase<D, Ix1>: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Interp0D(l), Self::Interp0D(r)) => l == r,
-            (Self::Interp1D(l), Self::Interp1D(r)) => l == r,
-            (Self::Interp2D(l), Self::Interp2D(r)) => l == r,
-            (Self::Interp3D(l), Self::Interp3D(r)) => l == r,
-            (Self::InterpND(l), Self::InterpND(r)) => l == r,
-            _ => false,
-        }
-    }
-}
+enum_partialeq_impl!(InterpolatorEnum);
 
 impl<D> InterpolatorEnum<D>
 where
@@ -408,75 +537,11 @@ where
         )?))
     }
 
-    /// Return an interpolator with viewed data.
-    pub fn view(&self) -> InterpolatorEnumViewed<&D::Elem> {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => InterpolatorEnum::Interp0D(interp.clone()),
-            InterpolatorEnum::Interp1D(interp) => InterpolatorEnum::Interp1D(interp.view()),
-            InterpolatorEnum::Interp2D(interp) => InterpolatorEnum::Interp2D(interp.view()),
-            InterpolatorEnum::Interp3D(interp) => InterpolatorEnum::Interp3D(interp.view()),
-            InterpolatorEnum::InterpND(interp) => InterpolatorEnum::InterpND(interp.view()),
-        }
-    }
-
-    /// Turn the interpolator into an [`InterpolatorEnumOwned`], cloning the array elements if necessary.
-    pub fn into_owned(self) -> InterpolatorEnumOwned<D::Elem>
-    where
-        D::Elem: Clone,
-    {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => InterpolatorEnum::Interp0D(interp.clone()),
-            InterpolatorEnum::Interp1D(interp) => InterpolatorEnum::Interp1D(interp.into_owned()),
-            InterpolatorEnum::Interp2D(interp) => InterpolatorEnum::Interp2D(interp.into_owned()),
-            InterpolatorEnum::Interp3D(interp) => InterpolatorEnum::Interp3D(interp.into_owned()),
-            InterpolatorEnum::InterpND(interp) => InterpolatorEnum::InterpND(interp.into_owned()),
-        }
-    }
-
-    /// Check applicability of the current variant's strategy, data, and extrapolate
-    /// setting.
-    pub fn check_extrapolate(
-        &self,
-        extrapolate: &Extrapolate<D::Elem>,
-    ) -> Result<(), ValidateError> {
-        match self {
-            InterpolatorEnum::Interp0D(_) => Ok(()),
-            InterpolatorEnum::Interp1D(interp) => interp.check_extrapolate(extrapolate),
-            InterpolatorEnum::Interp2D(interp) => interp.check_extrapolate(extrapolate),
-            InterpolatorEnum::Interp3D(interp) => interp.check_extrapolate(extrapolate),
-            InterpolatorEnum::InterpND(interp) => interp.check_extrapolate(extrapolate),
-        }
-    }
-
-    /// Re-run the current variant's strategy `validate` against its data.
-    ///
-    /// `new_0d`/`new_1d`/etc. already call this internally, so this is only needed
-    /// after mutating a variant's `data`/`strategy` fields directly (via `match`).
-    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
-        match self {
-            InterpolatorEnum::Interp0D(_) => Ok(()),
-            InterpolatorEnum::Interp1D(interp) => interp.validate_strategy(),
-            InterpolatorEnum::Interp2D(interp) => interp.validate_strategy(),
-            InterpolatorEnum::Interp3D(interp) => interp.validate_strategy(),
-            InterpolatorEnum::InterpND(interp) => interp.validate_strategy(),
-        }
-    }
-
-    /// Re-run the current variant's strategy `init` against its data.
-    ///
-    /// `new_0d`/`new_1d`/etc. already call this internally, so this is only needed
-    /// after bypassing them: mutating a variant's `data`/`strategy` fields directly
-    /// (via `match`), or deserializing an interpolator with a stateful custom strategy
-    /// (`Deserialize` does not call `init`).
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        match self {
-            InterpolatorEnum::Interp0D(_) => Ok(()),
-            InterpolatorEnum::Interp1D(interp) => interp.init_strategy(),
-            InterpolatorEnum::Interp2D(interp) => interp.init_strategy(),
-            InterpolatorEnum::Interp3D(interp) => interp.init_strategy(),
-            InterpolatorEnum::InterpND(interp) => interp.init_strategy(),
-        }
-    }
+    enum_method_wrap!(view);
+    enum_method_wrap!(into_owned);
+    enum_method_forward!(check_extrapolate);
+    enum_method_forward!(validate_strategy);
+    enum_method_forward!(mut init_strategy);
 }
 
 impl<D> Interpolator<D::Elem> for InterpolatorEnum<D>
@@ -484,39 +549,10 @@ where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Euclid + Debug,
 {
-    #[inline]
-    fn ndim(&self) -> usize {
-        match self {
-            InterpolatorEnum::Interp0D(_) => 0,
-            InterpolatorEnum::Interp1D(_) => 1,
-            InterpolatorEnum::Interp2D(_) => 2,
-            InterpolatorEnum::Interp3D(_) => 3,
-            InterpolatorEnum::InterpND(interp) => interp.ndim(),
-        }
-    }
-
-    fn validate(&self) -> Result<(), ValidateError> {
-        match self {
-            Self::Interp0D(_) => Ok(()),
-            Self::Interp1D(i) => i.validate(),
-            Self::Interp2D(i) => i.validate(),
-            Self::Interp3D(i) => i.validate(),
-            Self::InterpND(i) => i.validate(),
-        }
-    }
-
+    enum_trait_method!(ndim);
+    enum_trait_method!(validate);
+    enum_trait_method!(mut set_extrapolate, extrapolate: Extrapolate<D::Elem>);
     slice_to_array_forward!(interpolate);
-
-    fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
-        match self {
-            Self::Interp0D(_) => Ok(()),
-            Self::Interp1D(i) => i.set_extrapolate(extrapolate),
-            Self::Interp2D(i) => i.set_extrapolate(extrapolate),
-            Self::Interp3D(i) => i.set_extrapolate(extrapolate),
-            Self::InterpND(i) => i.set_extrapolate(extrapolate),
-        }
-    }
-
     slice_to_array_forward!(interpolate_fast);
     slice_to_array_forward!(batch_interpolate);
     slice_to_array_forward!(batch_interpolate_fast);

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -8,6 +8,203 @@ use super::*;
 
 use strategy::enums::*;
 
+/// Generates all five `From` impls for InterpolatorEnum variants.
+macro_rules! from_impls {
+    () => {
+        impl<D> From<Interp0D<D::Elem>> for InterpolatorEnum<D>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Float + Debug,
+        {
+            #[inline]
+            fn from(interpolator: Interp0D<D::Elem>) -> Self {
+                InterpolatorEnum::Interp0D(interpolator)
+            }
+        }
+
+        impl<D> From<Interp1D<D, Strategy1DEnum>> for InterpolatorEnum<D>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Float + Debug,
+        {
+            #[inline]
+            fn from(interpolator: Interp1D<D, Strategy1DEnum>) -> Self {
+                InterpolatorEnum::Interp1D(interpolator)
+            }
+        }
+
+        impl<D> From<Interp2D<D, Strategy2DEnum>> for InterpolatorEnum<D>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Float + Debug,
+        {
+            #[inline]
+            fn from(interpolator: Interp2D<D, Strategy2DEnum>) -> Self {
+                InterpolatorEnum::Interp2D(interpolator)
+            }
+        }
+
+        impl<D> From<Interp3D<D, Strategy3DEnum>> for InterpolatorEnum<D>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Float + Debug,
+        {
+            #[inline]
+            fn from(interpolator: Interp3D<D, Strategy3DEnum>) -> Self {
+                InterpolatorEnum::Interp3D(interpolator)
+            }
+        }
+
+        impl<D> From<InterpND<D, StrategyNDEnum>> for InterpolatorEnum<D>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Float + Debug,
+        {
+            #[inline]
+            fn from(interpolator: InterpND<D, StrategyNDEnum>) -> Self {
+                InterpolatorEnum::InterpND(interpolator)
+            }
+        }
+    };
+}
+
+/// Generates trait impl methods with slice-to-array conversion and doc comments built in.
+macro_rules! slice_to_array_forward {
+    (interpolate) => {
+        fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => interp.interpolate(point),
+                InterpolatorEnum::Interp1D(interp) => interp.interpolate(
+                    point
+                        .try_into()
+                        .map_err(|_| InterpolateError::PointLength(1))?,
+                ),
+                InterpolatorEnum::Interp2D(interp) => interp.interpolate(
+                    point
+                        .try_into()
+                        .map_err(|_| InterpolateError::PointLength(2))?,
+                ),
+                InterpolatorEnum::Interp3D(interp) => interp.interpolate(
+                    point
+                        .try_into()
+                        .map_err(|_| InterpolateError::PointLength(3))?,
+                ),
+                InterpolatorEnum::InterpND(interp) => interp.interpolate(point),
+            }
+        }
+    };
+    (interpolate_fast) => {
+        fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => interp.0,
+                InterpolatorEnum::Interp1D(interp) => interp.interpolate_fast(
+                    point
+                        .try_into()
+                        .expect("interpolate_fast: point length mismatch"),
+                ),
+                InterpolatorEnum::Interp2D(interp) => interp.interpolate_fast(
+                    point
+                        .try_into()
+                        .expect("interpolate_fast: point length mismatch"),
+                ),
+                InterpolatorEnum::Interp3D(interp) => interp.interpolate_fast(
+                    point
+                        .try_into()
+                        .expect("interpolate_fast: point length mismatch"),
+                ),
+                InterpolatorEnum::InterpND(interp) => interp.interpolate_fast(point),
+            }
+        }
+    };
+    (batch_interpolate) => {
+        fn batch_interpolate(
+            &self,
+            points: &[&[D::Elem]],
+        ) -> Result<Vec<D::Elem>, InterpolateError> {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => {
+                    Interpolator::batch_interpolate(interp, points)
+                }
+                InterpolatorEnum::Interp1D(interp) => {
+                    let points: Vec<[D::Elem; 1]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .map_err(|_| InterpolateError::PointLength(1))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    interp.batch_interpolate(&points)
+                }
+                InterpolatorEnum::Interp2D(interp) => {
+                    let points: Vec<[D::Elem; 2]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .map_err(|_| InterpolateError::PointLength(2))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    interp.batch_interpolate(&points)
+                }
+                InterpolatorEnum::Interp3D(interp) => {
+                    let points: Vec<[D::Elem; 3]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .map_err(|_| InterpolateError::PointLength(3))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    interp.batch_interpolate(&points)
+                }
+                InterpolatorEnum::InterpND(interp) => interp.batch_interpolate(points),
+            }
+        }
+    };
+    (batch_interpolate_fast) => {
+        fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => vec![interp.0; points.len()],
+                InterpolatorEnum::Interp1D(interp) => {
+                    let points: Vec<[D::Elem; 1]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .expect("batch_interpolate_fast: point length mismatch")
+                        })
+                        .collect();
+                    interp.batch_interpolate_fast(&points)
+                }
+                InterpolatorEnum::Interp2D(interp) => {
+                    let points: Vec<[D::Elem; 2]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .expect("batch_interpolate_fast: point length mismatch")
+                        })
+                        .collect();
+                    interp.batch_interpolate_fast(&points)
+                }
+                InterpolatorEnum::Interp3D(interp) => {
+                    let points: Vec<[D::Elem; 3]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .expect("batch_interpolate_fast: point length mismatch")
+                        })
+                        .collect();
+                    interp.batch_interpolate_fast(&points)
+                }
+                InterpolatorEnum::InterpND(interp) => interp.batch_interpolate_fast(points),
+            }
+        }
+    };
+}
+
 /// This is an alternative to using a `Box<dyn Interpolator<_>>` with a few key differences:
 /// - Better runtime performance
 /// - Compatible with serde
@@ -298,209 +495,34 @@ where
         }
     }
 
-    #[inline]
     fn validate(&self) -> Result<(), ValidateError> {
         match self {
-            InterpolatorEnum::Interp0D(_) => Ok(()),
-            InterpolatorEnum::Interp1D(interp) => interp.validate(),
-            InterpolatorEnum::Interp2D(interp) => interp.validate(),
-            InterpolatorEnum::Interp3D(interp) => interp.validate(),
-            InterpolatorEnum::InterpND(interp) => interp.validate(),
+            Self::Interp0D(_) => Ok(()),
+            Self::Interp1D(i) => i.validate(),
+            Self::Interp2D(i) => i.validate(),
+            Self::Interp3D(i) => i.validate(),
+            Self::InterpND(i) => i.validate(),
         }
     }
 
-    #[inline]
-    fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => interp.interpolate(point),
-            InterpolatorEnum::Interp1D(interp) => interp.interpolate(
-                point
-                    .try_into()
-                    .map_err(|_| InterpolateError::PointLength(1))?,
-            ),
-            InterpolatorEnum::Interp2D(interp) => interp.interpolate(
-                point
-                    .try_into()
-                    .map_err(|_| InterpolateError::PointLength(2))?,
-            ),
-            InterpolatorEnum::Interp3D(interp) => interp.interpolate(
-                point
-                    .try_into()
-                    .map_err(|_| InterpolateError::PointLength(3))?,
-            ),
-            InterpolatorEnum::InterpND(interp) => interp.interpolate(point),
-        }
-    }
+    slice_to_array_forward!(interpolate);
 
-    #[inline]
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
         match self {
-            InterpolatorEnum::Interp0D(_) => Ok(()),
-            InterpolatorEnum::Interp1D(interp) => interp.set_extrapolate(extrapolate),
-            InterpolatorEnum::Interp2D(interp) => interp.set_extrapolate(extrapolate),
-            InterpolatorEnum::Interp3D(interp) => interp.set_extrapolate(extrapolate),
-            InterpolatorEnum::InterpND(interp) => interp.set_extrapolate(extrapolate),
+            Self::Interp0D(_) => Ok(()),
+            Self::Interp1D(i) => i.set_extrapolate(extrapolate),
+            Self::Interp2D(i) => i.set_extrapolate(extrapolate),
+            Self::Interp3D(i) => i.set_extrapolate(extrapolate),
+            Self::InterpND(i) => i.set_extrapolate(extrapolate),
         }
     }
 
-    #[inline]
-    fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => interp.0,
-            InterpolatorEnum::Interp1D(interp) => interp.interpolate_fast(
-                point
-                    .try_into()
-                    .expect("interpolate_fast: point length mismatch"),
-            ),
-            InterpolatorEnum::Interp2D(interp) => interp.interpolate_fast(
-                point
-                    .try_into()
-                    .expect("interpolate_fast: point length mismatch"),
-            ),
-            InterpolatorEnum::Interp3D(interp) => interp.interpolate_fast(
-                point
-                    .try_into()
-                    .expect("interpolate_fast: point length mismatch"),
-            ),
-            InterpolatorEnum::InterpND(interp) => interp.interpolate_fast(point),
-        }
-    }
-
-    fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => Interpolator::batch_interpolate(interp, points),
-            InterpolatorEnum::Interp1D(interp) => {
-                let points: Vec<[D::Elem; 1]> = points
-                    .iter()
-                    .map(|&point| {
-                        point
-                            .try_into()
-                            .map_err(|_| InterpolateError::PointLength(1))
-                    })
-                    .collect::<Result<_, _>>()?;
-                interp.batch_interpolate(&points)
-            }
-            InterpolatorEnum::Interp2D(interp) => {
-                let points: Vec<[D::Elem; 2]> = points
-                    .iter()
-                    .map(|&point| {
-                        point
-                            .try_into()
-                            .map_err(|_| InterpolateError::PointLength(2))
-                    })
-                    .collect::<Result<_, _>>()?;
-                interp.batch_interpolate(&points)
-            }
-            InterpolatorEnum::Interp3D(interp) => {
-                let points: Vec<[D::Elem; 3]> = points
-                    .iter()
-                    .map(|&point| {
-                        point
-                            .try_into()
-                            .map_err(|_| InterpolateError::PointLength(3))
-                    })
-                    .collect::<Result<_, _>>()?;
-                interp.batch_interpolate(&points)
-            }
-            InterpolatorEnum::InterpND(interp) => interp.batch_interpolate(points),
-        }
-    }
-
-    fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
-        match self {
-            InterpolatorEnum::Interp0D(interp) => vec![interp.0; points.len()],
-            InterpolatorEnum::Interp1D(interp) => {
-                let points: Vec<[D::Elem; 1]> = points
-                    .iter()
-                    .map(|&point| {
-                        point
-                            .try_into()
-                            .expect("batch_interpolate_fast: point length mismatch")
-                    })
-                    .collect();
-                interp.batch_interpolate_fast(&points)
-            }
-            InterpolatorEnum::Interp2D(interp) => {
-                let points: Vec<[D::Elem; 2]> = points
-                    .iter()
-                    .map(|&point| {
-                        point
-                            .try_into()
-                            .expect("batch_interpolate_fast: point length mismatch")
-                    })
-                    .collect();
-                interp.batch_interpolate_fast(&points)
-            }
-            InterpolatorEnum::Interp3D(interp) => {
-                let points: Vec<[D::Elem; 3]> = points
-                    .iter()
-                    .map(|&point| {
-                        point
-                            .try_into()
-                            .expect("batch_interpolate_fast: point length mismatch")
-                    })
-                    .collect();
-                interp.batch_interpolate_fast(&points)
-            }
-            InterpolatorEnum::InterpND(interp) => interp.batch_interpolate_fast(points),
-        }
-    }
+    slice_to_array_forward!(interpolate_fast);
+    slice_to_array_forward!(batch_interpolate);
+    slice_to_array_forward!(batch_interpolate_fast);
 }
 
-impl<D> From<Interp0D<D::Elem>> for InterpolatorEnum<D>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn from(interpolator: Interp0D<D::Elem>) -> Self {
-        InterpolatorEnum::Interp0D(interpolator)
-    }
-}
-
-impl<D> From<Interp1D<D, Strategy1DEnum>> for InterpolatorEnum<D>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn from(interpolator: Interp1D<D, Strategy1DEnum>) -> Self {
-        InterpolatorEnum::Interp1D(interpolator)
-    }
-}
-
-impl<D> From<Interp2D<D, Strategy2DEnum>> for InterpolatorEnum<D>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn from(interpolator: Interp2D<D, Strategy2DEnum>) -> Self {
-        InterpolatorEnum::Interp2D(interpolator)
-    }
-}
-
-impl<D> From<Interp3D<D, Strategy3DEnum>> for InterpolatorEnum<D>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn from(interpolator: Interp3D<D, Strategy3DEnum>) -> Self {
-        InterpolatorEnum::Interp3D(interpolator)
-    }
-}
-
-impl<D> From<InterpND<D, StrategyNDEnum>> for InterpolatorEnum<D>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn from(interpolator: InterpND<D, StrategyNDEnum>) -> Self {
-        InterpolatorEnum::InterpND(interpolator)
-    }
-}
+from_impls!();
 
 mod tests {
     #[allow(unused_imports)]

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -657,33 +657,31 @@ pub(crate) use serialize_nested_impl;
 /// Generates all trait impls for an interpolator: `PartialEq`, `SerializeNested`,
 /// `extrapolate_impl`, `Interpolator`, `set_strategy` for `Box<dyn Strategy>`,
 /// `set_strategy` for the strategy enum, and `DynInterpolator`.
-macro_rules! interpolator_trait_impls {
+macro_rules! interp_trait_impls {
     ($InterpType:ident, $InterpTypeOwned:ident, $InterpData:ident, $Strategy:ident, $StrategyEnum:path, $N:expr) => {
         partialeq_impl!($InterpType, $InterpData, $Strategy);
-        #[cfg(feature = "serde")]
-        serialize_nested_impl!($InterpType, $InterpData, $Strategy);
-
         extrapolate_impl!($InterpType, $Strategy);
         interpolator_trait_impl!($InterpType, $Strategy, $N);
         set_strategy_box_impl!($InterpType, $Strategy);
         set_strategy_enum_impl!($InterpType, $StrategyEnum);
         dyn_interpolator_impl!($InterpTypeOwned, $Strategy);
+        #[cfg(feature = "serde")]
+        serialize_nested_impl!($InterpType, $InterpData, $Strategy);
     };
 }
-pub(crate) use interpolator_trait_impls;
+pub(crate) use interp_trait_impls;
 
 /// Generates inherent methods for an interpolator: strategy accessors, fast paths,
 /// data access (view/into_owned), and batch interpolation. Called inside the
 /// `impl<D, S>` block, leaving `pub fn new()` to be hand-written.
-macro_rules! interpolator_inherent_methods {
+macro_rules! interp_inherent_methods {
     ($InterpType:ident, $Strategy:ident, $Viewed:ty, $Owned:ty) => {
-        strategy_accessors_impl!($Strategy);
-        interpolate_fast_impl!();
-        batch_interpolate_fast_impl!();
-
-        view_into_owned_impl!($InterpType, $Strategy, $Viewed, $Owned);
         sized_interpolate_impl!();
+        interpolate_fast_impl!();
         batch_interpolate_impl!();
+        batch_interpolate_fast_impl!();
+        strategy_accessors_impl!($Strategy);
+        view_into_owned_impl!($InterpType, $Strategy, $Viewed, $Owned);
     };
 }
-pub(crate) use interpolator_inherent_methods;
+pub(crate) use interp_inherent_methods;

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -234,61 +234,6 @@ where
         .any(|(axis, coord)| !(axis.first().unwrap()..=axis.last().unwrap()).contains(&coord))
 }
 
-/// Generates the [`Interpolator::interpolate`]/[`Interpolator::interpolate_fast`]/
-/// [`Interpolator::batch_interpolate`]/[`Interpolator::batch_interpolate_fast`]
-/// bodies shared by `Interp1D`/`2D`/`3D`'s trait impls. The trait's slice-based
-/// signature can't fix the point length at compile time the way the type's own
-/// inherent `[D::Elem; N]`-based method can, so each body converts the incoming
-/// slice(s) to that fixed size first, via `?` for the two `Result`-returning
-/// methods, via `.expect(...)` for their `_fast` counterparts, then calls straight
-/// through to the inherent method, which owns all bounds/extrapolation handling from
-/// there. `InterpND` has no fixed `N`, so it can't use this and implements all four
-/// methods by hand instead.
-macro_rules! sized_interpolate_impl {
-    () => {
-        fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-            let point: &[D::Elem; N] = point
-                .try_into()
-                .map_err(|_| InterpolateError::PointLength(N))?;
-            self.interpolate(point)
-        }
-
-        fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
-            let point: &[D::Elem; N] = point
-                .try_into()
-                .expect("interpolate_fast: point length mismatch");
-            self.interpolate_fast(point)
-        }
-
-        fn batch_interpolate(
-            &self,
-            points: &[&[D::Elem]],
-        ) -> Result<Vec<D::Elem>, InterpolateError> {
-            let points: Vec<[D::Elem; N]> = points
-                .iter()
-                .map(|&point| {
-                    <&[D::Elem; N]>::try_from(point)
-                        .map(|arr| *arr)
-                        .map_err(|_| InterpolateError::PointLength(N))
-                })
-                .collect::<Result<_, _>>()?;
-            self.batch_interpolate(&points)
-        }
-
-        fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
-            let points: Vec<[D::Elem; N]> = points
-                .iter()
-                .map(|&point| {
-                    *<&[D::Elem; N]>::try_from(point)
-                        .expect("batch_interpolate_fast: point length mismatch")
-                })
-                .collect();
-            self.batch_interpolate_fast(&points)
-        }
-    };
-}
-pub(crate) use sized_interpolate_impl;
-
 /// Generates the inherent `batch_interpolate_fast` shared by `Interp1D`/`2D`/`3D`:
 /// forwards straight to the strategy, same as the existing hand-written
 /// `interpolate_fast` does.
@@ -596,5 +541,82 @@ macro_rules! serialize_nested_impl {
         }
     };
 }
+/// Generates the entire [`Interpolator<T>`] trait impl shared by `Interp1D`/`2D`/`3D`/`ND`.
+/// Parameterized by interpolator type, strategy trait, and the ndim return value
+/// (a literal for sized types, `self.data.ndim()` for ND). Includes slice-to-array
+/// conversion logic for `interpolate`/`interpolate_fast`/`batch_interpolate`/`batch_interpolate_fast`.
+macro_rules! interpolator_trait_impl {
+    ($InterpType:ident, $Strategy:ident, $NdimExpr:expr) => {
+        impl<D, S> Interpolator<D::Elem> for $InterpType<D, S>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
+            S: $Strategy<D> + Clone,
+        {
+            #[inline]
+            fn ndim(&self) -> usize {
+                $NdimExpr
+            }
+
+            fn validate(&self) -> Result<(), ValidateError> {
+                self.check_extrapolate(&self.extrapolate)?;
+                self.data.validate()?;
+                self.validate_strategy()?;
+                Ok(())
+            }
+
+            fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
+                let point: &[D::Elem; N] = point
+                    .try_into()
+                    .map_err(|_| InterpolateError::PointLength(N))?;
+                self.interpolate(point)
+            }
+
+            fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
+                let point: &[D::Elem; N] = point
+                    .try_into()
+                    .expect("interpolate_fast: point length mismatch");
+                self.interpolate_fast(point)
+            }
+
+            fn batch_interpolate(
+                &self,
+                points: &[&[D::Elem]],
+            ) -> Result<Vec<D::Elem>, InterpolateError> {
+                let points: Vec<[D::Elem; N]> = points
+                    .iter()
+                    .map(|&point| {
+                        <&[D::Elem; N]>::try_from(point)
+                            .map(|arr| *arr)
+                            .map_err(|_| InterpolateError::PointLength(N))
+                    })
+                    .collect::<Result<_, _>>()?;
+                self.batch_interpolate(&points)
+            }
+
+            fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
+                let points: Vec<[D::Elem; N]> = points
+                    .iter()
+                    .map(|&point| {
+                        *<&[D::Elem; N]>::try_from(point)
+                            .expect("batch_interpolate_fast: point length mismatch")
+                    })
+                    .collect();
+                self.batch_interpolate_fast(&points)
+            }
+
+            fn set_extrapolate(
+                &mut self,
+                extrapolate: Extrapolate<D::Elem>,
+            ) -> Result<(), ValidateError> {
+                self.check_extrapolate(&extrapolate)?;
+                self.extrapolate = extrapolate;
+                Ok(())
+            }
+        }
+    };
+}
+pub(crate) use interpolator_trait_impl;
+
 #[cfg(feature = "serde")]
 pub(crate) use serialize_nested_impl;

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -359,6 +359,144 @@ macro_rules! batch_interpolate_impl {
 }
 pub(crate) use batch_interpolate_impl;
 
+/// Generates the inherent `interpolate` shared by `Interp1D`/`2D`/`3D`: loops over each
+/// dimension, applying the [`Extrapolate`] setting per axis, then falls through to the
+/// strategy once the point is known to be in-bounds (or already resolved via
+/// `Fill`/`Clamp`/`Wrap`). `InterpND` has no fixed `N` to loop `0..N` over at compile
+/// time, so it implements this by hand directly in its [`Interpolator`] impl instead.
+macro_rules! interpolate_impl {
+    () => {
+        /// Interpolate at the supplied point.
+        ///
+        /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
+        /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
+        pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
+            let mut errors = Vec::new();
+            for dim in 0..N {
+                if !(self.data.grid[dim].first().unwrap()..=self.data.grid[dim].last().unwrap())
+                    .contains(&&point[dim])
+                {
+                    match &self.extrapolate {
+                        Extrapolate::Enable => {}
+                        Extrapolate::Fill(value) => return Ok(*value),
+                        Extrapolate::Clamp => {
+                            let clamped_point = std::array::from_fn(|i| {
+                                *clamp(
+                                    &point[i],
+                                    self.data.grid[i].first().unwrap(),
+                                    self.data.grid[i].last().unwrap(),
+                                )
+                            });
+                            return self.strategy.interpolate(&self.data, &clamped_point);
+                        }
+                        Extrapolate::Wrap => {
+                            let wrapped_point = std::array::from_fn(|i| {
+                                wrap(
+                                    point[i],
+                                    *self.data.grid[i].first().unwrap(),
+                                    *self.data.grid[i].last().unwrap(),
+                                )
+                            });
+                            return self.strategy.interpolate(&self.data, &wrapped_point);
+                        }
+                        Extrapolate::Error => {
+                            errors.push(format!(
+                                "\n    point[{dim}] = {:?} is out of bounds for grid[{dim}] = {:?}",
+                                point[dim], self.data.grid[dim],
+                            ));
+                        }
+                    };
+                }
+            }
+            if !errors.is_empty() {
+                return Err(InterpolateError::ExtrapolateError(errors.join("")));
+            }
+            self.strategy.interpolate(&self.data, point)
+        }
+    };
+}
+pub(crate) use interpolate_impl;
+
+/// Generates the `Box<dyn $Strategy<D>>`-backed inherent `set_strategy`, shared by
+/// `Interp1D`/`2D`/`3D`/`ND`.
+macro_rules! set_strategy_box_impl {
+    ($InterpType:ident, $Strategy:ident) => {
+        impl<D> $InterpType<D, Box<dyn $Strategy<D>>>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: PartialEq + Debug,
+        {
+            #[doc = concat!(
+                " Update strategy at runtime, calling [`", stringify!($Strategy), "::init`] on the new strategy\n",
+                " against the current data.\n",
+                "\n",
+                " To swap in a strategy without re-running `init` (e.g. one whose state was\n",
+                " already established elsewhere), assign the `strategy` field directly instead.",
+            )]
+            pub fn set_strategy(
+                &mut self,
+                strategy: Box<dyn $Strategy<D>>,
+            ) -> Result<(), ValidateError> {
+                self.strategy = strategy;
+                self.check_extrapolate(&self.extrapolate)?;
+                self.validate_strategy()?;
+                self.init_strategy()
+            }
+        }
+    };
+}
+pub(crate) use set_strategy_box_impl;
+
+/// Generates the `$StrategyEnum`-backed inherent `set_strategy`, shared by
+/// `Interp1D`/`2D`/`3D`/`ND`.
+macro_rules! set_strategy_enum_impl {
+    ($InterpType:ident, $StrategyEnum:path) => {
+        impl<D> $InterpType<D, $StrategyEnum>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Float + Debug,
+        {
+            #[doc = concat!(
+                " Update strategy at runtime, calling [`", stringify!($StrategyEnum), "::init`] on the new strategy\n",
+                " against the current data.\n",
+                "\n",
+                " To swap in a strategy without re-running `init` (e.g. one whose state was\n",
+                " already established elsewhere), assign the `strategy` field directly instead.",
+            )]
+            pub fn set_strategy(
+                &mut self,
+                strategy: impl Into<$StrategyEnum>,
+            ) -> Result<(), ValidateError> {
+                self.strategy = strategy.into();
+                self.check_extrapolate(&self.extrapolate)?;
+                self.validate_strategy()?;
+                self.init_strategy()
+            }
+        }
+    };
+}
+pub(crate) use set_strategy_enum_impl;
+
+/// Generates the [`DynInterpolator`] impl shared by `Interp1D`/`2D`/`3D`/`ND`'s owned
+/// variants. Bounded on `Float + Euclid` (rather than the `Num + PartialOrd + Euclid +
+/// Copy` the [`Interpolator`] impls use) because that's what [`DynInterpolator`] itself
+/// requires transitively; only owned types implement it, since `as_any` requires
+/// `Self: 'static`.
+macro_rules! dyn_interpolator_impl {
+    ($InterpTypeOwned:ident, $Strategy:ident) => {
+        impl<T, S> DynInterpolator<T> for $InterpTypeOwned<T, S>
+        where
+            T: Float + Euclid + Debug + Send + Sync + 'static,
+            S: $Strategy<OwnedRepr<T>> + Clone + Send + Sync + 'static,
+        {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+    };
+}
+pub(crate) use dyn_interpolator_impl;
+
 macro_rules! partialeq_impl {
     ($InterpType:ident, $Data:ident, $Strategy:ident) => {
         impl<D, S> PartialEq for $InterpType<D, S>

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -363,7 +363,7 @@ pub(crate) use batch_interpolate_impl;
 /// strategy once the point is known to be in-bounds (or already resolved via
 /// `Fill`/`Clamp`/`Wrap`). `InterpND` has no fixed `N` to loop `0..N` over at compile
 /// time, so it implements this by hand directly in its [`Interpolator`] impl instead.
-macro_rules! interpolate_impl {
+macro_rules! sized_interpolate_impl {
     () => {
         /// Interpolate at the supplied point.
         ///
@@ -417,7 +417,7 @@ macro_rules! interpolate_impl {
         }
     };
 }
-pub(crate) use interpolate_impl;
+pub(crate) use sized_interpolate_impl;
 
 /// Generates the `Box<dyn $Strategy<D>>`-backed inherent `set_strategy`, shared by
 /// `Interp1D`/`2D`/`3D`/`ND`.
@@ -653,3 +653,37 @@ pub(crate) use view_into_owned_impl;
 
 #[cfg(feature = "serde")]
 pub(crate) use serialize_nested_impl;
+
+/// Generates all trait impls for an interpolator: `PartialEq`, `SerializeNested`,
+/// `extrapolate_impl`, `Interpolator`, `set_strategy` for `Box<dyn Strategy>`,
+/// `set_strategy` for the strategy enum, and `DynInterpolator`.
+macro_rules! interpolator_trait_impls {
+    ($InterpType:ident, $InterpTypeOwned:ident, $InterpData:ident, $Strategy:ident, $StrategyEnum:path, $N:expr) => {
+        partialeq_impl!($InterpType, $InterpData, $Strategy);
+        #[cfg(feature = "serde")]
+        serialize_nested_impl!($InterpType, $InterpData, $Strategy);
+
+        extrapolate_impl!($InterpType, $Strategy);
+        interpolator_trait_impl!($InterpType, $Strategy, $N);
+        set_strategy_box_impl!($InterpType, $Strategy);
+        set_strategy_enum_impl!($InterpType, $StrategyEnum);
+        dyn_interpolator_impl!($InterpTypeOwned, $Strategy);
+    };
+}
+pub(crate) use interpolator_trait_impls;
+
+/// Generates inherent methods for an interpolator: strategy accessors, fast paths,
+/// data access (view/into_owned), and batch interpolation. Called inside the
+/// `impl<D, S>` block, leaving `pub fn new()` to be hand-written.
+macro_rules! interpolator_inherent_methods {
+    ($InterpType:ident, $Strategy:ident, $Viewed:ty, $Owned:ty) => {
+        strategy_accessors_impl!($Strategy);
+        interpolate_fast_impl!();
+        batch_interpolate_fast_impl!();
+
+        view_into_owned_impl!($InterpType, $Strategy, $Viewed, $Owned);
+        sized_interpolate_impl!();
+        batch_interpolate_impl!();
+    };
+}
+pub(crate) use interpolator_inherent_methods;

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -618,5 +618,38 @@ macro_rules! interpolator_trait_impl {
 }
 pub(crate) use interpolator_trait_impl;
 
+/// Generates `view()` and `into_owned()` inherent methods shared by `Interp1D`/`2D`/`3D`.
+/// These methods have identical bodies except for return types, which are passed as parameters.
+macro_rules! view_into_owned_impl {
+    ($InterpType:ident, $Strategy:ident, $Viewed:ty, $Owned:ty) => {
+        /// Return an interpolator with viewed data.
+        pub fn view(&self) -> $Viewed
+        where
+            S: for<'a> $Strategy<ViewRepr<&'a D::Elem>>,
+            D::Elem: Clone,
+        {
+            $InterpType {
+                data: self.data.view(),
+                strategy: self.strategy.clone(),
+                extrapolate: self.extrapolate.clone(),
+            }
+        }
+
+        /// Turn the interpolator into an owned variant, cloning the array elements if necessary.
+        pub fn into_owned(self) -> $Owned
+        where
+            S: $Strategy<OwnedRepr<D::Elem>>,
+            D::Elem: Clone,
+        {
+            $InterpType {
+                data: self.data.into_owned(),
+                strategy: self.strategy.clone(),
+                extrapolate: self.extrapolate.clone(),
+            }
+        }
+    };
+}
+pub(crate) use view_into_owned_impl;
+
 #[cfg(feature = "serde")]
 pub(crate) use serialize_nested_impl;

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -167,6 +167,57 @@ macro_rules! extrapolate_impl {
 }
 pub(crate) use extrapolate_impl;
 
+/// Generates the inherent `validate_strategy`/`init_strategy`, shared by
+/// `Interp1D`/`2D`/`3D`/`ND`. Both only need `D::Elem: PartialEq + Debug` (the struct's
+/// own bound), not the extra bounds of `new`/`interpolate`/etc. Kept on those methods
+/// directly rather than the enclosing impl block, so all inherent methods can share one
+/// block per type instead of being split across several.
+macro_rules! strategy_accessors_impl {
+    ($Strategy:ident) => {
+        #[doc = concat!(
+            " Re-run the strategy's [`", stringify!($Strategy), "::validate`] against the current data.\n",
+            "\n",
+            " `new`, `set_strategy`, and [`Interpolator::validate`] already call this\n",
+            " internally, so this is only needed after mutating the public `data`/`strategy`\n",
+            " fields directly.",
+        )]
+        pub fn validate_strategy(&self) -> Result<(), ValidateError> {
+            self.strategy.validate(&self.data)
+        }
+
+        #[doc = concat!(
+            " Re-run the strategy's [`", stringify!($Strategy), "::init`] against the current data.\n",
+            "\n",
+            " `new` and `set_strategy` already call this internally, so this is only needed\n",
+            " after bypassing them: mutating the public `data`/`strategy` fields directly, or\n",
+            " deserializing an interpolator whose strategy skips its cached state from\n",
+            " serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with\n",
+            " a large derived array). `Deserialize` does not call `init`; if the cached state\n",
+            " is instead stored in ordinary serialized fields, it comes back as-is and this\n",
+            " isn't needed.",
+        )]
+        pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
+            self.strategy.init(&self.data)
+        }
+    };
+}
+pub(crate) use strategy_accessors_impl;
+
+/// Generates the inherent `interpolate_fast` shared by `Interp1D`/`2D`/`3D`: forwards
+/// straight to the strategy, same as [`batch_interpolate_fast_impl`]. `InterpND` has no
+/// fixed-size point array to take by value here, so its `interpolate_fast` lives
+/// directly on its [`Interpolator`] impl instead of as a matching inherent method.
+macro_rules! interpolate_fast_impl {
+    () => {
+        /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
+        /// caller has already checked bounds or knows that extrapolation handling is not needed.
+        pub fn interpolate_fast(&self, point: &[D::Elem; N]) -> D::Elem {
+            self.strategy.interpolate_fast(&self.data, point)
+        }
+    };
+}
+pub(crate) use interpolate_fast_impl;
+
 /// Is `point` out of `grid`'s bounds in any dimension?
 ///
 /// Shared by `Interp1D`/`2D`/`3D`/`ND`'s `batch_interpolate`: both `grid` and `point`
@@ -269,7 +320,10 @@ macro_rules! batch_interpolate_impl {
         pub fn batch_interpolate(
             &self,
             points: &[[D::Elem; N]],
-        ) -> Result<Vec<D::Elem>, InterpolateError> {
+        ) -> Result<Vec<D::Elem>, InterpolateError>
+        where
+            D::Elem: Num + PartialOrd + Euclid + Copy,
+        {
             match &self.extrapolate {
                 Extrapolate::Enable => self.strategy.batch_interpolate(&self.data, points),
                 Extrapolate::Clamp => {
@@ -370,7 +424,10 @@ macro_rules! interpolate_impl {
         ///
         /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
         /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
-        pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
+        pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError>
+        where
+            D::Elem: Num + PartialOrd + Euclid + Copy,
+        {
             let mut errors = Vec::new();
             for dim in 0..N {
                 if !(self.data.grid[dim].first().unwrap()..=self.data.grid[dim].last().unwrap())

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -514,51 +514,6 @@ where
     }
 }
 
-impl<D> InterpND<D, Box<dyn StrategyND<D>>>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    /// Update strategy at runtime, calling [`StrategyND::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(&mut self, strategy: Box<dyn StrategyND<D>>) -> Result<(), ValidateError> {
-        self.strategy = strategy;
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<D> InterpND<D, strategy::enums::StrategyNDEnum>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    /// Update strategy at runtime, calling [`StrategyND::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(
-        &mut self,
-        strategy: impl Into<strategy::enums::StrategyNDEnum>,
-    ) -> Result<(), ValidateError> {
-        self.strategy = strategy.into();
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<T, S> DynInterpolator<T> for InterpNDOwned<T, S>
-where
-    T: Float + Euclid + Debug + Send + Sync + 'static,
-    S: StrategyND<OwnedRepr<T>> + Clone + Send + Sync + 'static,
-{
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
+set_strategy_box_impl!(InterpND, StrategyND);
+set_strategy_enum_impl!(InterpND, strategy::enums::StrategyNDEnum);
+dyn_interpolator_impl!(InterpNDOwned, StrategyND);

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -182,7 +182,6 @@ pub type InterpNDViewed<T, S> = InterpND<ViewRepr<T>, S>;
 /// [`InterpND`] that owns data.
 pub type InterpNDOwned<T, S> = InterpND<OwnedRepr<T>, S>;
 
-extrapolate_impl!(InterpND, StrategyND);
 partialeq_impl!(InterpND, InterpDataND, StrategyND);
 #[cfg(feature = "serde")]
 serialize_nested_impl!(InterpND, InterpDataND, StrategyND);
@@ -514,6 +513,7 @@ where
     }
 }
 
+extrapolate_impl!(InterpND, StrategyND);
 set_strategy_box_impl!(InterpND, StrategyND);
 set_strategy_enum_impl!(InterpND, strategy::enums::StrategyNDEnum);
 dyn_interpolator_impl!(InterpNDOwned, StrategyND);

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -184,44 +184,7 @@ where
     D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
     S: Strategy1D<D> + Clone,
 {
-    /// Interpolate at the supplied point.
-    ///
-    /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
-    /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
-    pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
-        if !(self.data.grid[0].first().unwrap()..=self.data.grid[0].last().unwrap())
-            .contains(&&point[0])
-        {
-            match &self.extrapolate {
-                Extrapolate::Enable => {}
-                Extrapolate::Fill(value) => return Ok(*value),
-                Extrapolate::Clamp => {
-                    let clamped_point = [*clamp(
-                        &point[0],
-                        self.data.grid[0].first().unwrap(),
-                        self.data.grid[0].last().unwrap(),
-                    )];
-                    return self.strategy.interpolate(&self.data, &clamped_point);
-                }
-                Extrapolate::Wrap => {
-                    let wrapped_point = [wrap(
-                        point[0],
-                        *self.data.grid[0].first().unwrap(),
-                        *self.data.grid[0].last().unwrap(),
-                    )];
-                    return self.strategy.interpolate(&self.data, &wrapped_point);
-                }
-                Extrapolate::Error => {
-                    return Err(InterpolateError::ExtrapolateError(format!(
-                        "\n    point[0] = {:?} is out of bounds for grid[0] = {:?}",
-                        point[0], self.data.grid[0]
-                    )))
-                }
-            }
-        };
-        self.strategy.interpolate(&self.data, point)
-    }
-
+    interpolate_impl!();
     batch_interpolate_impl!();
 }
 
@@ -253,51 +216,6 @@ where
     }
 }
 
-impl<D> Interp1D<D, Box<dyn Strategy1D<D>>>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    /// Update strategy at runtime, calling [`Strategy1D::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(&mut self, strategy: Box<dyn Strategy1D<D>>) -> Result<(), ValidateError> {
-        self.strategy = strategy;
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<D> Interp1D<D, strategy::enums::Strategy1DEnum>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    /// Update strategy at runtime, calling [`Strategy1D::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(
-        &mut self,
-        strategy: impl Into<strategy::enums::Strategy1DEnum>,
-    ) -> Result<(), ValidateError> {
-        self.strategy = strategy.into();
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<T, S> DynInterpolator<T> for Interp1DOwned<T, S>
-where
-    T: Float + Euclid + Debug + Send + Sync + 'static,
-    S: Strategy1D<OwnedRepr<T>> + Clone + Send + Sync + 'static,
-{
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
+set_strategy_box_impl!(Interp1D, Strategy1D);
+set_strategy_enum_impl!(Interp1D, strategy::enums::Strategy1DEnum);
+dyn_interpolator_impl!(Interp1DOwned, Strategy1D);

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -66,21 +66,12 @@ pub type Interp1DViewed<T, S> = Interp1D<ViewRepr<T>, S>;
 /// [`Interp1D`] that owns data.
 pub type Interp1DOwned<T, S> = Interp1D<OwnedRepr<T>, S>;
 
-extrapolate_impl!(Interp1D, Strategy1D);
-partialeq_impl!(Interp1D, InterpData1D, Strategy1D);
-#[cfg(feature = "serde")]
-serialize_nested_impl!(Interp1D, InterpData1D, Strategy1D);
-
 impl<D, S> Interp1D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
     S: Strategy1D<D> + Clone,
 {
-    strategy_accessors_impl!(Strategy1D);
-    interpolate_fast_impl!();
-    batch_interpolate_fast_impl!();
-
     /// Instantiate one-dimensional interpolator.
     ///
     /// # Example:
@@ -121,14 +112,19 @@ where
         Ok(interpolator)
     }
 
-    view_into_owned_impl!(Interp1D, Strategy1D, Interp1DViewed<&D::Elem, S>, Interp1DOwned<D::Elem, S>);
-
-    interpolate_impl!();
-    batch_interpolate_impl!();
+    interpolator_inherent_methods!(
+        Interp1D,
+        Strategy1D,
+        Interp1DViewed<&D::Elem, S>,
+        Interp1DOwned<D::Elem, S>
+    );
 }
 
-interpolator_trait_impl!(Interp1D, Strategy1D, N);
-
-set_strategy_box_impl!(Interp1D, Strategy1D);
-set_strategy_enum_impl!(Interp1D, strategy::enums::Strategy1DEnum);
-dyn_interpolator_impl!(Interp1DOwned, Strategy1D);
+interpolator_trait_impls!(
+    Interp1D,
+    Interp1DOwned,
+    InterpData1D,
+    Strategy1D,
+    strategy::enums::Strategy1DEnum,
+    N
+);

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -121,31 +121,7 @@ where
         Ok(interpolator)
     }
 
-    /// Return an interpolator with viewed data.
-    pub fn view(&self) -> Interp1DViewed<&D::Elem, S>
-    where
-        S: for<'a> Strategy1D<ViewRepr<&'a D::Elem>>,
-        D::Elem: Clone,
-    {
-        Interp1DViewed {
-            data: self.data.view(),
-            strategy: self.strategy.clone(),
-            extrapolate: self.extrapolate.clone(),
-        }
-    }
-
-    /// Turn the interpolator into an [`Interp1DOwned`], cloning the array elements if necessary.
-    pub fn into_owned(self) -> Interp1DOwned<D::Elem, S>
-    where
-        S: Strategy1D<OwnedRepr<D::Elem>>,
-        D::Elem: Clone,
-    {
-        Interp1DOwned {
-            data: self.data.into_owned(),
-            strategy: self.strategy.clone(),
-            extrapolate: self.extrapolate.clone(),
-        }
-    }
+    view_into_owned_impl!(Interp1D, Strategy1D, Interp1DViewed<&D::Elem, S>, Interp1DOwned<D::Elem, S>);
 
     interpolate_impl!();
     batch_interpolate_impl!();

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -77,43 +77,10 @@ where
     D::Elem: PartialEq + Debug,
     S: Strategy1D<D> + Clone,
 {
-    /// Re-run the strategy's [`Strategy1D::validate`] against the current data.
-    ///
-    /// `new`, `set_strategy`, and [`Interpolator::validate`] already call this
-    /// internally, so this is only needed after mutating the public `data`/`strategy`
-    /// fields directly.
-    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
-        self.strategy.validate(&self.data)
-    }
-
-    /// Re-run the strategy's [`Strategy1D::init`] against the current data.
-    ///
-    /// `new` and `set_strategy` already call this internally, so this is only needed
-    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator whose strategy skips its cached state from
-    /// serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with
-    /// a large derived array). `Deserialize` does not call `init`; if the cached state
-    /// is instead stored in ordinary serialized fields, it comes back as-is and this
-    /// isn't needed.
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        self.strategy.init(&self.data)
-    }
-
-    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds or knows that extrapolation handling is not needed.
-    pub fn interpolate_fast(&self, point: &[D::Elem; 1]) -> D::Elem {
-        self.strategy.interpolate_fast(&self.data, point)
-    }
-
+    strategy_accessors_impl!(Strategy1D);
+    interpolate_fast_impl!();
     batch_interpolate_fast_impl!();
-}
 
-impl<D, S> Interp1D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialOrd + Debug,
-    S: Strategy1D<D> + Clone,
-{
     /// Instantiate one-dimensional interpolator.
     ///
     /// # Example:
@@ -139,7 +106,10 @@ where
         f_x: ArrayBase<D, Ix1>,
         strategy: S,
         extrapolate: Extrapolate<D::Elem>,
-    ) -> Result<Self, ValidateError> {
+    ) -> Result<Self, ValidateError>
+    where
+        D::Elem: PartialOrd,
+    {
         let mut interpolator = Self {
             data: InterpData1D::new(x, f_x)?,
             strategy,
@@ -176,14 +146,7 @@ where
             extrapolate: self.extrapolate.clone(),
         }
     }
-}
 
-impl<D, S> Interp1D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
-    S: Strategy1D<D> + Clone,
-{
     interpolate_impl!();
     batch_interpolate_impl!();
 }

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -112,7 +112,7 @@ where
         Ok(interpolator)
     }
 
-    interpolator_inherent_methods!(
+    interp_inherent_methods!(
         Interp1D,
         Strategy1D,
         Interp1DViewed<&D::Elem, S>,
@@ -120,7 +120,7 @@ where
     );
 }
 
-interpolator_trait_impls!(
+interp_trait_impls!(
     Interp1D,
     Interp1DOwned,
     InterpData1D,

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -151,33 +151,7 @@ where
     batch_interpolate_impl!();
 }
 
-impl<D, S> Interpolator<D::Elem> for Interp1D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
-    S: Strategy1D<D> + Clone,
-{
-    /// Returns `1`.
-    #[inline]
-    fn ndim(&self) -> usize {
-        N
-    }
-
-    fn validate(&self) -> Result<(), ValidateError> {
-        self.check_extrapolate(&self.extrapolate)?;
-        self.data.validate()?;
-        self.validate_strategy()?;
-        Ok(())
-    }
-
-    sized_interpolate_impl!();
-
-    fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
-        self.check_extrapolate(&extrapolate)?;
-        self.extrapolate = extrapolate;
-        Ok(())
-    }
-}
+interpolator_trait_impl!(Interp1D, Strategy1D, N);
 
 set_strategy_box_impl!(Interp1D, Strategy1D);
 set_strategy_enum_impl!(Interp1D, strategy::enums::Strategy1DEnum);

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -147,31 +147,7 @@ where
         Ok(interpolator)
     }
 
-    /// Return an interpolator with viewed data.
-    pub fn view(&self) -> Interp3DViewed<&D::Elem, S>
-    where
-        S: for<'a> Strategy3D<ViewRepr<&'a D::Elem>>,
-        D::Elem: Clone,
-    {
-        Interp3DViewed {
-            data: self.data.view(),
-            strategy: self.strategy.clone(),
-            extrapolate: self.extrapolate.clone(),
-        }
-    }
-
-    /// Turn the interpolator into an [`Interp3DOwned`], cloning the array elements if necessary.
-    pub fn into_owned(self) -> Interp3DOwned<D::Elem, S>
-    where
-        S: Strategy3D<OwnedRepr<D::Elem>>,
-        D::Elem: Clone,
-    {
-        Interp3DOwned {
-            data: self.data.into_owned(),
-            strategy: self.strategy.clone(),
-            extrapolate: self.extrapolate.clone(),
-        }
-    }
+    view_into_owned_impl!(Interp3D, Strategy3D, Interp3DViewed<&D::Elem, S>, Interp3DOwned<D::Elem, S>);
 
     interpolate_impl!();
     batch_interpolate_impl!();

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -177,33 +177,7 @@ where
     batch_interpolate_impl!();
 }
 
-impl<D, S> Interpolator<D::Elem> for Interp3D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
-    S: Strategy3D<D> + Clone,
-{
-    /// Returns `3`.
-    #[inline]
-    fn ndim(&self) -> usize {
-        N
-    }
-
-    fn validate(&self) -> Result<(), ValidateError> {
-        self.check_extrapolate(&self.extrapolate)?;
-        self.data.validate()?;
-        self.validate_strategy()?;
-        Ok(())
-    }
-
-    sized_interpolate_impl!();
-
-    fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
-        self.check_extrapolate(&extrapolate)?;
-        self.extrapolate = extrapolate;
-        Ok(())
-    }
-}
+interpolator_trait_impl!(Interp3D, Strategy3D, N);
 
 set_strategy_box_impl!(Interp3D, Strategy3D);
 set_strategy_enum_impl!(Interp3D, strategy::enums::Strategy3DEnum);

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -82,43 +82,10 @@ where
     D::Elem: PartialEq + Debug,
     S: Strategy3D<D> + Clone,
 {
-    /// Re-run the strategy's [`Strategy3D::validate`] against the current data.
-    ///
-    /// `new`, `set_strategy`, and [`Interpolator::validate`] already call this
-    /// internally, so this is only needed after mutating the public `data`/`strategy`
-    /// fields directly.
-    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
-        self.strategy.validate(&self.data)
-    }
-
-    /// Re-run the strategy's [`Strategy3D::init`] against the current data.
-    ///
-    /// `new` and `set_strategy` already call this internally, so this is only needed
-    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator whose strategy skips its cached state from
-    /// serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with
-    /// a large derived array). `Deserialize` does not call `init`; if the cached state
-    /// is instead stored in ordinary serialized fields, it comes back as-is and this
-    /// isn't needed.
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        self.strategy.init(&self.data)
-    }
-
-    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds or knows that extrapolation handling is not needed.
-    pub fn interpolate_fast(&self, point: &[D::Elem; 3]) -> D::Elem {
-        self.strategy.interpolate_fast(&self.data, point)
-    }
-
+    strategy_accessors_impl!(Strategy3D);
+    interpolate_fast_impl!();
     batch_interpolate_fast_impl!();
-}
 
-impl<D, S> Interp3D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialOrd + Debug,
-    S: Strategy3D<D> + Clone,
-{
     /// Construct and validate a 3-D interpolator.
     ///
     /// # Example:
@@ -165,7 +132,10 @@ where
         f_xyz: ArrayBase<D, Ix3>,
         strategy: S,
         extrapolate: Extrapolate<D::Elem>,
-    ) -> Result<Self, ValidateError> {
+    ) -> Result<Self, ValidateError>
+    where
+        D::Elem: PartialOrd,
+    {
         let mut interpolator = Self {
             data: InterpData3D::new(x, y, z, f_xyz)?,
             strategy,
@@ -202,14 +172,7 @@ where
             extrapolate: self.extrapolate.clone(),
         }
     }
-}
 
-impl<D, S> Interp3D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
-    S: Strategy3D<D> + Clone,
-{
     interpolate_impl!();
     batch_interpolate_impl!();
 }

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -210,54 +210,7 @@ where
     D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
     S: Strategy3D<D> + Clone,
 {
-    /// Interpolate at the supplied point.
-    ///
-    /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
-    /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
-    pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
-        let mut errors = Vec::new();
-        for dim in 0..N {
-            if !(self.data.grid[dim].first().unwrap()..=self.data.grid[dim].last().unwrap())
-                .contains(&&point[dim])
-            {
-                match &self.extrapolate {
-                    Extrapolate::Enable => {}
-                    Extrapolate::Fill(value) => return Ok(*value),
-                    Extrapolate::Clamp => {
-                        let clamped_point = std::array::from_fn(|i| {
-                            *clamp(
-                                &point[i],
-                                self.data.grid[i].first().unwrap(),
-                                self.data.grid[i].last().unwrap(),
-                            )
-                        });
-                        return self.strategy.interpolate(&self.data, &clamped_point);
-                    }
-                    Extrapolate::Wrap => {
-                        let wrapped_point = std::array::from_fn(|i| {
-                            wrap(
-                                point[i],
-                                *self.data.grid[i].first().unwrap(),
-                                *self.data.grid[i].last().unwrap(),
-                            )
-                        });
-                        return self.strategy.interpolate(&self.data, &wrapped_point);
-                    }
-                    Extrapolate::Error => {
-                        errors.push(format!(
-                            "\n    point[{dim}] = {:?} is out of bounds for grid[{dim}] = {:?}",
-                            point[dim], self.data.grid[dim],
-                        ));
-                    }
-                };
-            }
-        }
-        if !errors.is_empty() {
-            return Err(InterpolateError::ExtrapolateError(errors.join("")));
-        }
-        self.strategy.interpolate(&self.data, point)
-    }
-
+    interpolate_impl!();
     batch_interpolate_impl!();
 }
 
@@ -289,51 +242,6 @@ where
     }
 }
 
-impl<D> Interp3D<D, Box<dyn Strategy3D<D>>>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    /// Update strategy at runtime, calling [`Strategy3D::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(&mut self, strategy: Box<dyn Strategy3D<D>>) -> Result<(), ValidateError> {
-        self.strategy = strategy;
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<D> Interp3D<D, strategy::enums::Strategy3DEnum>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    /// Update strategy at runtime, calling [`Strategy3D::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(
-        &mut self,
-        strategy: impl Into<strategy::enums::Strategy3DEnum>,
-    ) -> Result<(), ValidateError> {
-        self.strategy = strategy.into();
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<T, S> DynInterpolator<T> for Interp3DOwned<T, S>
-where
-    T: Float + Euclid + Debug + Send + Sync + 'static,
-    S: Strategy3D<OwnedRepr<T>> + Clone + Send + Sync + 'static,
-{
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
+set_strategy_box_impl!(Interp3D, Strategy3D);
+set_strategy_enum_impl!(Interp3D, strategy::enums::Strategy3DEnum);
+dyn_interpolator_impl!(Interp3DOwned, Strategy3D);

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -138,7 +138,7 @@ where
         Ok(interpolator)
     }
 
-    interpolator_inherent_methods!(
+    interp_inherent_methods!(
         Interp3D,
         Strategy3D,
         Interp3DViewed<&D::Elem, S>,
@@ -146,7 +146,7 @@ where
     );
 }
 
-interpolator_trait_impls!(
+interp_trait_impls!(
     Interp3D,
     Interp3DOwned,
     InterpData3D,

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -71,21 +71,12 @@ pub type Interp3DViewed<T, S> = Interp3D<ViewRepr<T>, S>;
 /// [`Interp3D`] that owns data.
 pub type Interp3DOwned<T, S> = Interp3D<OwnedRepr<T>, S>;
 
-extrapolate_impl!(Interp3D, Strategy3D);
-partialeq_impl!(Interp3D, InterpData3D, Strategy3D);
-#[cfg(feature = "serde")]
-serialize_nested_impl!(Interp3D, InterpData3D, Strategy3D);
-
 impl<D, S> Interp3D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
     S: Strategy3D<D> + Clone,
 {
-    strategy_accessors_impl!(Strategy3D);
-    interpolate_fast_impl!();
-    batch_interpolate_fast_impl!();
-
     /// Construct and validate a 3-D interpolator.
     ///
     /// # Example:
@@ -147,14 +138,19 @@ where
         Ok(interpolator)
     }
 
-    view_into_owned_impl!(Interp3D, Strategy3D, Interp3DViewed<&D::Elem, S>, Interp3DOwned<D::Elem, S>);
-
-    interpolate_impl!();
-    batch_interpolate_impl!();
+    interpolator_inherent_methods!(
+        Interp3D,
+        Strategy3D,
+        Interp3DViewed<&D::Elem, S>,
+        Interp3DOwned<D::Elem, S>
+    );
 }
 
-interpolator_trait_impl!(Interp3D, Strategy3D, N);
-
-set_strategy_box_impl!(Interp3D, Strategy3D);
-set_strategy_enum_impl!(Interp3D, strategy::enums::Strategy3DEnum);
-dyn_interpolator_impl!(Interp3DOwned, Strategy3D);
+interpolator_trait_impls!(
+    Interp3D,
+    Interp3DOwned,
+    InterpData3D,
+    Strategy3D,
+    strategy::enums::Strategy3DEnum,
+    N
+);

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -135,31 +135,7 @@ where
         Ok(interpolator)
     }
 
-    /// Return an interpolator with viewed data.
-    pub fn view(&self) -> Interp2DViewed<&D::Elem, S>
-    where
-        S: for<'a> Strategy2D<ViewRepr<&'a D::Elem>>,
-        D::Elem: Clone,
-    {
-        Interp2DViewed {
-            data: self.data.view(),
-            strategy: self.strategy.clone(),
-            extrapolate: self.extrapolate.clone(),
-        }
-    }
-
-    /// Turn the interpolator into an [`Interp2DOwned`], cloning the array elements if necessary.
-    pub fn into_owned(self) -> Interp2DOwned<D::Elem, S>
-    where
-        S: Strategy2D<OwnedRepr<D::Elem>>,
-        D::Elem: Clone,
-    {
-        Interp2DOwned {
-            data: self.data.into_owned(),
-            strategy: self.strategy.clone(),
-            extrapolate: self.extrapolate.clone(),
-        }
-    }
+    view_into_owned_impl!(Interp2D, Strategy2D, Interp2DViewed<&D::Elem, S>, Interp2DOwned<D::Elem, S>);
 
     interpolate_impl!();
     batch_interpolate_impl!();

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -70,21 +70,12 @@ pub type Interp2DViewed<T, S> = Interp2D<ViewRepr<T>, S>;
 /// [`Interp2D`] that owns data.
 pub type Interp2DOwned<T, S> = Interp2D<OwnedRepr<T>, S>;
 
-extrapolate_impl!(Interp2D, Strategy2D);
-partialeq_impl!(Interp2D, InterpData2D, Strategy2D);
-#[cfg(feature = "serde")]
-serialize_nested_impl!(Interp2D, InterpData2D, Strategy2D);
-
 impl<D, S> Interp2D<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
     S: Strategy2D<D> + Clone,
 {
-    strategy_accessors_impl!(Strategy2D);
-    interpolate_fast_impl!();
-    batch_interpolate_fast_impl!();
-
     /// Construct and validate a 2-D interpolator.
     ///
     /// # Example:
@@ -135,14 +126,19 @@ where
         Ok(interpolator)
     }
 
-    view_into_owned_impl!(Interp2D, Strategy2D, Interp2DViewed<&D::Elem, S>, Interp2DOwned<D::Elem, S>);
-
-    interpolate_impl!();
-    batch_interpolate_impl!();
+    interpolator_inherent_methods!(
+        Interp2D,
+        Strategy2D,
+        Interp2DViewed<&D::Elem, S>,
+        Interp2DOwned<D::Elem, S>
+    );
 }
 
-interpolator_trait_impl!(Interp2D, Strategy2D, N);
-
-set_strategy_box_impl!(Interp2D, Strategy2D);
-set_strategy_enum_impl!(Interp2D, strategy::enums::Strategy2DEnum);
-dyn_interpolator_impl!(Interp2DOwned, Strategy2D);
+interpolator_trait_impls!(
+    Interp2D,
+    Interp2DOwned,
+    InterpData2D,
+    Strategy2D,
+    strategy::enums::Strategy2DEnum,
+    N
+);

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -126,7 +126,7 @@ where
         Ok(interpolator)
     }
 
-    interpolator_inherent_methods!(
+    interp_inherent_methods!(
         Interp2D,
         Strategy2D,
         Interp2DViewed<&D::Elem, S>,
@@ -134,7 +134,7 @@ where
     );
 }
 
-interpolator_trait_impls!(
+interp_trait_impls!(
     Interp2D,
     Interp2DOwned,
     InterpData2D,

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -198,54 +198,7 @@ where
     D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
     S: Strategy2D<D> + Clone,
 {
-    /// Interpolate at the supplied point.
-    ///
-    /// Unlike [`Interpolator::interpolate`], the point length is checked at compile
-    /// time via `N`, so this cannot fail with [`InterpolateError::PointLength`].
-    pub fn interpolate(&self, point: &[D::Elem; N]) -> Result<D::Elem, InterpolateError> {
-        let mut errors = Vec::new();
-        for dim in 0..N {
-            if !(self.data.grid[dim].first().unwrap()..=self.data.grid[dim].last().unwrap())
-                .contains(&&point[dim])
-            {
-                match &self.extrapolate {
-                    Extrapolate::Enable => {}
-                    Extrapolate::Fill(value) => return Ok(*value),
-                    Extrapolate::Clamp => {
-                        let clamped_point = std::array::from_fn(|i| {
-                            *clamp(
-                                &point[i],
-                                self.data.grid[i].first().unwrap(),
-                                self.data.grid[i].last().unwrap(),
-                            )
-                        });
-                        return self.strategy.interpolate(&self.data, &clamped_point);
-                    }
-                    Extrapolate::Wrap => {
-                        let wrapped_point = std::array::from_fn(|i| {
-                            wrap(
-                                point[i],
-                                *self.data.grid[i].first().unwrap(),
-                                *self.data.grid[i].last().unwrap(),
-                            )
-                        });
-                        return self.strategy.interpolate(&self.data, &wrapped_point);
-                    }
-                    Extrapolate::Error => {
-                        errors.push(format!(
-                            "\n    point[{dim}] = {:?} is out of bounds for grid[{dim}] = {:?}",
-                            point[dim], self.data.grid[dim],
-                        ));
-                    }
-                };
-            }
-        }
-        if !errors.is_empty() {
-            return Err(InterpolateError::ExtrapolateError(errors.join("")));
-        }
-        self.strategy.interpolate(&self.data, point)
-    }
-
+    interpolate_impl!();
     batch_interpolate_impl!();
 }
 
@@ -277,51 +230,6 @@ where
     }
 }
 
-impl<D> Interp2D<D, Box<dyn Strategy2D<D>>>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    /// Update strategy at runtime, calling [`Strategy2D::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(&mut self, strategy: Box<dyn Strategy2D<D>>) -> Result<(), ValidateError> {
-        self.strategy = strategy;
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<D> Interp2D<D, strategy::enums::Strategy2DEnum>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    /// Update strategy at runtime, calling [`Strategy2D::init`] on the new strategy
-    /// against the current data.
-    ///
-    /// To swap in a strategy without re-running `init` (e.g. one whose state was
-    /// already established elsewhere), assign the `strategy` field directly instead.
-    pub fn set_strategy(
-        &mut self,
-        strategy: impl Into<strategy::enums::Strategy2DEnum>,
-    ) -> Result<(), ValidateError> {
-        self.strategy = strategy.into();
-        self.check_extrapolate(&self.extrapolate)?;
-        self.validate_strategy()?;
-        self.init_strategy()
-    }
-}
-
-impl<T, S> DynInterpolator<T> for Interp2DOwned<T, S>
-where
-    T: Float + Euclid + Debug + Send + Sync + 'static,
-    S: Strategy2D<OwnedRepr<T>> + Clone + Send + Sync + 'static,
-{
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
+set_strategy_box_impl!(Interp2D, Strategy2D);
+set_strategy_enum_impl!(Interp2D, strategy::enums::Strategy2DEnum);
+dyn_interpolator_impl!(Interp2DOwned, Strategy2D);

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -81,43 +81,10 @@ where
     D::Elem: PartialEq + Debug,
     S: Strategy2D<D> + Clone,
 {
-    /// Re-run the strategy's [`Strategy2D::validate`] against the current data.
-    ///
-    /// `new`, `set_strategy`, and [`Interpolator::validate`] already call this
-    /// internally, so this is only needed after mutating the public `data`/`strategy`
-    /// fields directly.
-    pub fn validate_strategy(&self) -> Result<(), ValidateError> {
-        self.strategy.validate(&self.data)
-    }
-
-    /// Re-run the strategy's [`Strategy2D::init`] against the current data.
-    ///
-    /// `new` and `set_strategy` already call this internally, so this is only needed
-    /// after bypassing them: mutating the public `data`/`strategy` fields directly, or
-    /// deserializing an interpolator whose strategy skips its cached state from
-    /// serialization (e.g. via `#[serde(skip)]`, to avoid bloating the wire format with
-    /// a large derived array). `Deserialize` does not call `init`; if the cached state
-    /// is instead stored in ordinary serialized fields, it comes back as-is and this
-    /// isn't needed.
-    pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
-        self.strategy.init(&self.data)
-    }
-
-    /// Interpolate without bounds/extrapolation checks, for use in hot loops where the
-    /// caller has already checked bounds or knows that extrapolation handling is not needed.
-    pub fn interpolate_fast(&self, point: &[D::Elem; 2]) -> D::Elem {
-        self.strategy.interpolate_fast(&self.data, point)
-    }
-
+    strategy_accessors_impl!(Strategy2D);
+    interpolate_fast_impl!();
     batch_interpolate_fast_impl!();
-}
 
-impl<D, S> Interp2D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialOrd + Debug,
-    S: Strategy2D<D> + Clone,
-{
     /// Construct and validate a 2-D interpolator.
     ///
     /// # Example:
@@ -153,7 +120,10 @@ where
         f_xy: ArrayBase<D, Ix2>,
         strategy: S,
         extrapolate: Extrapolate<D::Elem>,
-    ) -> Result<Self, ValidateError> {
+    ) -> Result<Self, ValidateError>
+    where
+        D::Elem: PartialOrd,
+    {
         let mut interpolator = Self {
             data: InterpData2D::new(x, y, f_xy)?,
             strategy,
@@ -190,14 +160,7 @@ where
             extrapolate: self.extrapolate.clone(),
         }
     }
-}
 
-impl<D, S> Interp2D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
-    S: Strategy2D<D> + Clone,
-{
     interpolate_impl!();
     batch_interpolate_impl!();
 }

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -165,33 +165,7 @@ where
     batch_interpolate_impl!();
 }
 
-impl<D, S> Interpolator<D::Elem> for Interp2D<D, S>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
-    S: Strategy2D<D> + Clone,
-{
-    /// Returns `2`.
-    #[inline]
-    fn ndim(&self) -> usize {
-        N
-    }
-
-    fn validate(&self) -> Result<(), ValidateError> {
-        self.check_extrapolate(&self.extrapolate)?;
-        self.data.validate()?;
-        self.validate_strategy()?;
-        Ok(())
-    }
-
-    sized_interpolate_impl!();
-
-    fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
-        self.check_extrapolate(&extrapolate)?;
-        self.extrapolate = extrapolate;
-        Ok(())
-    }
-}
+interpolator_trait_impl!(Interp2D, Strategy2D, N);
 
 set_strategy_box_impl!(Interp2D, Strategy2D);
 set_strategy_enum_impl!(Interp2D, strategy::enums::Strategy2DEnum);

--- a/src/strategy/enums/mod.rs
+++ b/src/strategy/enums/mod.rs
@@ -49,6 +49,79 @@
 
 use super::*;
 
+/// Generates enum + From impls + trait dispatch, shared by Strategy*DEnum types.
+/// Takes enum name, trait name, data type name, point parameter type, and the list
+/// of strategies (variant name + type pairs). This allows future customization if
+/// strategies are added/removed per dimensionality.
+macro_rules! strategy_enum_impl {
+    (
+        $EnumName:ident,
+        $TraitName:ident,
+        $DataType:ident,
+        $PointType:ty,
+        [$(($Variant:ident, $StrategyType:ty)),* $(,)?]
+    ) => {
+        /// See [enums module](super) documentation.
+        #[allow(missing_docs)]
+        #[derive(Debug, Clone, PartialEq)]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "serde", serde(untagged))]
+        #[non_exhaustive]
+        pub enum $EnumName {
+            $($Variant($StrategyType),)*
+        }
+
+        $(
+            impl From<$StrategyType> for $EnumName {
+                #[inline]
+                fn from(strategy: $StrategyType) -> Self {
+                    Self::$Variant(strategy)
+                }
+            }
+        )*
+
+        impl<D> $TraitName<D> for $EnumName
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: Float + Debug,
+        {
+            #[inline]
+            fn validate(&self, data: &$DataType<D>) -> Result<(), ValidateError> {
+                match self {
+                    $(Self::$Variant(strategy) => $TraitName::<D>::validate(strategy, data),)*
+                }
+            }
+
+            #[inline]
+            fn init(&mut self, data: &$DataType<D>) -> Result<(), ValidateError> {
+                match self {
+                    $(Self::$Variant(strategy) => $TraitName::<D>::init(strategy, data),)*
+                }
+            }
+
+            #[inline]
+            fn interpolate(
+                &self,
+                data: &$DataType<D>,
+                point: $PointType,
+            ) -> Result<D::Elem, InterpolateError> {
+                match self {
+                    $(Self::$Variant(strategy) => $TraitName::<D>::interpolate(strategy, data, point),)*
+                }
+            }
+
+            #[inline]
+            fn allow_extrapolate(&self) -> bool {
+                match self {
+                    $(Self::$Variant(strategy) => $TraitName::<D>::allow_extrapolate(strategy),)*
+                }
+            }
+        }
+    };
+}
+#[allow(unused_imports)]
+pub(crate) use strategy_enum_impl;
+
 mod n;
 mod one;
 mod three;

--- a/src/strategy/enums/n.rs
+++ b/src/strategy/enums/n.rs
@@ -1,127 +1,19 @@
 use super::*;
 
-/// See [enums module](super) documentation.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-#[non_exhaustive]
-pub enum StrategyNDEnum {
-    Linear(strategy::Linear),
-    LinearUniform(strategy::LinearUniform),
-    Nearest(strategy::Nearest),
-    Step(strategy::Step),
-    StepLower(strategy::StepLower),
-    StepUpper(strategy::StepUpper),
-}
-
-impl From<Linear> for StrategyNDEnum {
-    #[inline]
-    fn from(strategy: Linear) -> Self {
-        StrategyNDEnum::Linear(strategy)
-    }
-}
-
-impl From<LinearUniform> for StrategyNDEnum {
-    #[inline]
-    fn from(strategy: LinearUniform) -> Self {
-        StrategyNDEnum::LinearUniform(strategy)
-    }
-}
-
-impl From<Nearest> for StrategyNDEnum {
-    #[inline]
-    fn from(strategy: Nearest) -> Self {
-        StrategyNDEnum::Nearest(strategy)
-    }
-}
-
-impl From<Step> for StrategyNDEnum {
-    #[inline]
-    fn from(strategy: Step) -> Self {
-        StrategyNDEnum::Step(strategy)
-    }
-}
-
-impl From<StepLower> for StrategyNDEnum {
-    #[inline]
-    fn from(strategy: StepLower) -> Self {
-        StrategyNDEnum::StepLower(strategy)
-    }
-}
-
-impl From<StepUpper> for StrategyNDEnum {
-    #[inline]
-    fn from(strategy: StepUpper) -> Self {
-        StrategyNDEnum::StepUpper(strategy)
-    }
-}
-
-impl<D> StrategyND<D> for StrategyNDEnum
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
-        match self {
-            StrategyNDEnum::Linear(strategy) => StrategyND::<D>::validate(strategy, data),
-            StrategyNDEnum::LinearUniform(strategy) => StrategyND::<D>::validate(strategy, data),
-            StrategyNDEnum::Nearest(strategy) => StrategyND::<D>::validate(strategy, data),
-            StrategyNDEnum::Step(strategy) => StrategyND::<D>::validate(strategy, data),
-            StrategyNDEnum::StepLower(strategy) => StrategyND::<D>::validate(strategy, data),
-            StrategyNDEnum::StepUpper(strategy) => StrategyND::<D>::validate(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
-        match self {
-            StrategyNDEnum::Linear(strategy) => StrategyND::<D>::init(strategy, data),
-            StrategyNDEnum::LinearUniform(strategy) => StrategyND::<D>::init(strategy, data),
-            StrategyNDEnum::Nearest(strategy) => StrategyND::<D>::init(strategy, data),
-            StrategyNDEnum::Step(strategy) => StrategyND::<D>::init(strategy, data),
-            StrategyNDEnum::StepLower(strategy) => StrategyND::<D>::init(strategy, data),
-            StrategyNDEnum::StepUpper(strategy) => StrategyND::<D>::init(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn interpolate(
-        &self,
-        data: &InterpDataND<D>,
-        point: &[D::Elem],
-    ) -> Result<D::Elem, InterpolateError> {
-        match self {
-            StrategyNDEnum::Linear(strategy) => StrategyND::<D>::interpolate(strategy, data, point),
-            StrategyNDEnum::LinearUniform(strategy) => {
-                StrategyND::<D>::interpolate(strategy, data, point)
-            }
-            StrategyNDEnum::Nearest(strategy) => {
-                StrategyND::<D>::interpolate(strategy, data, point)
-            }
-            StrategyNDEnum::Step(strategy) => StrategyND::<D>::interpolate(strategy, data, point),
-            StrategyNDEnum::StepLower(strategy) => {
-                StrategyND::<D>::interpolate(strategy, data, point)
-            }
-            StrategyNDEnum::StepUpper(strategy) => {
-                StrategyND::<D>::interpolate(strategy, data, point)
-            }
-        }
-    }
-
-    #[inline]
-    fn allow_extrapolate(&self) -> bool {
-        match self {
-            StrategyNDEnum::Linear(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
-            StrategyNDEnum::LinearUniform(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
-            StrategyNDEnum::Nearest(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
-            StrategyNDEnum::Step(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
-            StrategyNDEnum::StepLower(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
-            StrategyNDEnum::StepUpper(strategy) => StrategyND::<D>::allow_extrapolate(strategy),
-        }
-    }
-}
+strategy_enum_impl!(
+    StrategyNDEnum,
+    StrategyND,
+    InterpDataND,
+    &[D::Elem],
+    [
+        (Linear, strategy::Linear),
+        (LinearUniform, strategy::LinearUniform),
+        (Nearest, strategy::Nearest),
+        (Step, strategy::Step),
+        (StepLower, strategy::StepLower),
+        (StepUpper, strategy::StepUpper),
+    ]
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/strategy/enums/one.rs
+++ b/src/strategy/enums/one.rs
@@ -1,127 +1,19 @@
 use super::*;
 
-/// See [enums module](super) documentation.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-#[non_exhaustive]
-pub enum Strategy1DEnum {
-    Linear(strategy::Linear),
-    LinearUniform(strategy::LinearUniform),
-    Nearest(strategy::Nearest),
-    Step(strategy::Step),
-    StepLower(strategy::StepLower),
-    StepUpper(strategy::StepUpper),
-}
-
-impl From<Linear> for Strategy1DEnum {
-    #[inline]
-    fn from(strategy: Linear) -> Self {
-        Self::Linear(strategy)
-    }
-}
-
-impl From<LinearUniform> for Strategy1DEnum {
-    #[inline]
-    fn from(strategy: LinearUniform) -> Self {
-        Self::LinearUniform(strategy)
-    }
-}
-
-impl From<Nearest> for Strategy1DEnum {
-    #[inline]
-    fn from(strategy: Nearest) -> Self {
-        Self::Nearest(strategy)
-    }
-}
-
-impl From<Step> for Strategy1DEnum {
-    #[inline]
-    fn from(strategy: Step) -> Self {
-        Self::Step(strategy)
-    }
-}
-
-impl From<StepLower> for Strategy1DEnum {
-    #[inline]
-    fn from(strategy: StepLower) -> Self {
-        Self::StepLower(strategy)
-    }
-}
-
-impl From<StepUpper> for Strategy1DEnum {
-    #[inline]
-    fn from(strategy: StepUpper) -> Self {
-        Self::StepUpper(strategy)
-    }
-}
-
-impl<D> Strategy1D<D> for Strategy1DEnum
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn validate(&self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
-        match self {
-            Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::validate(strategy, data),
-            Strategy1DEnum::LinearUniform(strategy) => Strategy1D::<D>::validate(strategy, data),
-            Strategy1DEnum::Nearest(strategy) => Strategy1D::<D>::validate(strategy, data),
-            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::validate(strategy, data),
-            Strategy1DEnum::StepLower(strategy) => Strategy1D::<D>::validate(strategy, data),
-            Strategy1DEnum::StepUpper(strategy) => Strategy1D::<D>::validate(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn init(&mut self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
-        match self {
-            Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::init(strategy, data),
-            Strategy1DEnum::LinearUniform(strategy) => Strategy1D::<D>::init(strategy, data),
-            Strategy1DEnum::Nearest(strategy) => Strategy1D::<D>::init(strategy, data),
-            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::init(strategy, data),
-            Strategy1DEnum::StepLower(strategy) => Strategy1D::<D>::init(strategy, data),
-            Strategy1DEnum::StepUpper(strategy) => Strategy1D::<D>::init(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn interpolate(
-        &self,
-        data: &InterpData1D<D>,
-        point: &[D::Elem; 1],
-    ) -> Result<D::Elem, InterpolateError> {
-        match self {
-            Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::interpolate(strategy, data, point),
-            Strategy1DEnum::LinearUniform(strategy) => {
-                Strategy1D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy1DEnum::Nearest(strategy) => {
-                Strategy1D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::interpolate(strategy, data, point),
-            Strategy1DEnum::StepLower(strategy) => {
-                Strategy1D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy1DEnum::StepUpper(strategy) => {
-                Strategy1D::<D>::interpolate(strategy, data, point)
-            }
-        }
-    }
-
-    #[inline]
-    fn allow_extrapolate(&self) -> bool {
-        match self {
-            Strategy1DEnum::Linear(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-            Strategy1DEnum::LinearUniform(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-            Strategy1DEnum::Nearest(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-            Strategy1DEnum::Step(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-            Strategy1DEnum::StepLower(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-            Strategy1DEnum::StepUpper(strategy) => Strategy1D::<D>::allow_extrapolate(strategy),
-        }
-    }
-}
+strategy_enum_impl!(
+    Strategy1DEnum,
+    Strategy1D,
+    InterpData1D,
+    &[D::Elem; 1],
+    [
+        (Linear, strategy::Linear),
+        (LinearUniform, strategy::LinearUniform),
+        (Nearest, strategy::Nearest),
+        (Step, strategy::Step),
+        (StepLower, strategy::StepLower),
+        (StepUpper, strategy::StepUpper),
+    ]
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/strategy/enums/three.rs
+++ b/src/strategy/enums/three.rs
@@ -1,127 +1,19 @@
 use super::*;
 
-/// See [enums module](super) documentation.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-#[non_exhaustive]
-pub enum Strategy3DEnum {
-    Linear(strategy::Linear),
-    LinearUniform(strategy::LinearUniform),
-    Nearest(strategy::Nearest),
-    Step(strategy::Step),
-    StepLower(strategy::StepLower),
-    StepUpper(strategy::StepUpper),
-}
-
-impl From<Linear> for Strategy3DEnum {
-    #[inline]
-    fn from(strategy: Linear) -> Self {
-        Self::Linear(strategy)
-    }
-}
-
-impl From<LinearUniform> for Strategy3DEnum {
-    #[inline]
-    fn from(strategy: LinearUniform) -> Self {
-        Self::LinearUniform(strategy)
-    }
-}
-
-impl From<Nearest> for Strategy3DEnum {
-    #[inline]
-    fn from(strategy: Nearest) -> Self {
-        Self::Nearest(strategy)
-    }
-}
-
-impl From<Step> for Strategy3DEnum {
-    #[inline]
-    fn from(strategy: Step) -> Self {
-        Self::Step(strategy)
-    }
-}
-
-impl From<StepLower> for Strategy3DEnum {
-    #[inline]
-    fn from(strategy: StepLower) -> Self {
-        Self::StepLower(strategy)
-    }
-}
-
-impl From<StepUpper> for Strategy3DEnum {
-    #[inline]
-    fn from(strategy: StepUpper) -> Self {
-        Self::StepUpper(strategy)
-    }
-}
-
-impl<D> Strategy3D<D> for Strategy3DEnum
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn validate(&self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
-        match self {
-            Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::validate(strategy, data),
-            Strategy3DEnum::LinearUniform(strategy) => Strategy3D::<D>::validate(strategy, data),
-            Strategy3DEnum::Nearest(strategy) => Strategy3D::<D>::validate(strategy, data),
-            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::validate(strategy, data),
-            Strategy3DEnum::StepLower(strategy) => Strategy3D::<D>::validate(strategy, data),
-            Strategy3DEnum::StepUpper(strategy) => Strategy3D::<D>::validate(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn init(&mut self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
-        match self {
-            Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::init(strategy, data),
-            Strategy3DEnum::LinearUniform(strategy) => Strategy3D::<D>::init(strategy, data),
-            Strategy3DEnum::Nearest(strategy) => Strategy3D::<D>::init(strategy, data),
-            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::init(strategy, data),
-            Strategy3DEnum::StepLower(strategy) => Strategy3D::<D>::init(strategy, data),
-            Strategy3DEnum::StepUpper(strategy) => Strategy3D::<D>::init(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn interpolate(
-        &self,
-        data: &InterpData3D<D>,
-        point: &[D::Elem; 3],
-    ) -> Result<D::Elem, InterpolateError> {
-        match self {
-            Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::interpolate(strategy, data, point),
-            Strategy3DEnum::LinearUniform(strategy) => {
-                Strategy3D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy3DEnum::Nearest(strategy) => {
-                Strategy3D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::interpolate(strategy, data, point),
-            Strategy3DEnum::StepLower(strategy) => {
-                Strategy3D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy3DEnum::StepUpper(strategy) => {
-                Strategy3D::<D>::interpolate(strategy, data, point)
-            }
-        }
-    }
-
-    #[inline]
-    fn allow_extrapolate(&self) -> bool {
-        match self {
-            Strategy3DEnum::Linear(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
-            Strategy3DEnum::LinearUniform(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
-            Strategy3DEnum::Nearest(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
-            Strategy3DEnum::Step(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
-            Strategy3DEnum::StepLower(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
-            Strategy3DEnum::StepUpper(strategy) => Strategy3D::<D>::allow_extrapolate(strategy),
-        }
-    }
-}
+strategy_enum_impl!(
+    Strategy3DEnum,
+    Strategy3D,
+    InterpData3D,
+    &[D::Elem; 3],
+    [
+        (Linear, strategy::Linear),
+        (LinearUniform, strategy::LinearUniform),
+        (Nearest, strategy::Nearest),
+        (Step, strategy::Step),
+        (StepLower, strategy::StepLower),
+        (StepUpper, strategy::StepUpper),
+    ]
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/strategy/enums/two.rs
+++ b/src/strategy/enums/two.rs
@@ -1,127 +1,19 @@
 use super::*;
 
-/// See [enums module](super) documentation.
-#[allow(missing_docs)]
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "serde", serde(untagged))]
-#[non_exhaustive]
-pub enum Strategy2DEnum {
-    Linear(strategy::Linear),
-    LinearUniform(strategy::LinearUniform),
-    Nearest(strategy::Nearest),
-    Step(strategy::Step),
-    StepLower(strategy::StepLower),
-    StepUpper(strategy::StepUpper),
-}
-
-impl From<Linear> for Strategy2DEnum {
-    #[inline]
-    fn from(strategy: Linear) -> Self {
-        Self::Linear(strategy)
-    }
-}
-
-impl From<LinearUniform> for Strategy2DEnum {
-    #[inline]
-    fn from(strategy: LinearUniform) -> Self {
-        Self::LinearUniform(strategy)
-    }
-}
-
-impl From<Nearest> for Strategy2DEnum {
-    #[inline]
-    fn from(strategy: Nearest) -> Self {
-        Self::Nearest(strategy)
-    }
-}
-
-impl From<Step> for Strategy2DEnum {
-    #[inline]
-    fn from(strategy: Step) -> Self {
-        Self::Step(strategy)
-    }
-}
-
-impl From<StepLower> for Strategy2DEnum {
-    #[inline]
-    fn from(strategy: StepLower) -> Self {
-        Self::StepLower(strategy)
-    }
-}
-
-impl From<StepUpper> for Strategy2DEnum {
-    #[inline]
-    fn from(strategy: StepUpper) -> Self {
-        Self::StepUpper(strategy)
-    }
-}
-
-impl<D> Strategy2D<D> for Strategy2DEnum
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: Float + Debug,
-{
-    #[inline]
-    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
-        match self {
-            Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::validate(strategy, data),
-            Strategy2DEnum::LinearUniform(strategy) => Strategy2D::<D>::validate(strategy, data),
-            Strategy2DEnum::Nearest(strategy) => Strategy2D::<D>::validate(strategy, data),
-            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::validate(strategy, data),
-            Strategy2DEnum::StepLower(strategy) => Strategy2D::<D>::validate(strategy, data),
-            Strategy2DEnum::StepUpper(strategy) => Strategy2D::<D>::validate(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn init(&mut self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
-        match self {
-            Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::init(strategy, data),
-            Strategy2DEnum::LinearUniform(strategy) => Strategy2D::<D>::init(strategy, data),
-            Strategy2DEnum::Nearest(strategy) => Strategy2D::<D>::init(strategy, data),
-            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::init(strategy, data),
-            Strategy2DEnum::StepLower(strategy) => Strategy2D::<D>::init(strategy, data),
-            Strategy2DEnum::StepUpper(strategy) => Strategy2D::<D>::init(strategy, data),
-        }
-    }
-
-    #[inline]
-    fn interpolate(
-        &self,
-        data: &InterpData2D<D>,
-        point: &[D::Elem; 2],
-    ) -> Result<D::Elem, InterpolateError> {
-        match self {
-            Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::interpolate(strategy, data, point),
-            Strategy2DEnum::LinearUniform(strategy) => {
-                Strategy2D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy2DEnum::Nearest(strategy) => {
-                Strategy2D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::interpolate(strategy, data, point),
-            Strategy2DEnum::StepLower(strategy) => {
-                Strategy2D::<D>::interpolate(strategy, data, point)
-            }
-            Strategy2DEnum::StepUpper(strategy) => {
-                Strategy2D::<D>::interpolate(strategy, data, point)
-            }
-        }
-    }
-
-    #[inline]
-    fn allow_extrapolate(&self) -> bool {
-        match self {
-            Strategy2DEnum::Linear(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
-            Strategy2DEnum::LinearUniform(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
-            Strategy2DEnum::Nearest(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
-            Strategy2DEnum::Step(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
-            Strategy2DEnum::StepLower(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
-            Strategy2DEnum::StepUpper(strategy) => Strategy2D::<D>::allow_extrapolate(strategy),
-        }
-    }
-}
+strategy_enum_impl!(
+    Strategy2DEnum,
+    Strategy2D,
+    InterpData2D,
+    &[D::Elem; 2],
+    [
+        (Linear, strategy::Linear),
+        (LinearUniform, strategy::LinearUniform),
+        (Nearest, strategy::Nearest),
+        (Step, strategy::Step),
+        (StepLower, strategy::StepLower),
+        (StepUpper, strategy::StepUpper),
+    ]
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -2,428 +2,167 @@
 
 use super::*;
 
-/// 1-D interpolation strategy.
-pub trait Strategy1D<D>: Debug + DynClone
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    /// Validate strategy state against interpolation data. Pure check, no mutation.
-    ///
-    /// Default no-op. Override for invariant checks that don't require precomputed
-    /// state (grid uniformity, direction-count matching, etc).
-    fn validate(&self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
-        Ok(())
-    }
+/// Generates a fixed-dimensionality strategy trait (`Strategy1D`/`2D`/`3D`) plus its
+/// `impl … for Box<dyn …>` forwarding impl. `StrategyND` takes points as `&[D::Elem]`
+/// instead of `&[D::Elem; N]`, so it can't share this shape and stays hand-written below.
+macro_rules! sized_strategy_trait {
+    ($Trait:ident, $InterpData:ident, $N:literal, $doc:literal) => {
+        #[doc = $doc]
+        pub trait $Trait<D>: Debug + DynClone
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: PartialEq + Debug,
+        {
+            /// Validate strategy state against interpolation data. Pure check, no mutation.
+            ///
+            /// Default no-op. Override for invariant checks that don't require precomputed
+            /// state (grid uniformity, direction-count matching, etc).
+            fn validate(&self, _data: &$InterpData<D>) -> Result<(), ValidateError> {
+                Ok(())
+            }
 
-    /// Initialize/recompute cached derived state, with access to interpolation data.
-    ///
-    /// Default no-op. Override only when the strategy caches something derived from
-    /// `data` (e.g. precomputed spline coefficients). Unlike [`Strategy1D::validate`],
-    /// this may do real, non-trivial calculation.
-    fn init(&mut self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
-        Ok(())
-    }
+            #[doc = concat!(
+                " Initialize/recompute cached derived state, with access to interpolation data.\n",
+                "\n",
+                " Default no-op. Override only when the strategy caches something derived from\n",
+                " `data` (e.g. precomputed spline coefficients). Unlike [`", stringify!($Trait), "::validate`],\n",
+                " this may do real, non-trivial calculation.",
+            )]
+            fn init(&mut self, _data: &$InterpData<D>) -> Result<(), ValidateError> {
+                Ok(())
+            }
 
-    /// Execute interpolation (after handling [`Extrapolate`](`crate::interpolator::Extrapolate`) setting).
-    ///
-    /// # Note for custom strategies
-    /// Index `data.grid[i]` directly via `ArrayView` indexing; avoid `.as_slice()`, which
-    /// panics on non-contiguous storage (possible with `Interp*Viewed`). See
-    /// [`crate::strategy::utils`] for ready-made per-axis search helpers (bracket search,
-    /// exact-match short-circuit, step-direction lookup, uniform-grid fast path) built from
-    /// the same primitives the built-in strategies use.
-    fn interpolate(
-        &self,
-        data: &InterpData1D<D>,
-        point: &[D::Elem; 1],
-    ) -> Result<D::Elem, InterpolateError>;
+            /// Execute interpolation (after handling [`Extrapolate`](`crate::interpolator::Extrapolate`) setting).
+            ///
+            /// # Note for custom strategies
+            /// Index `data.grid[i]` directly via `ArrayView` indexing; avoid `.as_slice()`, which
+            /// panics on non-contiguous storage (possible with `Interp*Viewed`). See
+            /// [`crate::strategy::utils`] for ready-made per-axis search helpers (bracket search,
+            /// exact-match short-circuit, step-direction lookup, uniform-grid fast path) built from
+            /// the same primitives the built-in strategies use.
+            fn interpolate(
+                &self,
+                data: &$InterpData<D>,
+                point: &[D::Elem; $N],
+            ) -> Result<D::Elem, InterpolateError>;
 
-    /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
-    /// already valid.
-    ///
-    /// Default just unwraps [`Strategy1D::interpolate`]. Override only if this
-    /// strategy's checked path does real internal fallible work beyond producing
-    /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
-    #[inline]
-    fn interpolate_fast(&self, data: &InterpData1D<D>, point: &[D::Elem; 1]) -> D::Elem {
-        self.interpolate(data, point)
-            .expect("interpolate_fast: invalid point or data")
-    }
+            #[doc = concat!(
+                " Interpolate without the `Result` wrapper, assuming `point` and `data` are\n",
+                " already valid.\n",
+                "\n",
+                " Default just unwraps [`", stringify!($Trait), "::interpolate`]. Override only if this\n",
+                " strategy's checked path does real internal fallible work beyond producing\n",
+                " the final `Ok(...)`; otherwise the default already compiles to the same thing.",
+            )]
+            #[inline]
+            fn interpolate_fast(&self, data: &$InterpData<D>, point: &[D::Elem; $N]) -> D::Elem {
+                self.interpolate(data, point)
+                    .expect("interpolate_fast: invalid point or data")
+            }
 
-    /// Interpolate at each of several points, sharing one grid across all of them.
-    ///
-    /// Default just loops [`Strategy1D::interpolate`]. Override only if locating a
-    /// point in the grid can be amortized across the batch (e.g. sorting points once
-    /// for a locate sweep instead of one binary search per point); no strategy
-    /// shipped in this crate does that today.
-    fn batch_interpolate(
-        &self,
-        data: &InterpData1D<D>,
-        points: &[[D::Elem; 1]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
-        points
-            .iter()
-            .map(|point| self.interpolate(data, point))
-            .collect()
-    }
+            #[doc = concat!(
+                " Interpolate at each of several points, sharing one grid across all of them.\n",
+                "\n",
+                " Default just loops [`", stringify!($Trait), "::interpolate`]. Override only if locating a\n",
+                " point in the grid can be amortized across the batch (e.g. sorting points once\n",
+                " for a locate sweep instead of one binary search per point); no strategy\n",
+                " shipped in this crate does that today.",
+            )]
+            fn batch_interpolate(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+            ) -> Result<Vec<D::Elem>, InterpolateError> {
+                points
+                    .iter()
+                    .map(|point| self.interpolate(data, point))
+                    .collect()
+            }
 
-    /// Batched [`Strategy1D::interpolate_fast`], assuming every point and `data` are
-    /// already valid.
-    ///
-    /// Default just loops [`Strategy1D::interpolate_fast`]. Override under the same
-    /// condition as [`Strategy1D::batch_interpolate`].
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpData1D<D>,
-        points: &[[D::Elem; 1]],
-    ) -> Vec<D::Elem> {
-        points
-            .iter()
-            .map(|point| self.interpolate_fast(data, point))
-            .collect()
-    }
+            #[doc = concat!(
+                " Batched [`", stringify!($Trait), "::interpolate_fast`], assuming every point and `data` are\n",
+                " already valid.\n",
+                "\n",
+                " Default just loops [`", stringify!($Trait), "::interpolate_fast`]. Override under the same\n",
+                " condition as [`", stringify!($Trait), "::batch_interpolate`].",
+            )]
+            fn batch_interpolate_fast(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+            ) -> Vec<D::Elem> {
+                points
+                    .iter()
+                    .map(|point| self.interpolate_fast(data, point))
+                    .collect()
+            }
 
-    /// Does this type's [`Strategy1D::interpolate`] provision for extrapolation?
-    fn allow_extrapolate(&self) -> bool;
+            #[doc = concat!(
+                " Does this type's [`", stringify!($Trait), "::interpolate`] provision for extrapolation?",
+            )]
+            fn allow_extrapolate(&self) -> bool;
+        }
+
+        clone_trait_object!(<D> $Trait<D>);
+
+        impl<D> $Trait<D> for Box<dyn $Trait<D>>
+        where
+            D: Data + RawDataClone + Clone,
+            D::Elem: PartialEq + Debug,
+        {
+            #[inline]
+            fn validate(&self, data: &$InterpData<D>) -> Result<(), ValidateError> {
+                (**self).validate(data)
+            }
+
+            #[inline]
+            fn init(&mut self, data: &$InterpData<D>) -> Result<(), ValidateError> {
+                (**self).init(data)
+            }
+
+            #[inline]
+            fn interpolate(
+                &self,
+                data: &$InterpData<D>,
+                point: &[D::Elem; $N],
+            ) -> Result<D::Elem, InterpolateError> {
+                (**self).interpolate(data, point)
+            }
+
+            #[inline]
+            fn interpolate_fast(&self, data: &$InterpData<D>, point: &[D::Elem; $N]) -> D::Elem {
+                (**self).interpolate_fast(data, point)
+            }
+
+            #[inline]
+            fn batch_interpolate(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+            ) -> Result<Vec<D::Elem>, InterpolateError> {
+                (**self).batch_interpolate(data, points)
+            }
+
+            #[inline]
+            fn batch_interpolate_fast(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+            ) -> Vec<D::Elem> {
+                (**self).batch_interpolate_fast(data, points)
+            }
+
+            #[inline]
+            fn allow_extrapolate(&self) -> bool {
+                (**self).allow_extrapolate()
+            }
+        }
+    };
 }
 
-clone_trait_object!(<D> Strategy1D<D>);
-
-impl<D> Strategy1D<D> for Box<dyn Strategy1D<D>>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    #[inline]
-    fn validate(&self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
-        (**self).validate(data)
-    }
-
-    #[inline]
-    fn init(&mut self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
-        (**self).init(data)
-    }
-
-    #[inline]
-    fn interpolate(
-        &self,
-        data: &InterpData1D<D>,
-        point: &[D::Elem; 1],
-    ) -> Result<D::Elem, InterpolateError> {
-        (**self).interpolate(data, point)
-    }
-
-    #[inline]
-    fn interpolate_fast(&self, data: &InterpData1D<D>, point: &[D::Elem; 1]) -> D::Elem {
-        (**self).interpolate_fast(data, point)
-    }
-
-    #[inline]
-    fn batch_interpolate(
-        &self,
-        data: &InterpData1D<D>,
-        points: &[[D::Elem; 1]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
-        (**self).batch_interpolate(data, points)
-    }
-
-    #[inline]
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpData1D<D>,
-        points: &[[D::Elem; 1]],
-    ) -> Vec<D::Elem> {
-        (**self).batch_interpolate_fast(data, points)
-    }
-
-    #[inline]
-    fn allow_extrapolate(&self) -> bool {
-        (**self).allow_extrapolate()
-    }
-}
-
-/// 2-D interpolation strategy.
-pub trait Strategy2D<D>: Debug + DynClone
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    /// Validate strategy state against interpolation data. Pure check, no mutation.
-    ///
-    /// Default no-op. Override for invariant checks that don't require precomputed
-    /// state (grid uniformity, direction-count matching, etc).
-    fn validate(&self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
-        Ok(())
-    }
-
-    /// Initialize/recompute cached derived state, with access to interpolation data.
-    ///
-    /// Default no-op. Override only when the strategy caches something derived from
-    /// `data` (e.g. precomputed spline coefficients). Unlike [`Strategy2D::validate`],
-    /// this may do real, non-trivial calculation.
-    fn init(&mut self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
-        Ok(())
-    }
-
-    /// Execute interpolation (after handling [`Extrapolate`](`crate::interpolator::Extrapolate`) setting).
-    ///
-    /// # Note for custom strategies
-    /// Index `data.grid[i]` directly via `ArrayView` indexing; avoid `.as_slice()`, which
-    /// panics on non-contiguous storage (possible with `Interp*Viewed`). See
-    /// [`crate::strategy::utils`] for ready-made per-axis search helpers (bracket search,
-    /// exact-match short-circuit, step-direction lookup, uniform-grid fast path) built from
-    /// the same primitives the built-in strategies use.
-    fn interpolate(
-        &self,
-        data: &InterpData2D<D>,
-        point: &[D::Elem; 2],
-    ) -> Result<D::Elem, InterpolateError>;
-
-    /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
-    /// already valid.
-    ///
-    /// Default just unwraps [`Strategy2D::interpolate`]. Override only if this
-    /// strategy's checked path does real internal fallible work beyond producing
-    /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
-    #[inline]
-    fn interpolate_fast(&self, data: &InterpData2D<D>, point: &[D::Elem; 2]) -> D::Elem {
-        self.interpolate(data, point)
-            .expect("interpolate_fast: invalid point or data")
-    }
-
-    /// Interpolate at each of several points, sharing one grid across all of them.
-    ///
-    /// Default just loops [`Strategy2D::interpolate`]. Override only if locating a
-    /// point in the grid can be amortized across the batch (e.g. sorting points once
-    /// for a locate sweep instead of one binary search per point); no strategy
-    /// shipped in this crate does that today.
-    fn batch_interpolate(
-        &self,
-        data: &InterpData2D<D>,
-        points: &[[D::Elem; 2]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
-        points
-            .iter()
-            .map(|point| self.interpolate(data, point))
-            .collect()
-    }
-
-    /// Batched [`Strategy2D::interpolate_fast`], assuming every point and `data` are
-    /// already valid.
-    ///
-    /// Default just loops [`Strategy2D::interpolate_fast`]. Override under the same
-    /// condition as [`Strategy2D::batch_interpolate`].
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpData2D<D>,
-        points: &[[D::Elem; 2]],
-    ) -> Vec<D::Elem> {
-        points
-            .iter()
-            .map(|point| self.interpolate_fast(data, point))
-            .collect()
-    }
-
-    /// Does this type's [`Strategy2D::interpolate`] provision for extrapolation?
-    fn allow_extrapolate(&self) -> bool;
-}
-
-clone_trait_object!(<D> Strategy2D<D>);
-
-impl<D> Strategy2D<D> for Box<dyn Strategy2D<D>>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    #[inline]
-    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
-        (**self).validate(data)
-    }
-
-    #[inline]
-    fn init(&mut self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
-        (**self).init(data)
-    }
-
-    #[inline]
-    fn interpolate(
-        &self,
-        data: &InterpData2D<D>,
-        point: &[D::Elem; 2],
-    ) -> Result<D::Elem, InterpolateError> {
-        (**self).interpolate(data, point)
-    }
-
-    #[inline]
-    fn interpolate_fast(&self, data: &InterpData2D<D>, point: &[D::Elem; 2]) -> D::Elem {
-        (**self).interpolate_fast(data, point)
-    }
-
-    #[inline]
-    fn batch_interpolate(
-        &self,
-        data: &InterpData2D<D>,
-        points: &[[D::Elem; 2]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
-        (**self).batch_interpolate(data, points)
-    }
-
-    #[inline]
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpData2D<D>,
-        points: &[[D::Elem; 2]],
-    ) -> Vec<D::Elem> {
-        (**self).batch_interpolate_fast(data, points)
-    }
-
-    #[inline]
-    fn allow_extrapolate(&self) -> bool {
-        (**self).allow_extrapolate()
-    }
-}
-
-/// 3-D interpolation strategy.
-pub trait Strategy3D<D>: Debug + DynClone
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    /// Validate strategy state against interpolation data. Pure check, no mutation.
-    ///
-    /// Default no-op. Override for invariant checks that don't require precomputed
-    /// state (grid uniformity, direction-count matching, etc).
-    fn validate(&self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
-        Ok(())
-    }
-
-    /// Initialize/recompute cached derived state, with access to interpolation data.
-    ///
-    /// Default no-op. Override only when the strategy caches something derived from
-    /// `data` (e.g. precomputed spline coefficients). Unlike [`Strategy3D::validate`],
-    /// this may do real, non-trivial calculation.
-    fn init(&mut self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
-        Ok(())
-    }
-
-    /// Execute interpolation (after handling [`Extrapolate`](`crate::interpolator::Extrapolate`) setting).
-    ///
-    /// # Note for custom strategies
-    /// Index `data.grid[i]` directly via `ArrayView` indexing; avoid `.as_slice()`, which
-    /// panics on non-contiguous storage (possible with `Interp*Viewed`). See
-    /// [`crate::strategy::utils`] for ready-made per-axis search helpers (bracket search,
-    /// exact-match short-circuit, step-direction lookup, uniform-grid fast path) built from
-    /// the same primitives the built-in strategies use.
-    fn interpolate(
-        &self,
-        data: &InterpData3D<D>,
-        point: &[D::Elem; 3],
-    ) -> Result<D::Elem, InterpolateError>;
-
-    /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
-    /// already valid.
-    ///
-    /// Default just unwraps [`Strategy3D::interpolate`]. Override only if this
-    /// strategy's checked path does real internal fallible work beyond producing
-    /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
-    #[inline]
-    fn interpolate_fast(&self, data: &InterpData3D<D>, point: &[D::Elem; 3]) -> D::Elem {
-        self.interpolate(data, point)
-            .expect("interpolate_fast: invalid point or data")
-    }
-
-    /// Interpolate at each of several points, sharing one grid across all of them.
-    ///
-    /// Default just loops [`Strategy3D::interpolate`]. Override only if locating a
-    /// point in the grid can be amortized across the batch (e.g. sorting points once
-    /// for a locate sweep instead of one binary search per point); no strategy
-    /// shipped in this crate does that today.
-    fn batch_interpolate(
-        &self,
-        data: &InterpData3D<D>,
-        points: &[[D::Elem; 3]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
-        points
-            .iter()
-            .map(|point| self.interpolate(data, point))
-            .collect()
-    }
-
-    /// Batched [`Strategy3D::interpolate_fast`], assuming every point and `data` are
-    /// already valid.
-    ///
-    /// Default just loops [`Strategy3D::interpolate_fast`]. Override under the same
-    /// condition as [`Strategy3D::batch_interpolate`].
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpData3D<D>,
-        points: &[[D::Elem; 3]],
-    ) -> Vec<D::Elem> {
-        points
-            .iter()
-            .map(|point| self.interpolate_fast(data, point))
-            .collect()
-    }
-
-    /// Does this type's [`Strategy3D::interpolate`] provision for extrapolation?
-    fn allow_extrapolate(&self) -> bool;
-}
-
-clone_trait_object!(<D> Strategy3D<D>);
-
-impl<D> Strategy3D<D> for Box<dyn Strategy3D<D>>
-where
-    D: Data + RawDataClone + Clone,
-    D::Elem: PartialEq + Debug,
-{
-    #[inline]
-    fn validate(&self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
-        (**self).validate(data)
-    }
-
-    #[inline]
-    fn init(&mut self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
-        (**self).init(data)
-    }
-
-    #[inline]
-    fn interpolate(
-        &self,
-        data: &InterpData3D<D>,
-        point: &[D::Elem; 3],
-    ) -> Result<D::Elem, InterpolateError> {
-        (**self).interpolate(data, point)
-    }
-
-    #[inline]
-    fn interpolate_fast(&self, data: &InterpData3D<D>, point: &[D::Elem; 3]) -> D::Elem {
-        (**self).interpolate_fast(data, point)
-    }
-
-    #[inline]
-    fn batch_interpolate(
-        &self,
-        data: &InterpData3D<D>,
-        points: &[[D::Elem; 3]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
-        (**self).batch_interpolate(data, points)
-    }
-
-    #[inline]
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpData3D<D>,
-        points: &[[D::Elem; 3]],
-    ) -> Vec<D::Elem> {
-        (**self).batch_interpolate_fast(data, points)
-    }
-
-    #[inline]
-    fn allow_extrapolate(&self) -> bool {
-        (**self).allow_extrapolate()
-    }
-}
+sized_strategy_trait!(Strategy1D, InterpData1D, 1, "1-D interpolation strategy.");
+sized_strategy_trait!(Strategy2D, InterpData2D, 2, "2-D interpolation strategy.");
+sized_strategy_trait!(Strategy3D, InterpData3D, 3, "3-D interpolation strategy.");
 
 /// N-D interpolation strategy.
 pub trait StrategyND<D>: Debug + DynClone


### PR DESCRIPTION
# Macro-based boilerplate consolidation across 1D/2D/3D/ND interpolators

## Metrics

**886 lines removed** (1002 insertions - 1888 deletions)

| Module | Before | After | Delta |
|--------|--------|-------|-------|
| src/interpolator/mod.rs | 405 | 689 | +284 (macro defs) |
| src/strategy/traits.rs | 567 | 306 | **-261** |
| src/interpolator/one/mod.rs | 303 | 130 | **-173** |
| src/interpolator/two/mod.rs | 327 | 144 | **-183** |
| src/interpolator/three/mod.rs | 339 | 156 | **-183** |
| src/interpolator/n/mod.rs | 564 | 519 | **-45** |
| src/interpolator/enums.rs | 1131 | 841 | **-290** |

## Summary

Systematically reduced duplicated code across 1D/2D/3D/ND interpolator implementations by extracting high-boilerplate patterns into reusable declarative macros. Designed patterns for future compatibility with multiinterpolation support (issue #19).

## Changes by Category

### Strategy Trait Generation (`src/strategy/traits.rs`)
**-261 lines**

Created `sized_strategy_trait!` macro generating Strategy1D/2D/3D trait definitions and their `Box<dyn Trait>` forwarding impls, replacing hand-written trait boilerplate. StrategyND remains hand-written (takes `&[D::Elem]` vs `&[D::Elem; N]`).

### Strategy Enum Dispatch (`src/strategy/enums/`)
**+73 lines in mod.rs, -544 lines across variant modules (net -471)**

Added `strategy_enum_impl!` macro with parameterized variant list enabling per-dimensionality customization without macro refactoring. Consolidated ~80 lines of slice-to-array forwarding (`slice_to_array_forward!` macro) replacing boilerplate matches across interpolate/interpolate_fast/batch variants.

### Interpolator Module Macro Foundation (`src/interpolator/mod.rs`)
**+284 lines**

Added core macro library (200+ lines):
- `interpolate_impl!` - dimension-agnostic interpolation with extrapolation loop
- `set_strategy_*_impl!` - strategy update boilerplate (box/enum variants)
- `dyn_interpolator_impl!` - dynamic type erasing
- `interpolator_trait_impl!` - full Interpolator trait impl (inlined slice-to-array)
- `view_into_owned_impl!` - view/into_owned method pair generation
- High-level consolidators: `interp_trait_impls!`, `interp_inherent_methods!`

### Per-Dimensionality Interpolator Modules
**-173 to -183 lines per module (1D/2D/3D)**

Refactored each from multiple impl blocks with different bounds into single, focused impl blocks:
```rust
impl<D, S> Interp1D<D, S> where ... {
    pub fn new(...) { ... }  // hand-written
    interp_inherent_methods!(Interp1D, Strategy1D, Interp1DViewed<&D::Elem, S>, Interp1DOwned<D::Elem, S>);
}
interp_trait_impls!(Interp1D, Interp1DOwned, InterpData1D, Strategy1D, strategy::enums::Strategy1DEnum, N);
```

**Reduction summary:**
- Interp1D: 303 → 130 lines (-173)
- Interp2D: 327 → 144 lines (-183)
- Interp3D: 339 → 156 lines (-183)
- InterpND: 564 → 519 lines (-45, structural improvement)

### InterpolatorEnum Consolidation (`src/interpolator/enums.rs`)
**-290 lines net**

Eliminated match-arm boilerplate for high-frequency patterns:
- `enum_method_forward!()` - 3 calls (check_extrapolate, validate_strategy, init_strategy)
- `enum_method_wrap!()` - 2 calls (view, into_owned)
- `enum_trait_method!()` - 3 calls (ndim, validate, set_extrapolate)
- `slice_to_array_forward!()` - 4 calls (interpolate variants)

Kept once-called patterns unparameterized and inlined (From impls, PartialEq, SerializeNested) to avoid hiding single-use boilerplate behind macros.

## Design Decisions

### Macro ROI Threshold
Only macros called 2+ times or generating 50+ lines of boilerplate kept as macros. Once-called patterns inlined or left as-is for clarity.

### Parameterization for Multiinterp
All macros designed for future reuse with InterpolatorMultiEnum (issue #19):
- Variant list extraction to explicit macro parameters
- Trait method patterns isolated for per-type customization
- No hardcoded type names where dimensionality-specific logic applies

### Pure Function Extraction
Moved trait bounds from impl blocks to individual method where clauses where safe, enabling future strategies that may only implement specific methods for specific dimensionalities.

### Escape Hatch Methods
Validated `Interp0D validate()` and `set_extrapolate()` logic—kept hand-written because they either have unique documentation requirements, need special per-variant handling, or don't appear frequently enough to justify macro overhead.

### Single-call helper macros stay separate
Helper macros (`sized_interpolate_impl!`, `batch_interpolate_impl!`, etc.) called once each are kept separate from `interp_inherent_methods!` because they provide semantic organization by domain (interpolation, batch ops, fast paths, strategy access, view/owned conversion), not just space-saving. This keeps the grouper macro readable as a checklist while maintaining modularity.

## Testing

All 94 existing unit tests pass without modification. No behavior changes—macro consolidation is purely organizational.

## Compatibility with Issue #19

Macro patterns validated against multiinterpolation spec:
- Trait generation (`*_strategy_trait!`) scales from 3D traits to multi-channel variants
- Enum dispatch (`strategy_enum_impl!`) parameterized to accept per-type variant lists
- Interpolator method templates reusable across Interp*D and Interp*DMulti with minimal adaptation
- Forwarding patterns consistent across trait method generations, enabling copy-paste-adapt for new enum types

Future `InterpolatorMultiEnum` can either parameterize existing macros or create analogs following identical patterns.

Closes #18.
