### PR TITLE
Add allocation-free batch_interpolate_into/_fast_into variants (closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ Everything below is merged to `main` but not yet tagged/released.
   out-of-range point in one `ExtrapolateError`, not just the first one found.
 - `ExtrapolateError`'s message now reads "point(s)" instead of "point", since a batch
   error can name more than one offending point.
+- `batch_interpolate_into`/`batch_interpolate_fast_into` on `Interpolator<T>`,
+  `Strategy1D`/`2D`/`3D`/`ND`, `Interp1D`/`2D`/`3D`/`InterpND`, and `InterpolatorEnum`:
+  allocation-free batched interpolation that writes results into a caller-supplied output
+  slice. `batch_interpolate` and `batch_interpolate_fast` now defer to their `_into`
+  counterparts internally, so a strategy author who overrides `batch_interpolate_into`
+  for real batch amortization automatically gets that optimization in both paths (no
+  drift risk). New `InterpolateError::OutputLength` variant for length mismatches.
 - `interpolator::DynInterpolator<T>: Interpolator<T> + Send + Sync` (not in the
   `prelude`): a downcastable counterpart to `Interpolator<T>`, for storing
   heterogeneous interpolators behind `Box<dyn DynInterpolator<T>>` and recovering the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ Everything below is merged to `main` but not yet tagged/released.
   do on the concrete, unboxed type.
 
 ### Changed
+- **Breaking:** `InterpolateError` and `ValidateError` are now `#[non_exhaustive]`,
+  allowing new error variants to be added without breaking downstream exhaustive
+  matches. Any existing exhaustive `match` over one without a `_` arm now needs one.
 - **Breaking:** `Strategy1DEnum`/`Strategy2DEnum`/`Strategy3DEnum`/`StrategyNDEnum` are
   now `#[non_exhaustive]`, since every new built-in strategy adds a variant. Any
   existing exhaustive `match` over one without a `_` arm now needs one; construction

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 /// Error in interpolator data validation
 #[allow(missing_docs)]
 #[derive(Error, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ValidateError {
     #[error("selected `Extrapolate` variant ({0}) is unimplemented/inapplicable for interpolator")]
     InvalidExtrapolate(String),
@@ -28,6 +29,7 @@ impl fmt::Debug for ValidateError {
 /// Error in interpolation call
 #[allow(missing_docs)]
 #[derive(Error, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum InterpolateError {
     #[error("attempted to interpolate at point(s) beyond grid data: {0}")]
     ExtrapolateError(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,8 @@ pub enum InterpolateError {
     ExtrapolateError(String),
     #[error("supplied point slice should have length {0} for {0}-D interpolation")]
     PointLength(usize),
+    #[error("output slice has length {found}, expected {expected}")]
+    OutputLength { expected: usize, found: usize },
     #[error("{0}")]
     Other(String),
 }

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -263,7 +263,16 @@ macro_rules! slice_to_array_forward {
         ) -> Result<(), InterpolateError> {
             match self {
                 InterpolatorEnum::Interp0D(interp) => {
-                    Interpolator::batch_interpolate_into(interp, points, out)
+                    if out.len() != points.len() {
+                        return Err(InterpolateError::OutputLength {
+                            expected: points.len(),
+                            found: out.len(),
+                        });
+                    }
+                    for o in out.iter_mut() {
+                        *o = interp.0;
+                    }
+                    Ok(())
                 }
                 InterpolatorEnum::Interp1D(interp) => {
                     let points: Vec<[D::Elem; 1]> = points
@@ -306,7 +315,9 @@ macro_rules! slice_to_array_forward {
         fn batch_interpolate_fast_into(&self, points: &[&[D::Elem]], out: &mut [D::Elem]) {
             match self {
                 InterpolatorEnum::Interp0D(interp) => {
-                    Interpolator::batch_interpolate_fast_into(interp, points, out)
+                    for o in out.iter_mut() {
+                        *o = interp.0;
+                    }
                 }
                 InterpolatorEnum::Interp1D(interp) => {
                     let points: Vec<[D::Elem; 1]> = points

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -255,6 +255,98 @@ macro_rules! slice_to_array_forward {
             }
         }
     };
+    (batch_interpolate_into) => {
+        fn batch_interpolate_into(
+            &self,
+            points: &[&[D::Elem]],
+            out: &mut [D::Elem],
+        ) -> Result<(), InterpolateError> {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => {
+                    Interpolator::batch_interpolate_into(interp, points, out)
+                }
+                InterpolatorEnum::Interp1D(interp) => {
+                    let points: Vec<[D::Elem; 1]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .map_err(|_| InterpolateError::PointLength(1))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    interp.batch_interpolate_into(&points, out)
+                }
+                InterpolatorEnum::Interp2D(interp) => {
+                    let points: Vec<[D::Elem; 2]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .map_err(|_| InterpolateError::PointLength(2))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    interp.batch_interpolate_into(&points, out)
+                }
+                InterpolatorEnum::Interp3D(interp) => {
+                    let points: Vec<[D::Elem; 3]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .map_err(|_| InterpolateError::PointLength(3))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    interp.batch_interpolate_into(&points, out)
+                }
+                InterpolatorEnum::InterpND(interp) => interp.batch_interpolate_into(points, out),
+            }
+        }
+    };
+    (batch_interpolate_fast_into) => {
+        fn batch_interpolate_fast_into(&self, points: &[&[D::Elem]], out: &mut [D::Elem]) {
+            match self {
+                InterpolatorEnum::Interp0D(interp) => {
+                    Interpolator::batch_interpolate_fast_into(interp, points, out)
+                }
+                InterpolatorEnum::Interp1D(interp) => {
+                    let points: Vec<[D::Elem; 1]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .expect("batch_interpolate_fast_into: point length mismatch")
+                        })
+                        .collect();
+                    interp.batch_interpolate_fast_into(&points, out)
+                }
+                InterpolatorEnum::Interp2D(interp) => {
+                    let points: Vec<[D::Elem; 2]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .expect("batch_interpolate_fast_into: point length mismatch")
+                        })
+                        .collect();
+                    interp.batch_interpolate_fast_into(&points, out)
+                }
+                InterpolatorEnum::Interp3D(interp) => {
+                    let points: Vec<[D::Elem; 3]> = points
+                        .iter()
+                        .map(|&point| {
+                            point
+                                .try_into()
+                                .expect("batch_interpolate_fast_into: point length mismatch")
+                        })
+                        .collect();
+                    interp.batch_interpolate_fast_into(&points, out)
+                }
+                InterpolatorEnum::InterpND(interp) => {
+                    interp.batch_interpolate_fast_into(points, out)
+                }
+            }
+        }
+    };
 }
 
 /// This is an alternative to using a `Box<dyn Interpolator<_>>` with a few key differences:
@@ -534,6 +626,8 @@ where
     slice_to_array_forward!(interpolate_fast);
     slice_to_array_forward!(batch_interpolate);
     slice_to_array_forward!(batch_interpolate_fast);
+    slice_to_array_forward!(batch_interpolate_into);
+    slice_to_array_forward!(batch_interpolate_fast_into);
 }
 
 mod tests {

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -101,7 +101,7 @@ pub trait Interpolator<T>: DynClone {
     ///
     /// `self.extrapolate` is one setting for the whole call, not resolved per
     /// point. Default allocates an output buffer and calls [`Interpolator::batch_interpolate_into`];
-    /// `Interp1D`/`2D`/`3D`/`ND` override [`batch_interpolate_into`] to funnel every point into
+    /// `Interp1D`/`2D`/`3D`/`ND` override [`Self::batch_interpolate_into`] to funnel every point into
     /// at most one call to the strategy instead. Do not override this method.
     fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError>
     where
@@ -119,7 +119,7 @@ pub trait Interpolator<T>: DynClone {
     /// valid.
     ///
     /// Default allocates an output buffer and calls [`Interpolator::batch_interpolate_fast_into`].
-    /// `Interp1D`/`2D`/`3D`/`ND` override [`batch_interpolate_fast_into`] instead. Do not override this method.
+    /// `Interp1D`/`2D`/`3D`/`ND` override [`Self::batch_interpolate_fast_into`] instead. Do not override this method.
     fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T>
     where
         T: Num + Copy,

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -54,26 +54,82 @@ pub trait Interpolator<T>: DynClone {
             .expect("interpolate_fast: invalid point or data")
     }
 
+    /// Interpolate at each of several points, writing results into `out` instead of
+    /// allocating. `out.len()` must equal `points.len()`.
+    ///
+    /// `self.extrapolate` is one setting for the whole call, not resolved per
+    /// point. Default just loops [`Interpolator::interpolate`] into `out`;
+    /// `Interp1D`/`2D`/`3D`/`ND` override this to funnel every point into at most
+    /// one call to the strategy instead.
+    fn batch_interpolate_into(
+        &self,
+        points: &[&[T]],
+        out: &mut [T],
+    ) -> Result<(), InterpolateError> {
+        if out.len() != points.len() {
+            return Err(InterpolateError::OutputLength {
+                expected: points.len(),
+                found: out.len(),
+            });
+        }
+        for (o, point) in out.iter_mut().zip(points) {
+            *o = self.interpolate(point)?;
+        }
+        Ok(())
+    }
+
+    /// Unchecked [`Interpolator::batch_interpolate_into`], assuming every point is valid.
+    ///
+    /// Default loops [`Interpolator::interpolate_fast`] into `out`, panicking on
+    /// length mismatch. `Interp1D`/`2D`/`3D`/`ND` override this the same way as
+    /// [`Interpolator::batch_interpolate_into`].
+    ///
+    /// # Panics
+    /// Panics if `out.len() != points.len()`.
+    fn batch_interpolate_fast_into(&self, points: &[&[T]], out: &mut [T]) {
+        assert_eq!(
+            out.len(),
+            points.len(),
+            "batch_interpolate_fast_into: length mismatch"
+        );
+        for (o, point) in out.iter_mut().zip(points) {
+            *o = self.interpolate_fast(point);
+        }
+    }
+
     /// Interpolate at each of several points, sharing one grid across all of them.
     ///
     /// `self.extrapolate` is one setting for the whole call, not resolved per
-    /// point. Default just loops [`Interpolator::interpolate`]; `Interp1D`/`2D`/
-    /// `3D`/`ND` override this to funnel every point into at most one call to the
+    /// point. Default allocates an output buffer and calls [`Interpolator::batch_interpolate_into`];
+    /// `Interp1D`/`2D`/`3D`/`ND` override this to funnel every point into at most one call to the
     /// strategy instead.
-    fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError> {
-        points.iter().map(|point| self.interpolate(point)).collect()
+    fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError>
+    where
+        T: Num,
+    {
+        let mut out = Vec::with_capacity(points.len());
+        for _ in 0..points.len() {
+            out.push(T::zero());
+        }
+        self.batch_interpolate_into(points, &mut out)?;
+        Ok(out)
     }
 
     /// Batched [`Interpolator::interpolate_fast`], assuming every point is already
     /// valid.
     ///
-    /// Default just loops [`Interpolator::interpolate_fast`]. `Interp1D`/`2D`/`3D`/
-    /// `ND` override this the same way as [`Interpolator::batch_interpolate`].
-    fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T> {
-        points
-            .iter()
-            .map(|point| self.interpolate_fast(point))
-            .collect()
+    /// Default allocates an output buffer and calls [`Interpolator::batch_interpolate_fast_into`].
+    /// `Interp1D`/`2D`/`3D`/`ND` override this the same way as [`Interpolator::batch_interpolate`].
+    fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T>
+    where
+        T: Num + Copy,
+    {
+        let mut out = Vec::with_capacity(points.len());
+        for _ in 0..points.len() {
+            out.push(T::zero());
+        }
+        self.batch_interpolate_fast_into(points, &mut out);
+        out
     }
 }
 
@@ -95,10 +151,26 @@ impl<T> Interpolator<T> for Box<dyn Interpolator<T>> {
     fn interpolate_fast(&self, point: &[T]) -> T {
         (**self).interpolate_fast(point)
     }
-    fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError> {
+    fn batch_interpolate_into(
+        &self,
+        points: &[&[T]],
+        out: &mut [T],
+    ) -> Result<(), InterpolateError> {
+        (**self).batch_interpolate_into(points, out)
+    }
+    fn batch_interpolate_fast_into(&self, points: &[&[T]], out: &mut [T]) {
+        (**self).batch_interpolate_fast_into(points, out)
+    }
+    fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError>
+    where
+        T: Num,
+    {
         (**self).batch_interpolate(points)
     }
-    fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T> {
+    fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T>
+    where
+        T: Num + Copy,
+    {
         (**self).batch_interpolate_fast(points)
     }
 }
@@ -246,28 +318,42 @@ where
         .any(|(axis, coord)| !(axis.first().unwrap()..=axis.last().unwrap()).contains(&coord))
 }
 
-/// Generates the inherent `batch_interpolate` shared by `Interp1D`/`2D`/`3D`:
+/// Generates the inherent `batch_interpolate_into` shared by `Interp1D`/`2D`/`3D`:
 /// resolves `self.extrapolate` once for the whole batch (see the extrapolate-mode
 /// partitioning table in issue #21), then funnels every point into at most one call
-/// to the strategy, rather than calling the existing hand-written `interpolate` once
-/// per point.
-macro_rules! batch_interpolate_impl {
+/// to the strategy, writing results into the provided output slice rather than
+/// allocating a Vec.
+macro_rules! batch_interpolate_into_impl {
     () => {
-        /// Interpolate at each of several points, sharing one grid across all of
-        /// them.
+        /// Interpolate at each of several points, writing results into `out` instead of
+        /// allocating.
         ///
         /// `self.extrapolate` is one setting for the whole call, not resolved per
         /// point: every point still funnels into at most one call to the strategy,
         /// rather than calling [`Self::interpolate`] once per point.
-        pub fn batch_interpolate(
+        ///
+        /// # Errors
+        /// Returns [`InterpolateError::OutputLength`] if `out.len() != points.len()`.
+        /// Returns other interpolation errors from the strategy or extrapolation check.
+        pub fn batch_interpolate_into(
             &self,
             points: &[[D::Elem; N]],
-        ) -> Result<Vec<D::Elem>, InterpolateError>
+            out: &mut [D::Elem],
+        ) -> Result<(), InterpolateError>
         where
             D::Elem: Num + PartialOrd + Euclid + Copy,
         {
+            if out.len() != points.len() {
+                return Err(InterpolateError::OutputLength {
+                    expected: points.len(),
+                    found: out.len(),
+                });
+            }
             match &self.extrapolate {
-                Extrapolate::Enable => self.strategy.batch_interpolate(&self.data, points),
+                Extrapolate::Enable => {
+                    self.strategy.batch_interpolate_into(&self.data, points, out)?;
+                    Ok(())
+                }
                 Extrapolate::Clamp => {
                     // Clamping an in-bounds point is already identity, so every point
                     // can be clamped unconditionally.
@@ -283,7 +369,8 @@ macro_rules! batch_interpolate_impl {
                             })
                         })
                         .collect();
-                    self.strategy.batch_interpolate(&self.data, &clamped)
+                    self.strategy.batch_interpolate_into(&self.data, &clamped, out)?;
+                    Ok(())
                 }
                 Extrapolate::Wrap => {
                     // Unlike `Clamp`, `wrap()` isn't identity exactly at the
@@ -304,10 +391,15 @@ macro_rules! batch_interpolate_impl {
                             }
                         })
                         .collect();
-                    self.strategy.batch_interpolate(&self.data, &wrapped)
+                    self.strategy.batch_interpolate_into(&self.data, &wrapped, out)?;
+                    Ok(())
                 }
                 Extrapolate::Fill(value) => {
-                    let mut results = vec![*value; points.len()];
+                    // Pre-fill output with the fill value, then scatter interpolated
+                    // results from in-bounds points into their corresponding indices.
+                    for o in out.iter_mut() {
+                        *o = *value;
+                    }
                     let (in_bounds_indices, in_bounds_points): (Vec<usize>, Vec<[D::Elem; N]>) =
                         points
                             .iter()
@@ -315,15 +407,18 @@ macro_rules! batch_interpolate_impl {
                             .filter(|(_, point)| !out_of_bounds(&self.data.grid, *point))
                             .map(|(i, point)| (i, *point))
                             .unzip();
-                    let interpolated =
-                        self.strategy.batch_interpolate(&self.data, &in_bounds_points)?;
-                    for (i, value) in in_bounds_indices.into_iter().zip(interpolated) {
-                        results[i] = value;
+                    if !in_bounds_indices.is_empty() {
+                        let mut scratch = vec![D::Elem::zero(); in_bounds_indices.len()];
+                        self.strategy.batch_interpolate_into(&self.data, &in_bounds_points, &mut scratch)?;
+                        for (idx, value) in in_bounds_indices.into_iter().zip(scratch) {
+                            out[idx] = value;
+                        }
                     }
-                    Ok(results)
+                    Ok(())
                 }
                 Extrapolate::Error => {
                     let mut errors = Vec::new();
+                    let mut in_bounds_indices = Vec::new();
                     let mut in_bounds_points = Vec::new();
                     for (i, point) in points.iter().enumerate() {
                         let mut point_errors = Vec::new();
@@ -339,6 +434,7 @@ macro_rules! batch_interpolate_impl {
                             }
                         }
                         if point_errors.is_empty() {
+                            in_bounds_indices.push(i);
                             in_bounds_points.push(*point);
                         } else {
                             errors.extend(point_errors);
@@ -347,9 +443,37 @@ macro_rules! batch_interpolate_impl {
                     if !errors.is_empty() {
                         return Err(InterpolateError::ExtrapolateError(errors.join("")));
                     }
-                    self.strategy.batch_interpolate(&self.data, &in_bounds_points)
+                    if !in_bounds_indices.is_empty() {
+                        self.strategy.batch_interpolate_into(&self.data, &in_bounds_points, &mut out[0..in_bounds_points.len()])?;
+                    }
+                    Ok(())
                 }
             }
+        }
+    };
+}
+pub(crate) use batch_interpolate_into_impl;
+
+/// Generates the inherent `batch_interpolate` shared by `Interp1D`/`2D`/`3D`:
+/// allocates an output buffer and delegates to [`batch_interpolate_into`].
+macro_rules! batch_interpolate_impl {
+    () => {
+        /// Interpolate at each of several points, sharing one grid across all of
+        /// them.
+        ///
+        /// `self.extrapolate` is one setting for the whole call, not resolved per
+        /// point: every point still funnels into at most one call to the strategy,
+        /// rather than calling [`Self::interpolate`] once per point.
+        pub fn batch_interpolate(
+            &self,
+            points: &[[D::Elem; N]],
+        ) -> Result<Vec<D::Elem>, InterpolateError>
+        where
+            D::Elem: Num + PartialOrd + Euclid + Copy,
+        {
+            let mut out = vec![D::Elem::zero(); points.len()];
+            self.batch_interpolate_into(points, &mut out)?;
+            Ok(out)
         }
     };
 }
@@ -512,6 +636,33 @@ macro_rules! interpolator_trait_impl {
                 self.interpolate_fast(point)
             }
 
+            fn batch_interpolate_into(
+                &self,
+                points: &[&[D::Elem]],
+                out: &mut [D::Elem],
+            ) -> Result<(), InterpolateError> {
+                let points: Vec<[D::Elem; N]> = points
+                    .iter()
+                    .map(|&point| {
+                        <&[D::Elem; N]>::try_from(point)
+                            .map(|arr| *arr)
+                            .map_err(|_| InterpolateError::PointLength(N))
+                    })
+                    .collect::<Result<_, _>>()?;
+                self.batch_interpolate_into(&points, out)
+            }
+
+            fn batch_interpolate_fast_into(&self, points: &[&[D::Elem]], out: &mut [D::Elem]) {
+                let points: Vec<[D::Elem; N]> = points
+                    .iter()
+                    .map(|&point| {
+                        *<&[D::Elem; N]>::try_from(point)
+                            .expect("batch_interpolate_fast_into: point length mismatch")
+                    })
+                    .collect();
+                self.batch_interpolate_fast_into(&points, out)
+            }
+
             fn batch_interpolate(
                 &self,
                 points: &[&[D::Elem]],
@@ -663,12 +814,35 @@ macro_rules! interp_inherent_methods {
         pub fn interpolate_fast(&self, point: &[D::Elem; N]) -> D::Elem {
             self.strategy.interpolate_fast(&self.data, point)
         }
+        batch_interpolate_into_impl!();
         batch_interpolate_impl!();
+        /// Unchecked batched [`Self::interpolate_fast`], assuming every point is valid
+        /// and `out.len() == points.len()`.
+        ///
+        /// # Panics
+        /// Panics if `out.len() != points.len()`.
+        pub fn batch_interpolate_fast_into(&self, points: &[[D::Elem; N]], out: &mut [D::Elem]) {
+            assert_eq!(
+                out.len(),
+                points.len(),
+                "batch_interpolate_fast_into: length mismatch"
+            );
+            self.strategy
+                .batch_interpolate_fast_into(&self.data, points, out)
+        }
         /// Batched [`Self::interpolate_fast`], for use in hot loops where the caller
         /// has already checked bounds or knows that extrapolation handling is not
         /// needed.
-        pub fn batch_interpolate_fast(&self, points: &[[D::Elem; N]]) -> Vec<D::Elem> {
-            self.strategy.batch_interpolate_fast(&self.data, points)
+        pub fn batch_interpolate_fast(&self, points: &[[D::Elem; N]]) -> Vec<D::Elem>
+        where
+            D::Elem: Num + Copy,
+        {
+            let mut out = Vec::with_capacity(points.len());
+            for _ in 0..points.len() {
+                out.push(D::Elem::zero());
+            }
+            self.batch_interpolate_fast_into(points, &mut out);
+            out
         }
         strategy_accessors_impl!($Strategy);
         view_into_owned_impl!($InterpType, $Strategy, $Viewed, $Owned);

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -101,8 +101,8 @@ pub trait Interpolator<T>: DynClone {
     ///
     /// `self.extrapolate` is one setting for the whole call, not resolved per
     /// point. Default allocates an output buffer and calls [`Interpolator::batch_interpolate_into`];
-    /// `Interp1D`/`2D`/`3D`/`ND` override this to funnel every point into at most one call to the
-    /// strategy instead.
+    /// `Interp1D`/`2D`/`3D`/`ND` override [`batch_interpolate_into`] to funnel every point into
+    /// at most one call to the strategy instead. Do not override this method.
     fn batch_interpolate(&self, points: &[&[T]]) -> Result<Vec<T>, InterpolateError>
     where
         T: Num,
@@ -119,7 +119,7 @@ pub trait Interpolator<T>: DynClone {
     /// valid.
     ///
     /// Default allocates an output buffer and calls [`Interpolator::batch_interpolate_fast_into`].
-    /// `Interp1D`/`2D`/`3D`/`ND` override this the same way as [`Interpolator::batch_interpolate`].
+    /// `Interp1D`/`2D`/`3D`/`ND` override [`batch_interpolate_fast_into`] instead. Do not override this method.
     fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T>
     where
         T: Num + Copy,
@@ -461,9 +461,10 @@ macro_rules! batch_interpolate_impl {
         /// Interpolate at each of several points, sharing one grid across all of
         /// them.
         ///
-        /// `self.extrapolate` is one setting for the whole call, not resolved per
-        /// point: every point still funnels into at most one call to the strategy,
-        /// rather than calling [`Self::interpolate`] once per point.
+        /// Allocates an output buffer and calls [`Self::batch_interpolate_into`],
+        /// which handles `self.extrapolate` resolution and funnels every point into
+        /// at most one call to the strategy rather than calling [`Self::interpolate`]
+        /// once per point.
         pub fn batch_interpolate(
             &self,
             points: &[[D::Elem; N]],
@@ -831,8 +832,8 @@ macro_rules! interp_inherent_methods {
                 .batch_interpolate_fast_into(&self.data, points, out)
         }
         /// Batched [`Self::interpolate_fast`], for use in hot loops where the caller
-        /// has already checked bounds or knows that extrapolation handling is not
-        /// needed.
+        /// has already checked bounds. Allocates an output buffer and calls
+        /// [`Self::batch_interpolate_fast_into`].
         pub fn batch_interpolate_fast(&self, points: &[[D::Elem; N]]) -> Vec<D::Elem>
         where
             D::Elem: Num + Copy,

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -119,7 +119,8 @@ pub trait Interpolator<T>: DynClone {
     /// valid.
     ///
     /// Default allocates an output buffer and calls [`Interpolator::batch_interpolate_fast_into`].
-    /// `Interp1D`/`2D`/`3D`/`ND` override [`Self::batch_interpolate_fast_into`] instead. Do not override this method.
+    /// Do not override this method. If you need to amortize work across the batch, override
+    /// [`Self::batch_interpolate_into`] instead; the fast variant is rarely optimized.
     fn batch_interpolate_fast(&self, points: &[&[T]]) -> Vec<T>
     where
         T: Num + Copy,
@@ -350,10 +351,7 @@ macro_rules! batch_interpolate_into_impl {
                 });
             }
             match &self.extrapolate {
-                Extrapolate::Enable => {
-                    self.strategy.batch_interpolate_into(&self.data, points, out)?;
-                    Ok(())
-                }
+                Extrapolate::Enable => self.strategy.batch_interpolate_into(&self.data, points, out),
                 Extrapolate::Clamp => {
                     // Clamping an in-bounds point is already identity, so every point
                     // can be clamped unconditionally.
@@ -369,8 +367,7 @@ macro_rules! batch_interpolate_into_impl {
                             })
                         })
                         .collect();
-                    self.strategy.batch_interpolate_into(&self.data, &clamped, out)?;
-                    Ok(())
+                    self.strategy.batch_interpolate_into(&self.data, &clamped, out)
                 }
                 Extrapolate::Wrap => {
                     // Unlike `Clamp`, `wrap()` isn't identity exactly at the
@@ -391,8 +388,7 @@ macro_rules! batch_interpolate_into_impl {
                             }
                         })
                         .collect();
-                    self.strategy.batch_interpolate_into(&self.data, &wrapped, out)?;
-                    Ok(())
+                    self.strategy.batch_interpolate_into(&self.data, &wrapped, out)
                 }
                 Extrapolate::Fill(value) => {
                     // Pre-fill output with the fill value, then scatter interpolated
@@ -418,7 +414,6 @@ macro_rules! batch_interpolate_into_impl {
                 }
                 Extrapolate::Error => {
                     let mut errors = Vec::new();
-                    let mut in_bounds_indices = Vec::new();
                     let mut in_bounds_points = Vec::new();
                     for (i, point) in points.iter().enumerate() {
                         let mut point_errors = Vec::new();
@@ -434,7 +429,6 @@ macro_rules! batch_interpolate_into_impl {
                             }
                         }
                         if point_errors.is_empty() {
-                            in_bounds_indices.push(i);
                             in_bounds_points.push(*point);
                         } else {
                             errors.extend(point_errors);
@@ -443,10 +437,7 @@ macro_rules! batch_interpolate_into_impl {
                     if !errors.is_empty() {
                         return Err(InterpolateError::ExtrapolateError(errors.join("")));
                     }
-                    if !in_bounds_indices.is_empty() {
-                        self.strategy.batch_interpolate_into(&self.data, &in_bounds_points, &mut out[0..in_bounds_points.len()])?;
-                    }
-                    Ok(())
+                    self.strategy.batch_interpolate_into(&self.data, &in_bounds_points, out)
                 }
             }
         }

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -397,15 +397,29 @@ where
         self.strategy.interpolate_fast(&self.data, point)
     }
 
-    fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
+    fn batch_interpolate_into(
+        &self,
+        points: &[&[D::Elem]],
+        out: &mut [D::Elem],
+    ) -> Result<(), InterpolateError> {
         let n = self.ndim();
         for point in points {
             if point.len() != n {
                 return Err(InterpolateError::PointLength(n));
             }
         }
+        if out.len() != points.len() {
+            return Err(InterpolateError::OutputLength {
+                expected: points.len(),
+                found: out.len(),
+            });
+        }
         match &self.extrapolate {
-            Extrapolate::Enable => self.strategy.batch_interpolate(&self.data, points),
+            Extrapolate::Enable => {
+                self.strategy
+                    .batch_interpolate_into(&self.data, points, out)?;
+                Ok(())
+            }
             Extrapolate::Clamp => {
                 // Clamping an in-bounds point is already identity, so every point
                 // can be clamped unconditionally.
@@ -426,7 +440,9 @@ where
                     })
                     .collect();
                 let clamped: Vec<&[D::Elem]> = clamped.iter().map(Vec::as_slice).collect();
-                self.strategy.batch_interpolate(&self.data, &clamped)
+                self.strategy
+                    .batch_interpolate_into(&self.data, &clamped, out)?;
+                Ok(())
             }
             Extrapolate::Wrap => {
                 // Unlike `Clamp`, `wrap()` isn't identity exactly at the boundary,
@@ -452,10 +468,16 @@ where
                     })
                     .collect();
                 let wrapped: Vec<&[D::Elem]> = wrapped.iter().map(Vec::as_slice).collect();
-                self.strategy.batch_interpolate(&self.data, &wrapped)
+                self.strategy
+                    .batch_interpolate_into(&self.data, &wrapped, out)?;
+                Ok(())
             }
             Extrapolate::Fill(value) => {
-                let mut results = vec![*value; points.len()];
+                // Pre-fill output with the fill value, then scatter interpolated
+                // results from in-bounds points into their corresponding indices.
+                for o in out.iter_mut() {
+                    *o = *value;
+                }
                 let mut in_bounds_indices = Vec::new();
                 let mut in_bounds_points: Vec<&[D::Elem]> = Vec::new();
                 for (i, &point) in points.iter().enumerate() {
@@ -464,16 +486,22 @@ where
                         in_bounds_points.push(point);
                     }
                 }
-                let interpolated = self
-                    .strategy
-                    .batch_interpolate(&self.data, &in_bounds_points)?;
-                for (i, value) in in_bounds_indices.into_iter().zip(interpolated) {
-                    results[i] = value;
+                if !in_bounds_indices.is_empty() {
+                    let mut scratch = vec![D::Elem::zero(); in_bounds_indices.len()];
+                    self.strategy.batch_interpolate_into(
+                        &self.data,
+                        &in_bounds_points,
+                        &mut scratch,
+                    )?;
+                    for (idx, value) in in_bounds_indices.into_iter().zip(scratch) {
+                        out[idx] = value;
+                    }
                 }
-                Ok(results)
+                Ok(())
             }
             Extrapolate::Error => {
                 let mut errors = Vec::new();
+                let mut in_bounds_indices = Vec::new();
                 let mut in_bounds_points: Vec<&[D::Elem]> = Vec::new();
                 for (i, &point) in points.iter().enumerate() {
                     let mut point_errors = Vec::new();
@@ -486,6 +514,7 @@ where
                         }
                     }
                     if point_errors.is_empty() {
+                        in_bounds_indices.push(i);
                         in_bounds_points.push(point);
                     } else {
                         errors.extend(point_errors);
@@ -494,10 +523,49 @@ where
                 if !errors.is_empty() {
                     return Err(InterpolateError::ExtrapolateError(errors.join("")));
                 }
-                self.strategy
-                    .batch_interpolate(&self.data, &in_bounds_points)
+                if !in_bounds_indices.is_empty() {
+                    self.strategy.batch_interpolate_into(
+                        &self.data,
+                        &in_bounds_points,
+                        &mut out[0..in_bounds_points.len()],
+                    )?;
+                }
+                Ok(())
             }
         }
+    }
+
+    fn batch_interpolate_fast_into(&self, points: &[&[D::Elem]], out: &mut [D::Elem]) {
+        let n = self.ndim();
+        for point in points {
+            assert_eq!(
+                point.len(),
+                n,
+                "batch_interpolate_fast_into: point length mismatch"
+            );
+        }
+        assert_eq!(
+            out.len(),
+            points.len(),
+            "batch_interpolate_fast_into: length mismatch"
+        );
+        self.strategy
+            .batch_interpolate_fast_into(&self.data, points, out)
+    }
+
+    fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
+        let n = self.ndim();
+        for point in points {
+            if point.len() != n {
+                return Err(InterpolateError::PointLength(n));
+            }
+        }
+        let mut out = Vec::with_capacity(points.len());
+        for _ in 0..points.len() {
+            out.push(D::Elem::zero());
+        }
+        self.batch_interpolate_into(points, &mut out)?;
+        Ok(out)
     }
 
     fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
@@ -509,7 +577,12 @@ where
                 "batch_interpolate_fast: point length mismatch"
             );
         }
-        self.strategy.batch_interpolate_fast(&self.data, points)
+        let mut out = Vec::with_capacity(points.len());
+        for _ in 0..points.len() {
+            out.push(D::Elem::zero());
+        }
+        self.batch_interpolate_fast_into(points, &mut out);
+        out
     }
 }
 

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -415,11 +415,9 @@ where
             });
         }
         match &self.extrapolate {
-            Extrapolate::Enable => {
-                self.strategy
-                    .batch_interpolate_into(&self.data, points, out)?;
-                Ok(())
-            }
+            Extrapolate::Enable => self
+                .strategy
+                .batch_interpolate_into(&self.data, points, out),
             Extrapolate::Clamp => {
                 // Clamping an in-bounds point is already identity, so every point
                 // can be clamped unconditionally.
@@ -441,8 +439,7 @@ where
                     .collect();
                 let clamped: Vec<&[D::Elem]> = clamped.iter().map(Vec::as_slice).collect();
                 self.strategy
-                    .batch_interpolate_into(&self.data, &clamped, out)?;
-                Ok(())
+                    .batch_interpolate_into(&self.data, &clamped, out)
             }
             Extrapolate::Wrap => {
                 // Unlike `Clamp`, `wrap()` isn't identity exactly at the boundary,
@@ -469,8 +466,7 @@ where
                     .collect();
                 let wrapped: Vec<&[D::Elem]> = wrapped.iter().map(Vec::as_slice).collect();
                 self.strategy
-                    .batch_interpolate_into(&self.data, &wrapped, out)?;
-                Ok(())
+                    .batch_interpolate_into(&self.data, &wrapped, out)
             }
             Extrapolate::Fill(value) => {
                 // Pre-fill output with the fill value, then scatter interpolated
@@ -501,7 +497,6 @@ where
             }
             Extrapolate::Error => {
                 let mut errors = Vec::new();
-                let mut in_bounds_indices = Vec::new();
                 let mut in_bounds_points: Vec<&[D::Elem]> = Vec::new();
                 for (i, &point) in points.iter().enumerate() {
                     let mut point_errors = Vec::new();
@@ -514,7 +509,6 @@ where
                         }
                     }
                     if point_errors.is_empty() {
-                        in_bounds_indices.push(i);
                         in_bounds_points.push(point);
                     } else {
                         errors.extend(point_errors);
@@ -523,14 +517,8 @@ where
                 if !errors.is_empty() {
                     return Err(InterpolateError::ExtrapolateError(errors.join("")));
                 }
-                if !in_bounds_indices.is_empty() {
-                    self.strategy.batch_interpolate_into(
-                        &self.data,
-                        &in_bounds_points,
-                        &mut out[0..in_bounds_points.len()],
-                    )?;
-                }
-                Ok(())
+                self.strategy
+                    .batch_interpolate_into(&self.data, &in_bounds_points, out)
             }
         }
     }
@@ -553,22 +541,10 @@ where
             .batch_interpolate_fast_into(&self.data, points, out)
     }
 
-    fn batch_interpolate(&self, points: &[&[D::Elem]]) -> Result<Vec<D::Elem>, InterpolateError> {
-        let n = self.ndim();
-        for point in points {
-            if point.len() != n {
-                return Err(InterpolateError::PointLength(n));
-            }
-        }
-        let mut out = Vec::with_capacity(points.len());
-        for _ in 0..points.len() {
-            out.push(D::Elem::zero());
-        }
-        self.batch_interpolate_into(points, &mut out)?;
-        Ok(out)
-    }
-
-    fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
+    fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem>
+    where
+        D::Elem: Num + Copy,
+    {
         let n = self.ndim();
         for point in points {
             assert_eq!(
@@ -577,10 +553,7 @@ where
                 "batch_interpolate_fast: point length mismatch"
             );
         }
-        let mut out = Vec::with_capacity(points.len());
-        for _ in 0..points.len() {
-            out.push(D::Elem::zero());
-        }
+        let mut out = vec![D::Elem::zero(); points.len()];
         self.batch_interpolate_fast_into(points, &mut out);
         out
     }

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -460,6 +460,158 @@ fn test_dyn_interpolator() {
 }
 
 #[test]
+fn test_batch_interpolate_into_matches_interpolate() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let points = [[0.075, 0.25], [0.05, 0.10]];
+    let batched = interp.batch_interpolate(&points).unwrap();
+    let mut out = vec![0.0; points.len()];
+    interp.batch_interpolate_into(&points, &mut out).unwrap();
+    assert_eq!(out, batched);
+}
+
+#[test]
+fn test_batch_interpolate_into_output_length_error() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let mut out = vec![0.0; 1];
+    assert!(matches!(
+        interp.batch_interpolate_into(&[[0.075, 0.25], [0.05, 0.10]], &mut out),
+        Err(InterpolateError::OutputLength {
+            expected: 2,
+            found: 1
+        })
+    ));
+}
+
+#[test]
+fn test_batch_interpolate_fast_into_matches_interpolate() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let batched_fast = interp.batch_interpolate_fast(&[[0.075, 0.25], [0.05, 0.10]]);
+    let mut out = vec![0.0; 2];
+    interp.batch_interpolate_fast_into(&[[0.075, 0.25], [0.05, 0.10]], &mut out);
+    assert_eq!(out, batched_fast);
+}
+
+#[test]
+#[should_panic(expected = "batch_interpolate_fast_into: length mismatch")]
+fn test_batch_interpolate_fast_into_length_mismatch() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let mut out = vec![0.0; 1];
+    interp.batch_interpolate_fast_into(&[[0.075, 0.25], [0.05, 0.10]], &mut out);
+}
+
+#[test]
+fn test_batch_interpolate_into_clamp() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Clamp,
+    )
+    .unwrap();
+    let batched = interp.batch_interpolate(&[[-1., -1.], [2., 2.]]).unwrap();
+    let mut out = vec![0.0; 2];
+    interp
+        .batch_interpolate_into(&[[-1., -1.], [2., 2.]], &mut out)
+        .unwrap();
+    assert_eq!(out, batched);
+}
+
+#[test]
+fn test_batch_interpolate_into_fill() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Fill(99.0),
+    )
+    .unwrap();
+    let mut out = vec![0.0; 3];
+    interp
+        .batch_interpolate_into(&[[0.075, 0.25], [-1., -1.], [0.05, 0.10]], &mut out)
+        .unwrap();
+    assert_eq!(out[0], 3.0); // in-bounds
+    assert_eq!(out[1], 99.0); // out-of-bounds, filled
+    assert_eq!(out[2], 0.0); // in-bounds
+}
+
+#[test]
+fn test_batch_interpolate_into_error_aggregates_all_points() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let mut out = vec![0.0; 3];
+    let err = interp
+        .batch_interpolate_into(&[[0.5, 0.5], [-1., -1.], [2., 2.]], &mut out)
+        .unwrap_err();
+    match err {
+        InterpolateError::ExtrapolateError(s) => {
+            // Should mention all out-of-bounds points
+            assert!(s.contains("point[1]"));
+            assert!(s.contains("point[2]"));
+        }
+        _ => panic!("Expected ExtrapolateError"),
+    }
+}
+
+#[test]
+fn test_batch_interpolate_into_dyn() {
+    let interp = Interp2D::new(
+        array![0.05, 0.10, 0.15],
+        array![0.10, 0.20, 0.30],
+        array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
+        strategy::Linear,
+        Extrapolate::Error,
+    )
+    .unwrap();
+    let boxed: Box<dyn Interpolator<_>> = Box::new(interp.clone());
+    let points: [&[f64]; 2] = [&[0.075, 0.25], &[0.05, 0.10]];
+    let batched = boxed.batch_interpolate(&points).unwrap();
+    let mut out = vec![0.0; points.len()];
+    boxed.batch_interpolate_into(&points, &mut out).unwrap();
+    assert_eq!(out, batched);
+
+    let mut out_fast = vec![0.0; points.len()];
+    boxed.batch_interpolate_fast_into(&points, &mut out_fast);
+    let batched_fast = boxed.batch_interpolate_fast(&points);
+    assert_eq!(out_fast, batched_fast);
+}
+
+#[test]
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -135,7 +135,9 @@ macro_rules! sized_strategy_trait {
                 " already valid.\n",
                 "\n",
                 " Default allocates an output buffer and calls [`", stringify!($Trait), "::batch_interpolate_fast_into`].\n",
-                " Do not override this method; override [`", stringify!($Trait), "::batch_interpolate_fast_into`] instead.",
+                " Do not override this method. Override [`", stringify!($Trait), "::batch_interpolate_into`] instead\n",
+                " if you need to amortize per-point work; the fast variant inherits those optimizations with no\n",
+                " additional override needed.",
             )]
             fn batch_interpolate_fast(
                 &self,
@@ -367,7 +369,9 @@ where
     /// already valid.
     ///
     /// Default allocates an output buffer and calls [`StrategyND::batch_interpolate_fast_into`].
-    /// Do not override this method; override [`StrategyND::batch_interpolate_fast_into`] instead.
+    /// Do not override this method. Override [`StrategyND::batch_interpolate_into`] instead
+    /// if you need to amortize per-point work; the fast variant inherits those optimizations
+    /// with no additional override needed.
     fn batch_interpolate_fast(&self, data: &InterpDataND<D>, points: &[&[D::Elem]]) -> Vec<D::Elem>
     where
         D::Elem: Num + Copy,

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -61,40 +61,96 @@ macro_rules! sized_strategy_trait {
             }
 
             #[doc = concat!(
+                " Interpolate at each of several points, writing results into `out` instead of\n",
+                " allocating. `out.len()` must equal `points.len()`.\n",
+                "\n",
+                " Default loops [`", stringify!($Trait), "::interpolate`] into `out`; no allocation. Override\n",
+                " only if locating a point in the grid can be amortized across the batch (e.g. sorting\n",
+                " points once for a locate sweep instead of one binary search per point); no strategy\n",
+                " shipped in this crate does that today.",
+            )]
+            fn batch_interpolate_into(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+                out: &mut [D::Elem],
+            ) -> Result<(), InterpolateError> {
+                if out.len() != points.len() {
+                    return Err(InterpolateError::OutputLength {
+                        expected: points.len(),
+                        found: out.len(),
+                    });
+                }
+                for (o, point) in out.iter_mut().zip(points) {
+                    *o = self.interpolate(data, point)?;
+                }
+                Ok(())
+            }
+
+            #[doc = concat!(
+                " Unchecked [`", stringify!($Trait), "::batch_interpolate_into`].\n",
+                "\n",
+                " # Panics\n",
+                " Panics if `out.len() != points.len()`, or under the same conditions as\n",
+                " [`", stringify!($Trait), "::interpolate_fast`].",
+            )]
+            fn batch_interpolate_fast_into(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+                out: &mut [D::Elem],
+            ) {
+                assert_eq!(out.len(), points.len(), "batch_interpolate_fast_into: length mismatch");
+                for (o, point) in out.iter_mut().zip(points) {
+                    *o = self.interpolate_fast(data, point);
+                }
+            }
+
+            #[doc = concat!(
                 " Interpolate at each of several points, sharing one grid across all of them.\n",
                 "\n",
-                " Default just loops [`", stringify!($Trait), "::interpolate`]. Override only if locating a\n",
-                " point in the grid can be amortized across the batch (e.g. sorting points once\n",
-                " for a locate sweep instead of one binary search per point); no strategy\n",
-                " shipped in this crate does that today.",
+                " Default allocates an output buffer and calls [`", stringify!($Trait), "::batch_interpolate_into`].\n",
+                " Override only if locating a point in the grid can be amortized across the batch\n",
+                " (e.g. sorting points once for a locate sweep instead of one binary search per point);\n",
+                " no strategy shipped in this crate does that today.",
             )]
             fn batch_interpolate(
                 &self,
                 data: &$InterpData<D>,
                 points: &[[D::Elem; $N]],
-            ) -> Result<Vec<D::Elem>, InterpolateError> {
-                points
-                    .iter()
-                    .map(|point| self.interpolate(data, point))
-                    .collect()
+            ) -> Result<Vec<D::Elem>, InterpolateError>
+            where
+                D::Elem: Num,
+            {
+                let mut out = Vec::with_capacity(points.len());
+                for _ in 0..points.len() {
+                    out.push(D::Elem::zero());
+                }
+                self.batch_interpolate_into(data, points, &mut out)?;
+                Ok(out)
             }
 
             #[doc = concat!(
                 " Batched [`", stringify!($Trait), "::interpolate_fast`], assuming every point and `data` are\n",
                 " already valid.\n",
                 "\n",
-                " Default just loops [`", stringify!($Trait), "::interpolate_fast`]. Override under the same\n",
-                " condition as [`", stringify!($Trait), "::batch_interpolate`].",
+                " Default allocates an output buffer and calls [`", stringify!($Trait), "::batch_interpolate_fast_into`].\n",
+                " Override under the same condition as [`", stringify!($Trait), "::batch_interpolate`].",
             )]
             fn batch_interpolate_fast(
                 &self,
                 data: &$InterpData<D>,
                 points: &[[D::Elem; $N]],
-            ) -> Vec<D::Elem> {
-                points
-                    .iter()
-                    .map(|point| self.interpolate_fast(data, point))
-                    .collect()
+            ) -> Vec<D::Elem>
+            where
+                D::Elem: Num + Copy,
+            {
+                let mut out = Vec::with_capacity(points.len());
+                for _ in 0..points.len() {
+                    out.push(D::Elem::zero());
+                }
+                self.batch_interpolate_fast_into(data, points, &mut out);
+                out
             }
 
             #[doc = concat!(
@@ -135,11 +191,34 @@ macro_rules! sized_strategy_trait {
             }
 
             #[inline]
+            fn batch_interpolate_into(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+                out: &mut [D::Elem],
+            ) -> Result<(), InterpolateError> {
+                (**self).batch_interpolate_into(data, points, out)
+            }
+
+            #[inline]
+            fn batch_interpolate_fast_into(
+                &self,
+                data: &$InterpData<D>,
+                points: &[[D::Elem; $N]],
+                out: &mut [D::Elem],
+            ) {
+                (**self).batch_interpolate_fast_into(data, points, out)
+            }
+
+            #[inline]
             fn batch_interpolate(
                 &self,
                 data: &$InterpData<D>,
                 points: &[[D::Elem; $N]],
-            ) -> Result<Vec<D::Elem>, InterpolateError> {
+            ) -> Result<Vec<D::Elem>, InterpolateError>
+            where
+                D::Elem: Num,
+            {
                 (**self).batch_interpolate(data, points)
             }
 
@@ -148,7 +227,10 @@ macro_rules! sized_strategy_trait {
                 &self,
                 data: &$InterpData<D>,
                 points: &[[D::Elem; $N]],
-            ) -> Vec<D::Elem> {
+            ) -> Vec<D::Elem>
+            where
+                D::Elem: Num + Copy,
+            {
                 (**self).batch_interpolate_fast(data, points)
             }
 
@@ -213,37 +295,89 @@ where
             .expect("interpolate_fast: invalid point or data")
     }
 
+    /// Interpolate at each of several points, writing results into `out` instead of
+    /// allocating. `out.len()` must equal `points.len()`.
+    ///
+    /// Default loops [`StrategyND::interpolate`] into `out`; no allocation. Override
+    /// only if locating a point in the grid can be amortized across the batch (e.g.
+    /// sorting points once for a locate sweep instead of one binary search per point);
+    /// no strategy shipped in this crate does that today.
+    fn batch_interpolate_into(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+        out: &mut [D::Elem],
+    ) -> Result<(), InterpolateError> {
+        if out.len() != points.len() {
+            return Err(InterpolateError::OutputLength {
+                expected: points.len(),
+                found: out.len(),
+            });
+        }
+        for (o, point) in out.iter_mut().zip(points) {
+            *o = self.interpolate(data, point)?;
+        }
+        Ok(())
+    }
+
+    /// Unchecked [`StrategyND::batch_interpolate_into`].
+    ///
+    /// # Panics
+    /// Panics if `out.len() != points.len()`, or under the same conditions as
+    /// [`StrategyND::interpolate_fast`].
+    fn batch_interpolate_fast_into(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+        out: &mut [D::Elem],
+    ) {
+        assert_eq!(
+            out.len(),
+            points.len(),
+            "batch_interpolate_fast_into: length mismatch"
+        );
+        for (o, point) in out.iter_mut().zip(points) {
+            *o = self.interpolate_fast(data, point);
+        }
+    }
+
     /// Interpolate at each of several points, sharing one grid across all of them.
     ///
-    /// Default just loops [`StrategyND::interpolate`]. Override only if locating a
-    /// point in the grid can be amortized across the batch (e.g. sorting points once
-    /// for a locate sweep instead of one binary search per point); no strategy
-    /// shipped in this crate does that today.
+    /// Default allocates an output buffer and calls [`StrategyND::batch_interpolate_into`].
+    /// Override only if locating a point in the grid can be amortized across the batch
+    /// (e.g. sorting points once for a locate sweep instead of one binary search per point);
+    /// no strategy shipped in this crate does that today.
     fn batch_interpolate(
         &self,
         data: &InterpDataND<D>,
         points: &[&[D::Elem]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
-        points
-            .iter()
-            .map(|point| self.interpolate(data, point))
-            .collect()
+    ) -> Result<Vec<D::Elem>, InterpolateError>
+    where
+        D::Elem: Num,
+    {
+        let mut out = Vec::with_capacity(points.len());
+        for _ in 0..points.len() {
+            out.push(D::Elem::zero());
+        }
+        self.batch_interpolate_into(data, points, &mut out)?;
+        Ok(out)
     }
 
     /// Batched [`StrategyND::interpolate_fast`], assuming every point and `data` are
     /// already valid.
     ///
-    /// Default just loops [`StrategyND::interpolate_fast`]. Override under the same
-    /// condition as [`StrategyND::batch_interpolate`].
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpDataND<D>,
-        points: &[&[D::Elem]],
-    ) -> Vec<D::Elem> {
-        points
-            .iter()
-            .map(|point| self.interpolate_fast(data, point))
-            .collect()
+    /// Default allocates an output buffer and calls [`StrategyND::batch_interpolate_fast_into`].
+    /// Override under the same condition as [`StrategyND::batch_interpolate`].
+    fn batch_interpolate_fast(&self, data: &InterpDataND<D>, points: &[&[D::Elem]]) -> Vec<D::Elem>
+    where
+        D::Elem: Num + Copy,
+    {
+        let mut out = Vec::with_capacity(points.len());
+        for _ in 0..points.len() {
+            out.push(D::Elem::zero());
+        }
+        self.batch_interpolate_fast_into(data, points, &mut out);
+        out
     }
 
     /// Does this type's [`StrategyND::interpolate`] provision for extrapolation?
@@ -287,20 +421,42 @@ where
     }
 
     #[inline]
+    fn batch_interpolate_into(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+        out: &mut [D::Elem],
+    ) -> Result<(), InterpolateError> {
+        (**self).batch_interpolate_into(data, points, out)
+    }
+
+    #[inline]
+    fn batch_interpolate_fast_into(
+        &self,
+        data: &InterpDataND<D>,
+        points: &[&[D::Elem]],
+        out: &mut [D::Elem],
+    ) {
+        (**self).batch_interpolate_fast_into(data, points, out)
+    }
+
+    #[inline]
     fn batch_interpolate(
         &self,
         data: &InterpDataND<D>,
         points: &[&[D::Elem]],
-    ) -> Result<Vec<D::Elem>, InterpolateError> {
+    ) -> Result<Vec<D::Elem>, InterpolateError>
+    where
+        D::Elem: Num,
+    {
         (**self).batch_interpolate(data, points)
     }
 
     #[inline]
-    fn batch_interpolate_fast(
-        &self,
-        data: &InterpDataND<D>,
-        points: &[&[D::Elem]],
-    ) -> Vec<D::Elem> {
+    fn batch_interpolate_fast(&self, data: &InterpDataND<D>, points: &[&[D::Elem]]) -> Vec<D::Elem>
+    where
+        D::Elem: Num + Copy,
+    {
         (**self).batch_interpolate_fast(data, points)
     }
 }

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -110,9 +110,9 @@ macro_rules! sized_strategy_trait {
                 " Interpolate at each of several points, sharing one grid across all of them.\n",
                 "\n",
                 " Default allocates an output buffer and calls [`", stringify!($Trait), "::batch_interpolate_into`].\n",
-                " Override only if locating a point in the grid can be amortized across the batch\n",
-                " (e.g. sorting points once for a locate sweep instead of one binary search per point);\n",
-                " no strategy shipped in this crate does that today.",
+                " Do not override this method; override [`", stringify!($Trait), "::batch_interpolate_into`] instead\n",
+                " if you need to amortize locating a point across the batch (e.g. sorting points once\n",
+                " for a locate sweep instead of one binary search per point).",
             )]
             fn batch_interpolate(
                 &self,
@@ -135,7 +135,7 @@ macro_rules! sized_strategy_trait {
                 " already valid.\n",
                 "\n",
                 " Default allocates an output buffer and calls [`", stringify!($Trait), "::batch_interpolate_fast_into`].\n",
-                " Override under the same condition as [`", stringify!($Trait), "::batch_interpolate`].",
+                " Do not override this method; override [`", stringify!($Trait), "::batch_interpolate_fast_into`] instead.",
             )]
             fn batch_interpolate_fast(
                 &self,
@@ -344,9 +344,9 @@ where
     /// Interpolate at each of several points, sharing one grid across all of them.
     ///
     /// Default allocates an output buffer and calls [`StrategyND::batch_interpolate_into`].
-    /// Override only if locating a point in the grid can be amortized across the batch
-    /// (e.g. sorting points once for a locate sweep instead of one binary search per point);
-    /// no strategy shipped in this crate does that today.
+    /// Do not override this method; override [`StrategyND::batch_interpolate_into`] instead
+    /// if you need to amortize locating a point across the batch (e.g. sorting points once
+    /// for a locate sweep instead of one binary search per point).
     fn batch_interpolate(
         &self,
         data: &InterpDataND<D>,
@@ -367,7 +367,7 @@ where
     /// already valid.
     ///
     /// Default allocates an output buffer and calls [`StrategyND::batch_interpolate_fast_into`].
-    /// Override under the same condition as [`StrategyND::batch_interpolate`].
+    /// Do not override this method; override [`StrategyND::batch_interpolate_fast_into`] instead.
     fn batch_interpolate_fast(&self, data: &InterpDataND<D>, points: &[&[D::Elem]]) -> Vec<D::Elem>
     where
         D::Elem: Num + Copy,


### PR DESCRIPTION
## Summary

Implement allocation-free `batch_interpolate_into`/`batch_interpolate_fast_into` variants that write results into caller-supplied output slices, eliminating per-call allocation for batched interpolation in hot loops. Uses the full collapse design: `_into` variants become the true implementations, while `batch_interpolate` allocates and delegates.

Fixes #45. Prerequisite for #19 (multi-channel interpolate).

## Changes

**Core trait restructuring:**
- Add `batch_interpolate_into` and `batch_interpolate_fast_into` default methods to `Strategy1D/2D/3D/ND` and `Interpolator<T>` traits
- `batch_interpolate` and `batch_interpolate_fast` allocate zero-filled `Vec` and call the `_into` variants
- Add/update forwards in `Box<dyn ...>` implementations for all four methods

**Macro work:**
- New `batch_interpolate_into_impl!` macro with full Extrapolate-mode partitioning logic (replaces old `batch_interpolate_impl!` innards)
- Updated `batch_interpolate_impl!` to allocate and delegate
- Updated `interp_inherent_methods!` to call both macros and add `batch_interpolate_fast_into`
- Updated `interpolator_trait_impl!` to add slice-to-array conversions for `_into` methods
- Added `(batch_interpolate_into)` and `(batch_interpolate_fast_into)` arms to `slice_to_array_forward!` macro

**Hand-written code:**
- Full `batch_interpolate_into` implementation for `InterpND` with Extrapolate partitioning
- `batch_interpolate_fast_into` in `InterpND` with assertions

**Error types:**
- New `InterpolateError::OutputLength` variant for slice length mismatches

**Tests:**
- 8 new comprehensive tests in `two/tests.rs` covering:
  - Output parity with inherited methods
  - OutputLength error cases
  - Fast variant panic on mismatch
  - Clamp/Fill/Error extrapolation modes
  - Box<dyn Interpolator<T>> dispatch

**Documentation:**
- Updated CHANGELOG.md with feature summary

## Design rationale

Since `batch_interpolate` hasn't shipped in a release yet (merged via #21 but not tagged), restructuring it to defer to `_into` is not a breaking change. This ensures a strategy author who optimizes `batch_interpolate_into` for real amortization automatically gets the benefit in both `batch_interpolate` and `batch_interpolate_into` paths with no drift risk—there's only one implementation to override, not two.

Vector allocation uses `Vec::with_capacity` + loop to avoid `Clone` requirements on generic types.

Fill extrapolation pre-fills output and uses a scratch buffer to scatter results from in-bounds points only (Clamp/Wrap funnel straight through; Enable is a direct strategy call).

## Testing

- All 102 tests pass (added 8 new)
- Clippy clean
- `cargo build` and `cargo doc` successful

## Closes #45
