### PR TITLE
Refactor core API: make owned interpolators the default type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,11 +101,14 @@ Everything below is merged to `main` but not yet tagged/released.
 
 ### Changed
 - **Breaking**: Owned interpolators now the default type (following Rust idioms like `String` vs `&str`):
-  - `Interp{1D,2D,3D,ND}Owned<T, S>` -> `Interp{1D,2D,3D,ND}<T, S>`
-  - `Interp{1D,2D,3D,ND}Viewed<T, S>` -> `Interp{1D,2D,3D,ND}View<T, S>`
-  - Same pattern for data types: `InterpData{1D,2D,3D,ND}` and `InterpData{1D,2D,3D,ND}View`
-  - **Footgun**: Custom strategy implementations using `InterpData{1D,2D,3D,ND}<D>` still compile but
-    silently narrow to owned data. Use `InterpData{1D,2D,3D,ND}Base<D>` instead for generic support.
+  - Generic interpolator structs: `Interp{1D,2D,3D,ND}<D, S>` -> `Interp{1D,2D,3D,ND}Base<D, S>` (now generic over `D: Data`); new owned alias is `Interp{1D,2D,3D,ND}<T, S>`
+  - Generic data structs: `InterpData<D, const N: usize>` -> `InterpDataBase<D, const N: usize>` (now generic over `D: Data`)
+  - Type alias renames: `Interp{1D,2D,3D,ND}Owned<T, S>` -> `Interp{1D,2D,3D,ND}<T, S>` (owned becomes default)
+  - Type alias renames: `Interp{1D,2D,3D,ND}Viewed<T, S>` -> `Interp{1D,2D,3D,ND}View<T, S>` (viewed gets View suffix)
+  - Same pattern for data types: `InterpData{1D,2D,3D,ND}Owned<T>` -> `InterpData{1D,2D,3D,ND}<T>` and `InterpData{1D,2D,3D,ND}View<T>`
+  - Generic enum struct: `InterpolatorEnum<D>` -> `InterpolatorEnumBase<D>`; `InterpolatorEnumOwned<T>` -> `InterpolatorEnum<T>` and `InterpolatorEnumViewed<T>` -> `InterpolatorEnumView<T>`
+  - **Footgun**: Custom strategy implementations using `InterpData{1D,2D,3D,ND}<D>` or generic interpolators like `Interp{1D,2D,3D,ND}<D, S>` still compile but
+    silently narrow to owned data. Use `InterpData{1D,2D,3D,ND}Base<D>` and `Interp{1D,2D,3D,ND}Base<D, S>` instead for generic support.
 - **Breaking:** `InterpolateError` and `ValidateError` are now `#[non_exhaustive]`,
   allowing new error variants to be added without breaking downstream exhaustive
   matches. Any existing exhaustive `match` over one without a `_` arm now needs one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Everything below is merged to `main` but not yet tagged/released.
   that to a single dispatch that reaches the concrete type once, which then loops
   internally via ordinary static calls: this holds independently at both erasure
   points, a boxed interpolator reaches its concrete type in one hop, and (for an
-  interpolator holding a boxed strategy, e.g. `Interp2D<D, Box<dyn Strategy2D<D>>>`)
+  interpolator holding a boxed strategy, e.g. `Interp2DBase<D, Box<dyn Strategy2D<D>>>`)
   the strategy call inside it reaches its own concrete type in a separate one hop.
   `Box<dyn Interpolator<T>>` and `Box<dyn Strategy1D/2D/3D/ND<D>>` forward both
   methods to the wrapped concrete type (the same way `interpolate_fast` already is)
@@ -91,7 +91,7 @@ Everything below is merged to `main` but not yet tagged/released.
   `prelude`): a downcastable counterpart to `Interpolator<T>`, for storing
   heterogeneous interpolators behind `Box<dyn DynInterpolator<T>>` and recovering the
   concrete type via `as_any`. Implemented for owned `Interp1D`/`2D`/`3D`/`ND` only,
-  since `as_any` requires `Self: 'static` and the borrowed `Interp*Viewed` types can't
+  since `as_any` requires `Self: 'static` and the borrowed `Interp*View` types can't
   satisfy that; a viewed interpolator can still be used through `Interpolator<T>`.
   `interpolate`/`batch_interpolate` are inherited from the `Interpolator<T>`
   supertrait rather than duplicated under `DynInterpolator`-specific names: called
@@ -100,15 +100,31 @@ Everything below is merged to `main` but not yet tagged/released.
   do on the concrete, unboxed type.
 
 ### Changed
-- **Breaking**: Owned interpolators now the default type (following Rust idioms like `String` vs `&str`):
-  - Generic interpolator structs: `Interp{1D,2D,3D,ND}<D, S>` -> `Interp{1D,2D,3D,ND}Base<D, S>` (now generic over `D: Data`); new owned alias is `Interp{1D,2D,3D,ND}<T, S>`
-  - Generic data structs: `InterpData<D, const N: usize>` -> `InterpDataBase<D, const N: usize>` (now generic over `D: Data`)
-  - Type alias renames: `Interp{1D,2D,3D,ND}Owned<T, S>` -> `Interp{1D,2D,3D,ND}<T, S>` (owned becomes default)
-  - Type alias renames: `Interp{1D,2D,3D,ND}Viewed<T, S>` -> `Interp{1D,2D,3D,ND}View<T, S>` (viewed gets View suffix)
-  - Same pattern for data types: `InterpData{1D,2D,3D,ND}Owned<T>` -> `InterpData{1D,2D,3D,ND}<T>` and `InterpData{1D,2D,3D,ND}View<T>`
-  - Generic enum struct: `InterpolatorEnum<D>` -> `InterpolatorEnumBase<D>`; `InterpolatorEnumOwned<T>` -> `InterpolatorEnum<T>` and `InterpolatorEnumViewed<T>` -> `InterpolatorEnumView<T>`
-  - **Footgun**: Custom strategy implementations using `InterpData{1D,2D,3D,ND}<D>` or generic interpolators like `Interp{1D,2D,3D,ND}<D, S>` still compile but
-    silently narrow to owned data. Use `InterpData{1D,2D,3D,ND}Base<D>` and `Interp{1D,2D,3D,ND}Base<D, S>` instead for generic support.
+- **Breaking:** owned data is now the default in type names, following Rust idioms
+  (`String` vs `&str`, `Vec<T>` vs `&[T]`). Every form that is generic over the `ndarray`
+  data representation gains a `Base` suffix, the unsuffixed name becomes the owned alias,
+  and `Viewed` becomes `View`:
+  - Structs: `Interp{1D,2D,3D,ND}<D, S>` -> `Interp{1D,2D,3D,ND}Base<D, S>`,
+    `InterpData<D, const N: usize>` -> `InterpDataBase<D, N>`,
+    `InterpDataND<D>` -> `InterpDataNDBase<D>`,
+    `InterpolatorEnum<D>` -> `InterpolatorEnumBase<D>`. `Interp0D<T>` is unaffected;
+    it was never generic over the representation.
+  - Generic aliases: `InterpData{1D,2D,3D}<D>` -> `InterpData{1D,2D,3D}Base<D>`.
+  - Owned aliases drop their suffix: `Interp{1D,2D,3D,ND}Owned<T, S>` ->
+    `Interp{1D,2D,3D,ND}<T, S>`, `InterpData{1D,2D,3D,ND}Owned<T>` ->
+    `InterpData{1D,2D,3D,ND}<T>`, `InterpDataOwned<T, N>` -> `InterpData<T, N>`,
+    `InterpolatorEnumOwned<T>` -> `InterpolatorEnum<T>`.
+  - Viewed aliases swap suffix: `Interp{1D,2D,3D,ND}Viewed<T, S>` ->
+    `Interp{1D,2D,3D,ND}View<T, S>`, `InterpData{1D,2D,3D,ND}Viewed<T>` ->
+    `InterpData{1D,2D,3D,ND}View<T>`, `InterpDataViewed<T, N>` -> `InterpDataView<T, N>`,
+    `InterpolatorEnumViewed<T>` -> `InterpolatorEnumView<T>`.
+  - `InterpDataBase` is now re-exported from `ninterp::interpolator` as well as
+    `ninterp::data`.
+  - **Footgun:** code that is generic over the representation still compiles after a
+    mechanical rename, but silently narrows to owned data, because `InterpData1D<D>` now
+    means `InterpDataBase<OwnedRepr<D>, 1>` rather than `InterpDataBase<D, 1>`. Custom
+    strategy impls and any other generic-over-`D` code must move to the `Base` names
+    (`InterpData{1D,2D,3D,ND}Base<D>`, `Interp{1D,2D,3D,ND}Base<D, S>`).
 - **Breaking:** `InterpolateError` and `ValidateError` are now `#[non_exhaustive]`,
   allowing new error variants to be added without breaking downstream exhaustive
   matches. Any existing exhaustive `match` over one without a `_` arm now needs one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,12 @@ Everything below is merged to `main` but not yet tagged/released.
   do on the concrete, unboxed type.
 
 ### Changed
+- **Breaking**: Owned interpolators now the default type (following Rust idioms like `String` vs `&str`):
+  - `Interp{1D,2D,3D,ND}Owned<T, S>` -> `Interp{1D,2D,3D,ND}<T, S>`
+  - `Interp{1D,2D,3D,ND}Viewed<T, S>` -> `Interp{1D,2D,3D,ND}View<T, S>`
+  - Same pattern for data types: `InterpData{1D,2D,3D,ND}` and `InterpData{1D,2D,3D,ND}View`
+  - **Footgun**: Custom strategy implementations using `InterpData{1D,2D,3D,ND}<D>` still compile but
+    silently narrow to owned data. Use `InterpData{1D,2D,3D,ND}Base<D>` instead for generic support.
 - **Breaking:** `InterpolateError` and `ValidateError` are now `#[non_exhaustive]`,
   allowing new error variants to be added without breaking downstream exhaustive
   matches. Any existing exhaustive `match` over one without a `_` arm now needs one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,11 +120,13 @@ Everything below is merged to `main` but not yet tagged/released.
     `InterpolatorEnumViewed<T>` -> `InterpolatorEnumView<T>`.
   - `InterpDataBase` is now re-exported from `ninterp::interpolator` as well as
     `ninterp::data`.
-  - **Footgun:** code that is generic over the representation still compiles after a
-    mechanical rename, but silently narrows to owned data, because `InterpData1D<D>` now
-    means `InterpDataBase<OwnedRepr<D>, 1>` rather than `InterpDataBase<D, 1>`. Custom
-    strategy impls and any other generic-over-`D` code must move to the `Base` names
-    (`InterpData{1D,2D,3D,ND}Base<D>`, `Interp{1D,2D,3D,ND}Base<D, S>`).
+  - **Migrating generic-over-`D` code:** custom strategy impls and anything else written
+    against the representation parameter must move to the `Base` names
+    (`InterpData{1D,2D,3D,ND}Base<D>`, `Interp{1D,2D,3D,ND}Base<D, S>`). Keeping the old
+    unsuffixed name is a compile error, though an indirect one: `InterpData1D<D>` now
+    means `InterpDataBase<OwnedRepr<D>, 1>`, so `D` lands in `Elem` position and the
+    failure surfaces as an unsatisfied `D::Elem: PartialEq + Debug` bound, or as a
+    signature mismatch against `&InterpData1DBase<D>` on a trait impl.
 - **Breaking:** `InterpolateError` and `ValidateError` are now `#[non_exhaustive]`,
   allowing new error variants to be added without breaking downstream exhaustive
   matches. Any existing exhaustive `match` over one without a `_` arm now needs one.

--- a/README.md
+++ b/README.md
@@ -262,14 +262,16 @@ use ndarray::prelude::*;
 ```
 
 Type aliases in the [`prelude`](https://docs.rs/ninterp/latest/ninterp/prelude/index.html)
-make ownership intent explicit, for example in 1-D:
-- [`Interp1DOwned`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.Interp1DOwned.html)
-  - Data is owned by the interpolator
+follow Rust idioms (like `String` vs `&str` and `Vec` vs `&[T]`), making ownership intent explicit.
+For example, in 1-D:
+
+- [`Interp1D`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.Interp1D.html) (owned data)
+  - Default type for owned arrays
   - Examples: struct fields, general use
   ```rust
   use ndarray::prelude::*;
   use ninterp::prelude::*;
-  let interp: Interp1DOwned<f64, _> = Interp1D::new(
+  let interp = Interp1D::new(
       array![0.0, 1.0, 2.0, 3.0],
       array![0.0, 1.0, 4.0, 9.0],
       strategy::Linear,
@@ -277,15 +279,16 @@ make ownership intent explicit, for example in 1-D:
   )
   .unwrap();
   ```
-- [`Interp1DViewed`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.Interp1DViewed.html)
-  - Data is borrowed by the interpolator
+
+- [`Interp1DView`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.Interp1DView.html) (borrowed data)
+  - For viewed arrays (data borrowed from elsewhere)
   - Examples: data lives in a larger struct, data is shared without copying
   ```rust
   use ndarray::prelude::*;
   use ninterp::prelude::*;
   let x = array![0.0, 1.0, 2.0, 3.0];
   let f_x = array![0.0, 1.0, 4.0, 9.0];
-  let interp: Interp1DViewed<&f64, _> = Interp1D::new(
+  let interp = Interp1DView::new(
       x.view(),
       f_x.view(),
       strategy::Linear,
@@ -294,8 +297,7 @@ make ownership intent explicit, for example in 1-D:
   .unwrap();
   ```
 
-Typically, the compiler can infer concrete types from arguments passed to `new`.
-Some examples use explicit annotations for clarity.
+The same pattern applies to 2-D, 3-D, and N-D interpolators (`Interp2D`/`Interp2DView`, etc.).
 
 ## Examples
 See examples in `new` method documentation:

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ For dimensionalities N >= 1, this executes a validation step that prevents runti
 ## Choosing an Interpolator
 The [`prelude`](https://docs.rs/ninterp/latest/ninterp/prelude/index.html) exposes these interpolators:
 - [`Interp0D`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp0D.html): constant-value interpolator
-- [`Interp1D`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp1D.html): hard-coded 1-D interpolator
-- [`Interp2D`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp2D.html): hard-coded 2-D interpolator
-- [`Interp3D`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp3D.html): hard-coded 3-D interpolator
-- [`InterpND`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.InterpND.html): general N-D interpolator
+- [`Interp1D`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.Interp1D.html): hard-coded 1-D interpolator
+- [`Interp2D`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.Interp2D.html): hard-coded 2-D interpolator
+- [`Interp3D`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.Interp3D.html): hard-coded 3-D interpolator
+- [`InterpND`](https://docs.rs/ninterp/latest/ninterp/interpolator/type.InterpND.html): general N-D interpolator
 
 Use `Interp0D` when working with heterogeneous collections such as an `InterpolatorEnum` or `Box<dyn Interpolator>`.
 
@@ -302,10 +302,10 @@ The same pattern applies to 2-D, 3-D, and N-D interpolators (`Interp2D`/`Interp2
 ## Examples
 See examples in `new` method documentation:
 - [`Interp0D::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp0D.html#method.new)
-- [`Interp1D::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp1D.html#method.new)
-- [`Interp2D::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp2D.html#method.new)
-- [`Interp3D::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp3D.html#method.new)
-- [`InterpND::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.InterpND.html#method.new)
+- [`Interp1D::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp1DBase.html#method.new)
+- [`Interp2D::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp2DBase.html#method.new)
+- [`Interp3D::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.Interp3DBase.html#method.new)
+- [`InterpND::new`](https://docs.rs/ninterp/latest/ninterp/interpolator/struct.InterpNDBase.html#method.new)
 
 Also see the [`examples`](https://github.com/NatLabRockies/ninterp/tree/main/examples) directory for advanced examples:
 - Swapping strategies at runtime: [`swap_strategy.rs`](https://github.com/NatLabRockies/ninterp/blob/main/examples/swap_strategy.rs)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For dimensionalities N >= 1, this executes a validation step that prevents runti
     #[derive(serde::Serialize)]
     struct MyConfig {
         #[serde(serialize_with = "serialize_nested")]
-        surface: Interp2DOwned<f64, strategy::Linear>,
+        surface: Interp2D<f64, strategy::Linear>,
     }
     ```
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -78,7 +78,7 @@ fn benchmark_2D() {
     let grid_data: Array1<f64> = (0..100).map(|x| x as f64).collect();
     let values_data = Array2::random_using((100, 100), Uniform::new(0., 1.).unwrap(), &mut rng);
     // Create a 2D interpolator with 100x100 data (10,000 points)
-    let interp_2d = Interp2D::new(
+    let interp_2d = Interp2DView::new(
         grid_data.view(),
         grid_data.view(),
         values_data.view(),
@@ -104,7 +104,7 @@ fn benchmark_2D_multi() {
     let values_data =
         Array2::random_using((100, 100), Uniform::new(0., 1.).unwrap(), &mut rng).into_dyn();
     // Create an N-D interpolator with 100x100 data (10,000 points)
-    let interp_2d_multi = InterpND::new(
+    let interp_2d_multi = InterpNDView::new(
         vec![grid_data.view(), grid_data.view()],
         values_data.view(),
         strategy::Linear,
@@ -129,7 +129,7 @@ fn benchmark_3D() {
     let values_data =
         Array3::random_using((100, 100, 100), Uniform::new(0., 1.).unwrap(), &mut rng);
     // Create a 3D interpolator with 100x100x100 data (1,000,000 points)
-    let interp_3d = Interp3D::new(
+    let interp_3d = Interp3DView::new(
         grid_data.view(),
         grid_data.view(),
         grid_data.view(),
@@ -162,7 +162,7 @@ fn benchmark_3D_multi() {
     let values_data =
         Array3::random_using((100, 100, 100), Uniform::new(0., 1.).unwrap(), &mut rng).into_dyn();
     // Create an N-D interpolator with 100x100x100 data (1,000,000 points)
-    let interp_3d_multi = InterpND::new(
+    let interp_3d_multi = InterpNDView::new(
         vec![grid_data.view(), grid_data.view(), grid_data.view()],
         values_data.view(),
         strategy::Linear,
@@ -224,7 +224,7 @@ fn benchmark_2D_uniform() {
     let mut rng = StdRng::seed_from_u64(RANDOM_SEED);
     let grid_data: Array1<f64> = (0..100).map(|x| x as f64).collect();
     let values_data = Array2::random_using((100, 100), Uniform::new(0., 1.).unwrap(), &mut rng);
-    let interp = Interp2D::new(
+    let interp = Interp2DView::new(
         grid_data.view(),
         grid_data.view(),
         values_data.view(),
@@ -246,7 +246,7 @@ fn benchmark_2D_multi_uniform() {
     let grid_data: Array1<f64> = (0..100).map(|x| x as f64).collect();
     let values_data =
         Array2::random_using((100, 100), Uniform::new(0., 1.).unwrap(), &mut rng).into_dyn();
-    let interp = InterpND::new(
+    let interp = InterpNDView::new(
         vec![grid_data.view(), grid_data.view()],
         values_data.view(),
         strategy::LinearUniform,
@@ -267,7 +267,7 @@ fn benchmark_3D_uniform() {
     let grid_data: Array1<f64> = (0..100).map(|x| x as f64).collect();
     let values_data =
         Array3::random_using((100, 100, 100), Uniform::new(0., 1.).unwrap(), &mut rng);
-    let interp = Interp3D::new(
+    let interp = Interp3DView::new(
         grid_data.view(),
         grid_data.view(),
         grid_data.view(),
@@ -296,7 +296,7 @@ fn benchmark_3D_multi_uniform() {
     let grid_data: Array1<f64> = (0..100).map(|x| x as f64).collect();
     let values_data =
         Array3::random_using((100, 100, 100), Uniform::new(0., 1.).unwrap(), &mut rng).into_dyn();
-    let interp = InterpND::new(
+    let interp = InterpNDView::new(
         vec![grid_data.view(), grid_data.view(), grid_data.view()],
         values_data.view(),
         strategy::LinearUniform,

--- a/examples/custom_strategy.rs
+++ b/examples/custom_strategy.rs
@@ -65,7 +65,7 @@ where
     ) -> Result<f32, ninterp::error::InterpolateError> {
         // Dummy interpolation strategy, product of all point components
         //
-        // Here we could access the `InterpData2D` (and/or data in `self`) instead,
+        // Here we could access the `InterpData2DBase` (and/or data in `self`) instead,
         // but this is just an example.
         Ok(point.iter().fold(1., |acc, x| acc * x))
     }

--- a/examples/custom_strategy.rs
+++ b/examples/custom_strategy.rs
@@ -88,7 +88,7 @@ where
 
 fn main() {
     // type annotation for clarity
-    let interp: Interp2DOwned<f32, CustomStrategy> = Interp2D::new(
+    let interp: Interp2D<f32, CustomStrategy> = Interp2D::new(
         array![0., 2.],
         array![0., 4., 8.],
         array![[0., 0., 0.], [0., 0., 0.]],

--- a/examples/custom_strategy.rs
+++ b/examples/custom_strategy.rs
@@ -1,6 +1,6 @@
 use ninterp::prelude::*;
 
-use ninterp::data::InterpData2D;
+use ninterp::data::InterpData2DBase;
 use ninterp::strategy::traits::Strategy2D;
 
 // Note: ninterp also re-exposes the internally used `ndarray` crate
@@ -22,7 +22,7 @@ where
     //
     // Note: when reading grid coordinates in `interpolate`, index `data.grid[i]` directly
     // via ArrayView indexing (e.g. `data.grid[i][idx]`), not `.as_slice()`, which panics
-    // on non-contiguous storage. `Interp*Viewed` can produce that from a strided slice.
+    // on non-contiguous storage. `Interp*View` can produce that from a strided slice.
     // `ninterp::strategy::utils` has ready-made per-axis search helpers (bracket search,
     // exact-match short-circuit, step-direction lookup, uniform-grid fast path) built from
     // the same primitives the built-in strategies use.
@@ -35,7 +35,7 @@ where
     // `Interpolator::validate` is called on the interpolator directly.
     //
     // There is a default implementation that just returns `Ok(())`, so leave this out if not needed.
-    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ninterp::error::ValidateError> {
+    fn validate(&self, data: &InterpData2DBase<D>) -> Result<(), ninterp::error::ValidateError> {
         // Dummy invariant: reject non-uniformly-spaced grids. `strategy::utils` has a
         // ready-made helper for exactly this, used by the built-in `LinearUniform` strategy.
         ninterp::strategy::utils::check_uniform_grid(data.grid[0].view(), 0)?;
@@ -52,7 +52,7 @@ where
     // `validate`, it is not re-run by a standalone `Interpolator::validate` call.
     //
     // There is a default implementation that just returns `Ok(())`, so leave this out if not needed.
-    fn init(&mut self, _data: &InterpData2D<D>) -> Result<(), ninterp::error::ValidateError> {
+    fn init(&mut self, _data: &InterpData2DBase<D>) -> Result<(), ninterp::error::ValidateError> {
         println!("initialized!");
         Ok(())
     }
@@ -60,7 +60,7 @@ where
     // Returns interpolated value for the supplied point.
     fn interpolate(
         &self,
-        _data: &InterpData2D<D>,
+        _data: &InterpData2DBase<D>,
         point: &[f32; 2],
     ) -> Result<f32, ninterp::error::InterpolateError> {
         // Dummy interpolation strategy, product of all point components

--- a/examples/uom.rs
+++ b/examples/uom.rs
@@ -13,7 +13,7 @@ fn main() {
     // `uom::si::Quantity` is repr(transparent), meaning it has the same memory layout as its contained type.
     // This means we can get the contained type via transmuting.
     let interp: Interp1DView<&f64, _> = unsafe {
-        Interp1D::new(
+        Interp1DView::new(
             std::mem::transmute::<ArrayView1<Ratio>, ArrayView1<f64>>(x.view()),
             std::mem::transmute::<ArrayView1<Power>, ArrayView1<f64>>(f_x.view()),
             strategy::Linear,

--- a/examples/uom.rs
+++ b/examples/uom.rs
@@ -12,7 +12,7 @@ fn main() {
     let f_x = array![Power::new::<kilowatt>(0.25), Power::new::<kilowatt>(0.75)];
     // `uom::si::Quantity` is repr(transparent), meaning it has the same memory layout as its contained type.
     // This means we can get the contained type via transmuting.
-    let interp: Interp1DViewed<&f64, _> = unsafe {
+    let interp: Interp1DView<&f64, _> = unsafe {
         Interp1D::new(
             std::mem::transmute::<ArrayView1<Ratio>, ArrayView1<f64>>(x.view()),
             std::mem::transmute::<ArrayView1<Power>, ArrayView1<f64>>(f_x.view()),

--- a/src/interpolator/data.rs
+++ b/src/interpolator/data.rs
@@ -45,9 +45,9 @@ where
     #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_fixed"))]
     pub values: ArrayBase<D, Dim<[Ix; N]>>,
 }
-/// [`InterpData`] that views data.
+/// Viewed data variant (see [`InterpDataBase`] for the generic form).
 pub type InterpDataView<T, const N: usize> = InterpDataBase<ViewRepr<T>, N>;
-/// [`InterpData`] that owns data.
+/// Owned data variant (see [`InterpDataBase`] for the generic form).
 pub type InterpDataOwned<T, const N: usize> = InterpDataBase<OwnedRepr<T>, N>;
 
 #[cfg(feature = "serde")]

--- a/src/interpolator/data.rs
+++ b/src/interpolator/data.rs
@@ -2,10 +2,10 @@
 
 use super::*;
 
-pub use n::{InterpDataND, InterpDataNDOwned, InterpDataNDViewed};
-pub use one::{InterpData1D, InterpData1DOwned, InterpData1DViewed};
-pub use three::{InterpData3D, InterpData3DOwned, InterpData3DViewed};
-pub use two::{InterpData2D, InterpData2DOwned, InterpData2DViewed};
+pub use n::{InterpDataND, InterpDataNDBase, InterpDataNDView};
+pub use one::{InterpData1D, InterpData1DBase, InterpData1DView};
+pub use three::{InterpData3D, InterpData3DBase, InterpData3DView};
+pub use two::{InterpData2D, InterpData2DBase, InterpData2DView};
 
 /// Interpolator data for interpolators of concrete dimensionality `const N: usize`.
 ///
@@ -29,7 +29,7 @@ pub use two::{InterpData2D, InterpData2DOwned, InterpData2DViewed};
         "
     ))
 )]
-pub struct InterpData<D, const N: usize>
+pub struct InterpDataBase<D, const N: usize>
 where
     Dim<[Ix; N]>: Dimension,
     D: Data + RawDataClone + Clone,
@@ -46,12 +46,12 @@ where
     pub values: ArrayBase<D, Dim<[Ix; N]>>,
 }
 /// [`InterpData`] that views data.
-pub type InterpDataViewed<T, const N: usize> = InterpData<ViewRepr<T>, N>;
+pub type InterpDataView<T, const N: usize> = InterpDataBase<ViewRepr<T>, N>;
 /// [`InterpData`] that owns data.
-pub type InterpDataOwned<T, const N: usize> = InterpData<OwnedRepr<T>, N>;
+pub type InterpDataOwned<T, const N: usize> = InterpDataBase<OwnedRepr<T>, N>;
 
 #[cfg(feature = "serde")]
-impl<D, const N: usize> SerializeNested for InterpData<D, N>
+impl<D, const N: usize> SerializeNested for InterpDataBase<D, N>
 where
     Dim<[Ix; N]>: Dimension,
     D: Data + RawDataClone + Clone,
@@ -69,7 +69,7 @@ where
     }
 }
 
-impl<D, const N: usize> PartialEq for InterpData<D, N>
+impl<D, const N: usize> PartialEq for InterpDataBase<D, N>
 where
     Dim<[Ix; N]>: Dimension,
     D: Data + RawDataClone + Clone,
@@ -81,7 +81,7 @@ where
     }
 }
 
-impl<D, const N: usize> InterpData<D, N>
+impl<D, const N: usize> InterpDataBase<D, N>
 where
     Dim<[Ix; N]>: Dimension,
     D: Data + RawDataClone + Clone,
@@ -111,8 +111,8 @@ where
     }
 
     /// View interpolator data.
-    pub fn view(&self) -> InterpDataViewed<&D::Elem, N> {
-        InterpDataViewed {
+    pub fn view(&self) -> InterpDataView<&D::Elem, N> {
+        InterpDataView {
             grid: std::array::from_fn(|i| self.grid[i].view()),
             values: self.values.view(),
         }

--- a/src/interpolator/data.rs
+++ b/src/interpolator/data.rs
@@ -62,7 +62,7 @@ where
     where
         S: Serializer,
     {
-        let mut s = serializer.serialize_struct("InterpData", 2)?;
+        let mut s = serializer.serialize_struct("InterpDataBase", 2)?;
         s.serialize_field("grid", &GridArrWrapper(&self.grid))?;
         s.serialize_field("values", &ArrayWrapper(&self.values))?;
         s.end()

--- a/src/interpolator/data.rs
+++ b/src/interpolator/data.rs
@@ -45,10 +45,10 @@ where
     #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_fixed"))]
     pub values: ArrayBase<D, Dim<[Ix; N]>>,
 }
+/// Owned data variant (see [`InterpDataBase`] for the generic form).
+pub type InterpData<T, const N: usize> = InterpDataBase<OwnedRepr<T>, N>;
 /// Viewed data variant (see [`InterpDataBase`] for the generic form).
 pub type InterpDataView<T, const N: usize> = InterpDataBase<ViewRepr<T>, N>;
-/// Owned data variant (see [`InterpDataBase`] for the generic form).
-pub type InterpDataOwned<T, const N: usize> = InterpDataBase<OwnedRepr<T>, N>;
 
 #[cfg(feature = "serde")]
 impl<D, const N: usize> SerializeNested for InterpDataBase<D, N>
@@ -118,13 +118,13 @@ where
         }
     }
 
-    /// Turn the data into an [`InterpDataOwned`], cloning the array elements if necessary.
-    pub fn into_owned(self) -> InterpDataOwned<D::Elem, N>
+    /// Turn the data into an [`InterpData`], cloning the array elements if necessary.
+    pub fn into_owned(self) -> InterpData<D::Elem, N>
     where
         Dim<[Ix; N]>: Dimension,
         D::Elem: Clone,
     {
-        InterpDataOwned {
+        InterpData {
             grid: self.grid.map(|arr| arr.into_owned()),
             values: self.values.into_owned(),
         }

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -14,11 +14,11 @@ macro_rules! enum_method_forward {
         #[doc = "Re-run the current variant's strategy `validate` against its data.\n\n`new_0d`/`new_1d`/etc. already call this internally, so this is only needed\nafter mutating a variant's `data`/`strategy` fields directly (via `match`)."]
         pub fn validate_strategy(&self) -> Result<(), ValidateError> {
             match self {
-                InterpolatorEnum::Interp0D(_) => Ok(()),
-                InterpolatorEnum::Interp1D(interp) => interp.validate_strategy(),
-                InterpolatorEnum::Interp2D(interp) => interp.validate_strategy(),
-                InterpolatorEnum::Interp3D(interp) => interp.validate_strategy(),
-                InterpolatorEnum::InterpND(interp) => interp.validate_strategy(),
+                InterpolatorEnumBase::Interp0D(_) => Ok(()),
+                InterpolatorEnumBase::Interp1D(interp) => interp.validate_strategy(),
+                InterpolatorEnumBase::Interp2D(interp) => interp.validate_strategy(),
+                InterpolatorEnumBase::Interp3D(interp) => interp.validate_strategy(),
+                InterpolatorEnumBase::InterpND(interp) => interp.validate_strategy(),
             }
         }
     };
@@ -29,11 +29,11 @@ macro_rules! enum_method_forward {
             extrapolate: &Extrapolate<D::Elem>,
         ) -> Result<(), ValidateError> {
             match self {
-                InterpolatorEnum::Interp0D(_) => Ok(()),
-                InterpolatorEnum::Interp1D(interp) => interp.check_extrapolate(extrapolate),
-                InterpolatorEnum::Interp2D(interp) => interp.check_extrapolate(extrapolate),
-                InterpolatorEnum::Interp3D(interp) => interp.check_extrapolate(extrapolate),
-                InterpolatorEnum::InterpND(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnumBase::Interp0D(_) => Ok(()),
+                InterpolatorEnumBase::Interp1D(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnumBase::Interp2D(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnumBase::Interp3D(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnumBase::InterpND(interp) => interp.check_extrapolate(extrapolate),
             }
         }
     };
@@ -41,11 +41,11 @@ macro_rules! enum_method_forward {
         #[doc = "Re-run the current variant's strategy `init` against its data.\n\n`new_0d`/`new_1d`/etc. already call this internally, so this is only needed\nafter bypassing them: mutating a variant's `data`/`strategy` fields directly\n(via `match`), or deserializing an interpolator with a stateful custom strategy\n(`Deserialize` does not call `init`)."]
         pub fn init_strategy(&mut self) -> Result<(), ValidateError> {
             match self {
-                InterpolatorEnum::Interp0D(_) => Ok(()),
-                InterpolatorEnum::Interp1D(interp) => interp.init_strategy(),
-                InterpolatorEnum::Interp2D(interp) => interp.init_strategy(),
-                InterpolatorEnum::Interp3D(interp) => interp.init_strategy(),
-                InterpolatorEnum::InterpND(interp) => interp.init_strategy(),
+                InterpolatorEnumBase::Interp0D(_) => Ok(()),
+                InterpolatorEnumBase::Interp1D(interp) => interp.init_strategy(),
+                InterpolatorEnumBase::Interp2D(interp) => interp.init_strategy(),
+                InterpolatorEnumBase::Interp3D(interp) => interp.init_strategy(),
+                InterpolatorEnumBase::InterpND(interp) => interp.init_strategy(),
             }
         }
     };
@@ -55,28 +55,28 @@ macro_rules! enum_method_forward {
 macro_rules! enum_method_wrap {
     (view) => {
         #[doc = "Return an interpolator with viewed data."]
-        pub fn view(&self) -> InterpolatorEnumViewed<&D::Elem> {
+        pub fn view(&self) -> InterpolatorEnumView<&D::Elem> {
             match self {
-                InterpolatorEnum::Interp0D(interp) => InterpolatorEnum::Interp0D(interp.clone()),
-                InterpolatorEnum::Interp1D(interp) => InterpolatorEnum::Interp1D(interp.view()),
-                InterpolatorEnum::Interp2D(interp) => InterpolatorEnum::Interp2D(interp.view()),
-                InterpolatorEnum::Interp3D(interp) => InterpolatorEnum::Interp3D(interp.view()),
-                InterpolatorEnum::InterpND(interp) => InterpolatorEnum::InterpND(interp.view()),
+                InterpolatorEnumBase::Interp0D(interp) => InterpolatorEnumBase::Interp0D(interp.clone()),
+                InterpolatorEnumBase::Interp1D(interp) => InterpolatorEnumBase::Interp1D(interp.view()),
+                InterpolatorEnumBase::Interp2D(interp) => InterpolatorEnumBase::Interp2D(interp.view()),
+                InterpolatorEnumBase::Interp3D(interp) => InterpolatorEnumBase::Interp3D(interp.view()),
+                InterpolatorEnumBase::InterpND(interp) => InterpolatorEnumBase::InterpND(interp.view()),
             }
         }
     };
     (into_owned) => {
-        #[doc = "Turn the interpolator into an [`InterpolatorEnumOwned`], cloning the array elements if necessary."]
-        pub fn into_owned(self) -> InterpolatorEnumOwned<D::Elem>
+        #[doc = "Turn the interpolator into an [`InterpolatorEnum`], cloning the array elements if necessary."]
+        pub fn into_owned(self) -> InterpolatorEnum<D::Elem>
         where
             D::Elem: Clone,
         {
             match self {
-                InterpolatorEnum::Interp0D(interp) => InterpolatorEnum::Interp0D(interp.clone()),
-                InterpolatorEnum::Interp1D(interp) => InterpolatorEnum::Interp1D(interp.into_owned()),
-                InterpolatorEnum::Interp2D(interp) => InterpolatorEnum::Interp2D(interp.into_owned()),
-                InterpolatorEnum::Interp3D(interp) => InterpolatorEnum::Interp3D(interp.into_owned()),
-                InterpolatorEnum::InterpND(interp) => InterpolatorEnum::InterpND(interp.into_owned()),
+                InterpolatorEnumBase::Interp0D(interp) => InterpolatorEnumBase::Interp0D(interp.clone()),
+                InterpolatorEnumBase::Interp1D(interp) => InterpolatorEnumBase::Interp1D(interp.into_owned()),
+                InterpolatorEnumBase::Interp2D(interp) => InterpolatorEnumBase::Interp2D(interp.into_owned()),
+                InterpolatorEnumBase::Interp3D(interp) => InterpolatorEnumBase::Interp3D(interp.into_owned()),
+                InterpolatorEnumBase::InterpND(interp) => InterpolatorEnumBase::InterpND(interp.into_owned()),
             }
         }
     };
@@ -88,11 +88,11 @@ macro_rules! enum_trait_method {
         #[inline]
         fn ndim(&self) -> usize {
             match self {
-                InterpolatorEnum::Interp0D(_) => 0,
-                InterpolatorEnum::Interp1D(_) => 1,
-                InterpolatorEnum::Interp2D(_) => 2,
-                InterpolatorEnum::Interp3D(_) => 3,
-                InterpolatorEnum::InterpND(interp) => interp.ndim(),
+                InterpolatorEnumBase::Interp0D(_) => 0,
+                InterpolatorEnumBase::Interp1D(_) => 1,
+                InterpolatorEnumBase::Interp2D(_) => 2,
+                InterpolatorEnumBase::Interp3D(_) => 3,
+                InterpolatorEnumBase::InterpND(interp) => interp.ndim(),
             }
         }
     };
@@ -125,46 +125,46 @@ macro_rules! slice_to_array_forward {
     (interpolate) => {
         fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
             match self {
-                InterpolatorEnum::Interp0D(interp) => interp.interpolate(point),
-                InterpolatorEnum::Interp1D(interp) => interp.interpolate(
+                InterpolatorEnumBase::Interp0D(interp) => interp.interpolate(point),
+                InterpolatorEnumBase::Interp1D(interp) => interp.interpolate(
                     point
                         .try_into()
                         .map_err(|_| InterpolateError::PointLength(1))?,
                 ),
-                InterpolatorEnum::Interp2D(interp) => interp.interpolate(
+                InterpolatorEnumBase::Interp2D(interp) => interp.interpolate(
                     point
                         .try_into()
                         .map_err(|_| InterpolateError::PointLength(2))?,
                 ),
-                InterpolatorEnum::Interp3D(interp) => interp.interpolate(
+                InterpolatorEnumBase::Interp3D(interp) => interp.interpolate(
                     point
                         .try_into()
                         .map_err(|_| InterpolateError::PointLength(3))?,
                 ),
-                InterpolatorEnum::InterpND(interp) => interp.interpolate(point),
+                InterpolatorEnumBase::InterpND(interp) => interp.interpolate(point),
             }
         }
     };
     (interpolate_fast) => {
         fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
             match self {
-                InterpolatorEnum::Interp0D(interp) => interp.0,
-                InterpolatorEnum::Interp1D(interp) => interp.interpolate_fast(
+                InterpolatorEnumBase::Interp0D(interp) => interp.0,
+                InterpolatorEnumBase::Interp1D(interp) => interp.interpolate_fast(
                     point
                         .try_into()
                         .expect("interpolate_fast: point length mismatch"),
                 ),
-                InterpolatorEnum::Interp2D(interp) => interp.interpolate_fast(
+                InterpolatorEnumBase::Interp2D(interp) => interp.interpolate_fast(
                     point
                         .try_into()
                         .expect("interpolate_fast: point length mismatch"),
                 ),
-                InterpolatorEnum::Interp3D(interp) => interp.interpolate_fast(
+                InterpolatorEnumBase::Interp3D(interp) => interp.interpolate_fast(
                     point
                         .try_into()
                         .expect("interpolate_fast: point length mismatch"),
                 ),
-                InterpolatorEnum::InterpND(interp) => interp.interpolate_fast(point),
+                InterpolatorEnumBase::InterpND(interp) => interp.interpolate_fast(point),
             }
         }
     };
@@ -174,10 +174,10 @@ macro_rules! slice_to_array_forward {
             points: &[&[D::Elem]],
         ) -> Result<Vec<D::Elem>, InterpolateError> {
             match self {
-                InterpolatorEnum::Interp0D(interp) => {
+                InterpolatorEnumBase::Interp0D(interp) => {
                     Interpolator::batch_interpolate(interp, points)
                 }
-                InterpolatorEnum::Interp1D(interp) => {
+                InterpolatorEnumBase::Interp1D(interp) => {
                     let points: Vec<[D::Elem; 1]> = points
                         .iter()
                         .map(|&point| {
@@ -188,7 +188,7 @@ macro_rules! slice_to_array_forward {
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate(&points)
                 }
-                InterpolatorEnum::Interp2D(interp) => {
+                InterpolatorEnumBase::Interp2D(interp) => {
                     let points: Vec<[D::Elem; 2]> = points
                         .iter()
                         .map(|&point| {
@@ -199,7 +199,7 @@ macro_rules! slice_to_array_forward {
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate(&points)
                 }
-                InterpolatorEnum::Interp3D(interp) => {
+                InterpolatorEnumBase::Interp3D(interp) => {
                     let points: Vec<[D::Elem; 3]> = points
                         .iter()
                         .map(|&point| {
@@ -210,15 +210,15 @@ macro_rules! slice_to_array_forward {
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate(&points)
                 }
-                InterpolatorEnum::InterpND(interp) => interp.batch_interpolate(points),
+                InterpolatorEnumBase::InterpND(interp) => interp.batch_interpolate(points),
             }
         }
     };
     (batch_interpolate_fast) => {
         fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {
             match self {
-                InterpolatorEnum::Interp0D(interp) => vec![interp.0; points.len()],
-                InterpolatorEnum::Interp1D(interp) => {
+                InterpolatorEnumBase::Interp0D(interp) => vec![interp.0; points.len()],
+                InterpolatorEnumBase::Interp1D(interp) => {
                     let points: Vec<[D::Elem; 1]> = points
                         .iter()
                         .map(|&point| {
@@ -229,7 +229,7 @@ macro_rules! slice_to_array_forward {
                         .collect();
                     interp.batch_interpolate_fast(&points)
                 }
-                InterpolatorEnum::Interp2D(interp) => {
+                InterpolatorEnumBase::Interp2D(interp) => {
                     let points: Vec<[D::Elem; 2]> = points
                         .iter()
                         .map(|&point| {
@@ -240,7 +240,7 @@ macro_rules! slice_to_array_forward {
                         .collect();
                     interp.batch_interpolate_fast(&points)
                 }
-                InterpolatorEnum::Interp3D(interp) => {
+                InterpolatorEnumBase::Interp3D(interp) => {
                     let points: Vec<[D::Elem; 3]> = points
                         .iter()
                         .map(|&point| {
@@ -251,7 +251,7 @@ macro_rules! slice_to_array_forward {
                         .collect();
                     interp.batch_interpolate_fast(&points)
                 }
-                InterpolatorEnum::InterpND(interp) => interp.batch_interpolate_fast(points),
+                InterpolatorEnumBase::InterpND(interp) => interp.batch_interpolate_fast(points),
             }
         }
     };
@@ -262,7 +262,7 @@ macro_rules! slice_to_array_forward {
             out: &mut [D::Elem],
         ) -> Result<(), InterpolateError> {
             match self {
-                InterpolatorEnum::Interp0D(interp) => {
+                InterpolatorEnumBase::Interp0D(interp) => {
                     if out.len() != points.len() {
                         return Err(InterpolateError::OutputLength {
                             expected: points.len(),
@@ -274,7 +274,7 @@ macro_rules! slice_to_array_forward {
                     }
                     Ok(())
                 }
-                InterpolatorEnum::Interp1D(interp) => {
+                InterpolatorEnumBase::Interp1D(interp) => {
                     let points: Vec<[D::Elem; 1]> = points
                         .iter()
                         .map(|&point| {
@@ -285,7 +285,7 @@ macro_rules! slice_to_array_forward {
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate_into(&points, out)
                 }
-                InterpolatorEnum::Interp2D(interp) => {
+                InterpolatorEnumBase::Interp2D(interp) => {
                     let points: Vec<[D::Elem; 2]> = points
                         .iter()
                         .map(|&point| {
@@ -296,7 +296,7 @@ macro_rules! slice_to_array_forward {
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate_into(&points, out)
                 }
-                InterpolatorEnum::Interp3D(interp) => {
+                InterpolatorEnumBase::Interp3D(interp) => {
                     let points: Vec<[D::Elem; 3]> = points
                         .iter()
                         .map(|&point| {
@@ -307,19 +307,21 @@ macro_rules! slice_to_array_forward {
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate_into(&points, out)
                 }
-                InterpolatorEnum::InterpND(interp) => interp.batch_interpolate_into(points, out),
+                InterpolatorEnumBase::InterpND(interp) => {
+                    interp.batch_interpolate_into(points, out)
+                }
             }
         }
     };
     (batch_interpolate_fast_into) => {
         fn batch_interpolate_fast_into(&self, points: &[&[D::Elem]], out: &mut [D::Elem]) {
             match self {
-                InterpolatorEnum::Interp0D(interp) => {
+                InterpolatorEnumBase::Interp0D(interp) => {
                     for o in out.iter_mut() {
                         *o = interp.0;
                     }
                 }
-                InterpolatorEnum::Interp1D(interp) => {
+                InterpolatorEnumBase::Interp1D(interp) => {
                     let points: Vec<[D::Elem; 1]> = points
                         .iter()
                         .map(|&point| {
@@ -330,7 +332,7 @@ macro_rules! slice_to_array_forward {
                         .collect();
                     interp.batch_interpolate_fast_into(&points, out)
                 }
-                InterpolatorEnum::Interp2D(interp) => {
+                InterpolatorEnumBase::Interp2D(interp) => {
                     let points: Vec<[D::Elem; 2]> = points
                         .iter()
                         .map(|&point| {
@@ -341,7 +343,7 @@ macro_rules! slice_to_array_forward {
                         .collect();
                     interp.batch_interpolate_fast_into(&points, out)
                 }
-                InterpolatorEnum::Interp3D(interp) => {
+                InterpolatorEnumBase::Interp3D(interp) => {
                     let points: Vec<[D::Elem; 3]> = points
                         .iter()
                         .map(|&point| {
@@ -352,7 +354,7 @@ macro_rules! slice_to_array_forward {
                         .collect();
                     interp.batch_interpolate_fast_into(&points, out)
                 }
-                InterpolatorEnum::InterpND(interp) => {
+                InterpolatorEnumBase::InterpND(interp) => {
                     interp.batch_interpolate_fast_into(points, out)
                 }
             }
@@ -373,7 +375,7 @@ macro_rules! slice_to_array_forward {
 ///
 /// // 1-D linear
 /// // type annotation for clarity
-/// let mut interp: InterpolatorEnumOwned<_> = InterpolatorEnum::new_1d(
+/// let mut interp: InterpolatorEnum<_> = InterpolatorEnumBase::new_1d(
 ///     // x
 ///     array![0., 1., 2., 3., 4.],
 ///     // f(x)
@@ -387,7 +389,7 @@ macro_rules! slice_to_array_forward {
 /// assert_eq!(interp.interpolate(&[4.00]).unwrap(), 1.0);
 ///
 /// // 2-D nearest
-/// interp = InterpolatorEnum::new_2d(
+/// interp = InterpolatorEnumBase::new_2d(
 ///     // x
 ///     array![0.05, 0.10, 0.15],
 ///     // y
@@ -399,7 +401,7 @@ macro_rules! slice_to_array_forward {
 /// )
 /// .unwrap();
 /// let f_xy = match &interp {
-///     InterpolatorEnum::Interp2D(interp) => &interp.data.values,
+///     InterpolatorEnumBase::Interp2D(interp) => &interp.data.values,
 ///     _ => unreachable!(),
 /// };
 ///
@@ -409,7 +411,7 @@ macro_rules! slice_to_array_forward {
 /// assert_eq!(interp.interpolate(&[0.14, 0.29]).unwrap(), f_xy[[2, 2]]);
 ///
 /// // 0-D
-/// interp = InterpolatorEnum::new_0d(0.5);
+/// interp = InterpolatorEnumBase::new_0d(0.5);
 /// assert_eq!(interp.interpolate(&[]).unwrap(), 0.5);
 /// ```
 /// See also: `examples/swap_interpolator.rs`
@@ -427,24 +429,24 @@ macro_rules! slice_to_array_forward {
         "
     ))
 )]
-pub enum InterpolatorEnum<D>
+pub enum InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
 {
     Interp0D(Interp0D<D::Elem>),
-    Interp1D(Interp1D<D, Strategy1DEnum>),
-    Interp2D(Interp2D<D, Strategy2DEnum>),
-    Interp3D(Interp3D<D, Strategy3DEnum>),
-    InterpND(InterpND<D, StrategyNDEnum>),
+    Interp1D(Interp1DBase<D, Strategy1DEnum>),
+    Interp2D(Interp2DBase<D, Strategy2DEnum>),
+    Interp3D(Interp3DBase<D, Strategy3DEnum>),
+    InterpND(InterpNDBase<D, StrategyNDEnum>),
 }
-/// [`InterpolatorEnum`] that views data.
-pub type InterpolatorEnumViewed<T> = InterpolatorEnum<ViewRepr<T>>;
-/// [`InterpolatorEnum`] that owns data.
-pub type InterpolatorEnumOwned<T> = InterpolatorEnum<OwnedRepr<T>>;
+/// [`InterpolatorEnumBase`] that owns data.
+pub type InterpolatorEnum<T> = InterpolatorEnumBase<OwnedRepr<T>>;
+/// [`InterpolatorEnumBase`] that views data.
+pub type InterpolatorEnumView<T> = InterpolatorEnumBase<ViewRepr<T>>;
 
 #[cfg(feature = "serde")]
-impl<D> SerializeNested for InterpolatorEnum<D>
+impl<D> SerializeNested for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug + Serialize,
@@ -464,7 +466,7 @@ where
     }
 }
 
-impl<D> PartialEq for InterpolatorEnum<D>
+impl<D> PartialEq for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -482,73 +484,73 @@ where
     }
 }
 
-impl<D> From<Interp0D<D::Elem>> for InterpolatorEnum<D>
+impl<D> From<Interp0D<D::Elem>> for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
     #[inline]
     fn from(interpolator: Interp0D<D::Elem>) -> Self {
-        InterpolatorEnum::Interp0D(interpolator)
+        InterpolatorEnumBase::Interp0D(interpolator)
     }
 }
 
-impl<D> From<Interp1D<D, Strategy1DEnum>> for InterpolatorEnum<D>
+impl<D> From<Interp1DBase<D, Strategy1DEnum>> for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
     #[inline]
-    fn from(interpolator: Interp1D<D, Strategy1DEnum>) -> Self {
-        InterpolatorEnum::Interp1D(interpolator)
+    fn from(interpolator: Interp1DBase<D, Strategy1DEnum>) -> Self {
+        InterpolatorEnumBase::Interp1D(interpolator)
     }
 }
 
-impl<D> From<Interp2D<D, Strategy2DEnum>> for InterpolatorEnum<D>
+impl<D> From<Interp2DBase<D, Strategy2DEnum>> for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
     #[inline]
-    fn from(interpolator: Interp2D<D, Strategy2DEnum>) -> Self {
-        InterpolatorEnum::Interp2D(interpolator)
+    fn from(interpolator: Interp2DBase<D, Strategy2DEnum>) -> Self {
+        InterpolatorEnumBase::Interp2D(interpolator)
     }
 }
 
-impl<D> From<Interp3D<D, Strategy3DEnum>> for InterpolatorEnum<D>
+impl<D> From<Interp3DBase<D, Strategy3DEnum>> for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
     #[inline]
-    fn from(interpolator: Interp3D<D, Strategy3DEnum>) -> Self {
-        InterpolatorEnum::Interp3D(interpolator)
+    fn from(interpolator: Interp3DBase<D, Strategy3DEnum>) -> Self {
+        InterpolatorEnumBase::Interp3D(interpolator)
     }
 }
 
-impl<D> From<InterpND<D, StrategyNDEnum>> for InterpolatorEnum<D>
+impl<D> From<InterpNDBase<D, StrategyNDEnum>> for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
     #[inline]
-    fn from(interpolator: InterpND<D, StrategyNDEnum>) -> Self {
-        InterpolatorEnum::InterpND(interpolator)
+    fn from(interpolator: InterpNDBase<D, StrategyNDEnum>) -> Self {
+        InterpolatorEnumBase::InterpND(interpolator)
     }
 }
 
-impl<D> InterpolatorEnum<D>
+impl<D> InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Debug,
 {
-    /// Create [`InterpolatorEnum::Interp0D`], internally calling [`Interp0D::new`].
+    /// Create [`InterpolatorEnumBase::Interp0D`], internally calling [`Interp0D::new`].
     #[inline]
     pub fn new_0d(value: D::Elem) -> Self {
         Self::Interp0D(Interp0D::new(value))
     }
 
-    /// Create [`InterpolatorEnum::Interp1D`], internally calling [`Interp1D::new`].
+    /// Create [`InterpolatorEnumBase::Interp1D`], internally calling [`Interp1D::new`].
     #[inline]
     pub fn new_1d(
         x: ArrayBase<D, Ix1>,
@@ -556,7 +558,7 @@ where
         strategy: impl Into<Strategy1DEnum>,
         extrapolate: Extrapolate<D::Elem>,
     ) -> Result<Self, ValidateError> {
-        Ok(Self::Interp1D(Interp1D::new(
+        Ok(Self::Interp1D(Interp1DBase::new(
             x,
             f_x,
             strategy.into(),
@@ -564,7 +566,7 @@ where
         )?))
     }
 
-    /// Create [`InterpolatorEnum::Interp2D`], internally calling [`Interp2D::new`].
+    /// Create [`InterpolatorEnumBase::Interp2D`], internally calling [`Interp2D::new`].
     #[inline]
     pub fn new_2d(
         x: ArrayBase<D, Ix1>,
@@ -573,7 +575,7 @@ where
         strategy: impl Into<Strategy2DEnum>,
         extrapolate: Extrapolate<D::Elem>,
     ) -> Result<Self, ValidateError> {
-        Ok(Self::Interp2D(Interp2D::new(
+        Ok(Self::Interp2D(Interp2DBase::new(
             x,
             y,
             f_xy,
@@ -582,7 +584,7 @@ where
         )?))
     }
 
-    /// Create [`InterpolatorEnum::Interp3D`], internally calling [`Interp3D::new`].
+    /// Create [`InterpolatorEnumBase::Interp3D`], internally calling [`Interp3D::new`].
     #[inline]
     pub fn new_3d(
         x: ArrayBase<D, Ix1>,
@@ -592,7 +594,7 @@ where
         strategy: impl Into<Strategy3DEnum>,
         extrapolate: Extrapolate<D::Elem>,
     ) -> Result<Self, ValidateError> {
-        Ok(Self::Interp3D(Interp3D::new(
+        Ok(Self::Interp3D(Interp3DBase::new(
             x,
             y,
             z,
@@ -602,7 +604,7 @@ where
         )?))
     }
 
-    /// Create [`InterpolatorEnum::InterpND`], internally calling [`InterpND::new`].
+    /// Create [`InterpolatorEnumBase::InterpND`], internally calling [`InterpND::new`].
     #[inline]
     pub fn new_nd(
         grid: Vec<ArrayBase<D, Ix1>>,
@@ -610,7 +612,7 @@ where
         strategy: impl Into<StrategyNDEnum>,
         extrapolate: Extrapolate<D::Elem>,
     ) -> Result<Self, ValidateError> {
-        Ok(Self::InterpND(InterpND::new(
+        Ok(Self::InterpND(InterpNDBase::new(
             grid,
             values,
             strategy.into(),
@@ -625,7 +627,7 @@ where
     enum_method_forward!(mut init_strategy);
 }
 
-impl<D> Interpolator<D::Elem> for InterpolatorEnum<D>
+impl<D> Interpolator<D::Elem> for InterpolatorEnumBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Float + Euclid + Debug,
@@ -649,15 +651,15 @@ mod tests {
     fn test_partialeq() {
         #[derive(PartialEq)]
         #[allow(unused)]
-        struct MyStruct(InterpolatorEnumOwned<f64>);
+        struct MyStruct(InterpolatorEnum<f64>);
     }
 
     #[test]
     fn test_point_length() {
-        // `InterpolatorEnum::interpolate` takes a real slice (not an inherent
+        // `InterpolatorEnumBase::interpolate` takes a real slice (not an inherent
         // fixed-size array), so a wrong-length point is still a runtime `Err` here,
         // for every variant with a fixed `N`.
-        let interp_1d = InterpolatorEnum::new_1d(
+        let interp_1d = InterpolatorEnumBase::new_1d(
             array![0., 1., 2., 3., 4.],
             array![0.2, 0.4, 0.6, 0.8, 1.0],
             strategy::Linear,
@@ -669,7 +671,7 @@ mod tests {
             InterpolateError::PointLength(1)
         ));
 
-        let interp_2d = InterpolatorEnum::new_2d(
+        let interp_2d = InterpolatorEnumBase::new_2d(
             array![0.05, 0.10, 0.15],
             array![0.10, 0.20, 0.30],
             array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
@@ -682,7 +684,7 @@ mod tests {
             InterpolateError::PointLength(2)
         ));
 
-        let interp_3d = InterpolatorEnum::new_3d(
+        let interp_3d = InterpolatorEnumBase::new_3d(
             array![0.05, 0.10],
             array![0.10, 0.20],
             array![0.20, 0.40],
@@ -699,7 +701,7 @@ mod tests {
 
     #[test]
     fn test_batch_interpolate() {
-        let interp = InterpolatorEnum::new_1d(
+        let interp = InterpolatorEnumBase::new_1d(
             array![0., 1., 2., 3., 4.],
             array![0.2, 0.4, 0.6, 0.8, 1.0],
             strategy::Linear,
@@ -713,7 +715,7 @@ mod tests {
 
     #[test]
     fn test_batch_interpolate_0d() {
-        let interp: InterpolatorEnumOwned<f64> = InterpolatorEnum::new_0d(0.5);
+        let interp: InterpolatorEnum<f64> = InterpolatorEnumBase::new_0d(0.5);
         let points: [&[f64]; 3] = [&[], &[], &[]];
         assert_eq!(
             interp.batch_interpolate(&points).unwrap(),
@@ -724,7 +726,7 @@ mod tests {
 
     #[test]
     fn test_batch_interpolate_nd() {
-        let interp = InterpolatorEnum::new_nd(
+        let interp = InterpolatorEnumBase::new_nd(
             vec![array![0., 1.], array![0., 1.], array![0., 1.]],
             array![[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]].into_dyn(),
             strategy::Linear,
@@ -742,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_batch_interpolate_point_length_mismatch() {
-        let interp = InterpolatorEnum::new_2d(
+        let interp = InterpolatorEnumBase::new_2d(
             array![0.05, 0.10, 0.15],
             array![0.10, 0.20, 0.30],
             array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
@@ -765,7 +767,7 @@ mod tests {
         let f_xy = array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]];
         let f_xy_dyn = f_xy.clone().into_dyn();
 
-        let interp0: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
+        let interp0: Interp2DBase<_, strategy::enums::Strategy2DEnum> = Interp2DBase::new(
             x.view(),
             y.view(),
             f_xy.view(),
@@ -773,16 +775,16 @@ mod tests {
             Extrapolate::Error,
         )
         .unwrap();
-        let interp1 = InterpolatorEnum::from(interp0.clone());
+        let interp1 = InterpolatorEnumBase::from(interp0.clone());
 
-        let interp2: InterpND<_, strategy::enums::StrategyNDEnum> = InterpND::new(
+        let interp2: InterpNDBase<_, strategy::enums::StrategyNDEnum> = InterpNDBase::new(
             vec![x.view(), y.view()],
             f_xy_dyn.view(),
             strategy::Nearest.into(),
             Extrapolate::Error,
         )
         .unwrap();
-        let interp3 = InterpolatorEnum::from(interp2.view());
+        let interp3 = InterpolatorEnumBase::from(interp2.view());
 
         assert_eq!(
             serde_json::to_string(&interp0).unwrap(),

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -440,9 +440,9 @@ where
     Interp3D(Interp3DBase<D, Strategy3DEnum>),
     InterpND(InterpNDBase<D, StrategyNDEnum>),
 }
-/// [`InterpolatorEnumBase`] that owns data.
+/// Owned interpolator enum (see [`InterpolatorEnumBase`] for the generic form).
 pub type InterpolatorEnum<T> = InterpolatorEnumBase<OwnedRepr<T>>;
-/// [`InterpolatorEnumBase`] that views data.
+/// Viewed interpolator enum (see [`InterpolatorEnumBase`] for the generic form).
 pub type InterpolatorEnumView<T> = InterpolatorEnumBase<ViewRepr<T>>;
 
 #[cfg(feature = "serde")]

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -185,7 +185,7 @@ impl<T> Interpolator<T> for Box<dyn Interpolator<T>> {
 ///
 /// Implemented for owned `Interp1D`/`2D`/`3D`/`ND` types only:
 /// [`as_any`](DynInterpolator::as_any) requires `Self: 'static`, which the borrowed
-/// `Interp*Viewed` types can't satisfy. A viewed interpolator can still be used
+/// `Interp*View` types can't satisfy. A viewed interpolator can still be used
 /// through [`Interpolator<T>`].
 pub trait DynInterpolator<T>: Interpolator<T> + Send + Sync {
     /// Downcast to the concrete interpolator type.

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -13,10 +13,11 @@ mod zero;
 pub mod data;
 pub mod enums;
 
-pub use n::{InterpND, InterpNDOwned, InterpNDViewed};
-pub use one::{Interp1D, Interp1DOwned, Interp1DViewed};
-pub use three::{Interp3D, Interp3DOwned, Interp3DViewed};
-pub use two::{Interp2D, Interp2DOwned, Interp2DViewed};
+pub use data::InterpDataBase;
+pub use n::{InterpND, InterpNDBase, InterpNDView};
+pub use one::{Interp1D, Interp1DBase, Interp1DView};
+pub use three::{Interp3D, Interp3DBase, Interp3DView};
+pub use two::{Interp2D, Interp2DBase, Interp2DView};
 pub use zero::Interp0D;
 
 /// An interpolator of data type `T`

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -10,7 +10,8 @@ mod tests;
 
 /// Interpolator data for N-dimensional interpolators, where N can vary at runtime.
 ///
-/// See [`InterpData`] and its aliases for concrete-dimensionality interpolator data structs.
+/// See [`InterpDataBase`] and its dimension-specific aliases (e.g., [`InterpData1D`], [`InterpData2D`]) for
+/// concrete-dimensionality interpolator data structs.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -10,8 +10,8 @@ mod tests;
 
 /// Interpolator data for N-dimensional interpolators, where N can vary at runtime.
 ///
-/// See [`InterpDataBase`] and its dimension-specific aliases (e.g., [`InterpData1D`], [`InterpData2D`]) for
-/// concrete-dimensionality interpolator data structs.
+/// See [`InterpDataBase`] and its dimension-specific aliases
+/// for concrete-dimensionality interpolator data structs.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -36,9 +36,9 @@ where
     #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_dyn"))]
     pub values: ArrayBase<D, IxDyn>,
 }
-/// [`InterpDataND`] for N-D data that owns data.
+/// [`InterpDataNDBase`] for N-D data that owns data.
 pub type InterpDataND<T> = InterpDataNDBase<OwnedRepr<T>>;
-/// [`InterpDataND`] that views data.
+/// [`InterpDataNDBase`] that views data.
 pub type InterpDataNDView<T> = InterpDataNDBase<ViewRepr<T>>;
 
 #[cfg(feature = "serde")]

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -23,7 +23,7 @@ mod tests;
         "
     ))
 )]
-pub struct InterpDataND<D>
+pub struct InterpDataNDBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -35,13 +35,13 @@ where
     #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_dyn"))]
     pub values: ArrayBase<D, IxDyn>,
 }
+/// [`InterpDataND`] for N-D data that owns data.
+pub type InterpDataND<T> = InterpDataNDBase<OwnedRepr<T>>;
 /// [`InterpDataND`] that views data.
-pub type InterpDataNDViewed<T> = InterpDataND<ViewRepr<T>>;
-/// [`InterpDataND`] that owns data.
-pub type InterpDataNDOwned<T> = InterpDataND<OwnedRepr<T>>;
+pub type InterpDataNDView<T> = InterpDataNDBase<ViewRepr<T>>;
 
 #[cfg(feature = "serde")]
-impl<D> SerializeNested for InterpDataND<D>
+impl<D> SerializeNested for InterpDataNDBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug + Serialize,
@@ -57,7 +57,7 @@ where
     }
 }
 
-impl<D> PartialEq for InterpDataND<D>
+impl<D> PartialEq for InterpDataNDBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -68,7 +68,7 @@ where
     }
 }
 
-impl<D> InterpDataND<D>
+impl<D> InterpDataNDBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -128,19 +128,19 @@ where
     }
 
     /// View interpolator data.
-    pub fn view(&self) -> InterpDataNDViewed<&D::Elem> {
-        InterpDataNDViewed {
+    pub fn view(&self) -> InterpDataNDView<&D::Elem> {
+        InterpDataNDView {
             grid: self.grid.iter().map(|g| g.view()).collect(),
             values: self.values.view(),
         }
     }
 
-    /// Turn the data into an [`InterpDataNDOwned`], cloning the array elements if necessary.
-    pub fn into_owned(self) -> InterpDataNDOwned<D::Elem>
+    /// Turn the data into an [`InterpDataND`], cloning the array elements if necessary.
+    pub fn into_owned(self) -> InterpDataND<D::Elem>
     where
         D::Elem: Clone,
     {
-        InterpDataNDOwned {
+        InterpDataND {
             grid: self.grid.into_iter().map(|g| g.into_owned()).collect(),
             values: self.values.into_owned(),
         }
@@ -164,29 +164,29 @@ where
         "
     ))
 )]
-pub struct InterpND<D, S>
+pub struct InterpNDBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
     S: Clone,
 {
     /// Interpolator data.
-    pub data: InterpDataND<D>,
+    pub data: InterpDataNDBase<D>,
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`InterpND`] that views data.
-pub type InterpNDViewed<T, S> = InterpND<ViewRepr<T>, S>;
 /// [`InterpND`] that owns data.
-pub type InterpNDOwned<T, S> = InterpND<OwnedRepr<T>, S>;
+pub type InterpND<T, S> = InterpNDBase<OwnedRepr<T>, S>;
+/// [`InterpND`] that views data.
+pub type InterpNDView<T, S> = InterpNDBase<ViewRepr<T>, S>;
 
-partialeq_impl!(InterpND, InterpDataND, StrategyND);
+partialeq_impl!(InterpNDBase, InterpDataNDBase, StrategyND);
 #[cfg(feature = "serde")]
-serialize_nested_impl!(InterpND, InterpDataND, StrategyND);
+serialize_nested_impl!(InterpNDBase, InterpDataNDBase, StrategyND);
 
-impl<D, S> InterpND<D, S>
+impl<D, S> InterpNDBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -215,7 +215,7 @@ where
     }
 }
 
-impl<D, S> InterpND<D, S>
+impl<D, S> InterpNDBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
@@ -228,8 +228,7 @@ where
     /// use ndarray::prelude::*;
     /// use ninterp::prelude::*;
     /// // f(x, y, z) = 0.2 * x + 0.2 * y + 0.2 * z
-    /// // type annotation for clarity
-    /// let interp: InterpNDOwned<f64, _> = InterpND::new(
+    /// let interp = InterpND::new(
     ///     // grid
     ///     vec![
     ///         // x
@@ -271,7 +270,7 @@ where
         extrapolate: Extrapolate<D::Elem>,
     ) -> Result<Self, ValidateError> {
         let mut interpolator = Self {
-            data: InterpDataND::new(grid, values)?,
+            data: InterpDataNDBase::new(grid, values)?,
             strategy,
             extrapolate,
         };
@@ -282,25 +281,25 @@ where
     }
 
     /// Return an interpolator with viewed data.
-    pub fn view(&self) -> InterpNDViewed<&D::Elem, S>
+    pub fn view(&self) -> InterpNDView<&D::Elem, S>
     where
         S: for<'a> StrategyND<ViewRepr<&'a D::Elem>>,
         D::Elem: Clone,
     {
-        InterpNDViewed {
+        InterpNDView {
             data: self.data.view(),
             strategy: self.strategy.clone(),
             extrapolate: self.extrapolate.clone(),
         }
     }
 
-    /// Turn the interpolator into an [`InterpNDOwned`], cloning the array elements if necessary.
-    pub fn into_owned(self) -> InterpNDOwned<D::Elem, S>
+    /// Turn the interpolator into an [`InterpND`], cloning the array elements if necessary.
+    pub fn into_owned(self) -> InterpND<D::Elem, S>
     where
         S: StrategyND<OwnedRepr<D::Elem>>,
         D::Elem: Clone,
     {
-        InterpNDOwned {
+        InterpND {
             data: self.data.into_owned(),
             strategy: self.strategy.clone(),
             extrapolate: self.extrapolate.clone(),
@@ -308,7 +307,7 @@ where
     }
 }
 
-impl<D, S> Interpolator<D::Elem> for InterpND<D, S>
+impl<D, S> Interpolator<D::Elem> for InterpNDBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: Num + PartialOrd + Euclid + Copy + Debug,
@@ -559,7 +558,7 @@ where
     }
 }
 
-extrapolate_impl!(InterpND, StrategyND);
-set_strategy_box_impl!(InterpND, StrategyND);
-set_strategy_enum_impl!(InterpND, strategy::enums::StrategyNDEnum);
-dyn_interpolator_impl!(InterpNDOwned, StrategyND);
+extrapolate_impl!(InterpNDBase, StrategyND);
+set_strategy_box_impl!(InterpNDBase, StrategyND);
+set_strategy_enum_impl!(InterpNDBase, strategy::enums::StrategyNDEnum);
+dyn_interpolator_impl!(InterpND, StrategyND);

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -36,9 +36,9 @@ where
     #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_dyn"))]
     pub values: ArrayBase<D, IxDyn>,
 }
-/// [`InterpDataNDBase`] for N-D data that owns data.
+/// Owned data variant for N-D data (see [`InterpDataNDBase`] for the generic form).
 pub type InterpDataND<T> = InterpDataNDBase<OwnedRepr<T>>;
-/// [`InterpDataNDBase`] that views data.
+/// Viewed data variant for N-D data (see [`InterpDataNDBase`] for the generic form).
 pub type InterpDataNDView<T> = InterpDataNDBase<ViewRepr<T>>;
 
 #[cfg(feature = "serde")]
@@ -51,7 +51,7 @@ where
     where
         S: Serializer,
     {
-        let mut s = serializer.serialize_struct("InterpDataND", 2)?;
+        let mut s = serializer.serialize_struct("InterpDataNDBase", 2)?;
         s.serialize_field("grid", &GridVecWrapper(&self.grid))?;
         s.serialize_field("values", &ArrayWrapper(&self.values))?;
         s.end()
@@ -178,9 +178,9 @@ where
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`InterpND`] that owns data.
+/// Owned interpolator variant (see [`InterpNDBase`] for the generic form).
 pub type InterpND<T, S> = InterpNDBase<OwnedRepr<T>, S>;
-/// [`InterpND`] that views data.
+/// Viewed interpolator variant (see [`InterpNDBase`] for the generic form).
 pub type InterpNDView<T, S> = InterpNDBase<ViewRepr<T>, S>;
 
 partialeq_impl!(InterpNDBase, InterpDataNDBase, StrategyND);

--- a/src/interpolator/n/strategies.rs
+++ b/src/interpolator/n/strategies.rs
@@ -8,7 +8,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError> {
         // Dimensionality
@@ -92,7 +92,7 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures grid uniformity in all dimensions
-    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
         for (dim, grid) in data.grid.iter().enumerate() {
             check_uniform_grid(grid.view(), dim)?;
         }
@@ -101,7 +101,7 @@ where
 
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError> {
         let n = data.values.ndim();
@@ -147,7 +147,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError> {
         let n = data.values.ndim();
@@ -180,7 +180,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the dimensionality of the interpolator
-    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
         let n = data.values.ndim();
         if self.0.len() != 1 && self.0.len() != n {
             return Err(ValidateError::Other(format!(
@@ -193,7 +193,7 @@ where
 
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError> {
         let n = data.values.ndim();
@@ -217,7 +217,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError> {
         let n = data.values.ndim();
@@ -240,7 +240,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError> {
         let n = data.values.ndim();

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -668,7 +668,7 @@ fn test_mismatched_grid() {
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct(InterpDataNDOwned<f64>);
+    struct MyStruct(InterpDataND<f64>);
 
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -687,7 +687,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: InterpNDBase<f64, strategy::Nearest> = serde_json::from_str(&ser).unwrap();
+    let de: InterpND<f64, strategy::Nearest> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // `ndarray` format by default
@@ -704,7 +704,7 @@ fn test_serde() {
     );
     // ...and the whole interpolator nests too
     let interp_ser_nested = serde_json::to_string(&crate::prelude::Nested(&interp)).unwrap();
-    let de_nested: InterpNDBase<f64, strategy::Nearest> =
+    let de_nested: InterpND<f64, strategy::Nearest> =
         serde_json::from_str(&interp_ser_nested).unwrap();
     assert_eq!(interp, de_nested);
 

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -86,7 +86,7 @@ fn test_dyn_interpolator() {
         InterpolateError::PointLength(3)
     ));
     assert_eq!(
-        boxed.as_any().downcast_ref::<InterpNDOwned<f64, _>>(),
+        boxed.as_any().downcast_ref::<InterpND<f64, _>>(),
         Some(&interp)
     );
 }
@@ -672,7 +672,7 @@ fn test_partialeq() {
 
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct2(InterpNDOwned<f64, strategy::Linear>);
+    struct MyStruct2(InterpND<f64, strategy::Linear>);
 }
 
 #[test]
@@ -687,7 +687,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: InterpNDOwned<f64, strategy::Nearest> = serde_json::from_str(&ser).unwrap();
+    let de: InterpNDBase<f64, strategy::Nearest> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // `ndarray` format by default
@@ -704,7 +704,7 @@ fn test_serde() {
     );
     // ...and the whole interpolator nests too
     let interp_ser_nested = serde_json::to_string(&crate::prelude::Nested(&interp)).unwrap();
-    let de_nested: InterpNDOwned<f64, strategy::Nearest> =
+    let de_nested: InterpNDBase<f64, strategy::Nearest> =
         serde_json::from_str(&interp_ser_nested).unwrap();
     assert_eq!(interp, de_nested);
 
@@ -773,10 +773,10 @@ fn test_dyn_interpolator_heterogeneous_storage() {
     // Downcast back to the concrete type for the first entry.
     assert!(interps[0]
         .as_any()
-        .downcast_ref::<Interp1DOwned<f64, strategy::Linear>>()
+        .downcast_ref::<Interp1D<f64, strategy::Linear>>()
         .is_some());
     assert!(interps[0]
         .as_any()
-        .downcast_ref::<Interp2DOwned<f64, strategy::Nearest>>()
+        .downcast_ref::<Interp2D<f64, strategy::Nearest>>()
         .is_none());
 }

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -8,11 +8,11 @@ mod tests;
 
 const N: usize = 1;
 
-/// [`InterpData`] generic (base) form for 1-D data.
+/// Generic (base) form for 1-D data; parameterized by data representation.
 pub type InterpData1DBase<D> = InterpDataBase<D, N>;
-/// [`InterpData`] for 1-D data that owns data.
+/// Owned data variant for 1-D data (see [`InterpData1DBase`] for the generic form).
 pub type InterpData1D<T> = InterpData1DBase<OwnedRepr<T>>;
-/// [`InterpData1D`] that views data.
+/// Viewed data variant for 1-D data (see [`InterpData1DBase`] for the generic form).
 pub type InterpData1DView<T> = InterpData1DBase<ViewRepr<T>>;
 
 impl<D> InterpData1DBase<D>

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -8,14 +8,14 @@ mod tests;
 
 const N: usize = 1;
 
-/// [`InterpData`] for 1-D data.
-pub type InterpData1D<D> = InterpData<D, N>;
+/// [`InterpData`] generic (base) form for 1-D data.
+pub type InterpData1DBase<D> = InterpDataBase<D, N>;
+/// [`InterpData`] for 1-D data that owns data.
+pub type InterpData1D<T> = InterpData1DBase<OwnedRepr<T>>;
 /// [`InterpData1D`] that views data.
-pub type InterpData1DViewed<T> = InterpData1D<ViewRepr<T>>;
-/// [`InterpData1D`] that owns data.
-pub type InterpData1DOwned<T> = InterpData1D<OwnedRepr<T>>;
+pub type InterpData1DView<T> = InterpData1DBase<ViewRepr<T>>;
 
-impl<D> InterpData1D<D>
+impl<D> InterpData1DBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
@@ -48,25 +48,25 @@ where
         "
     ))
 )]
-pub struct Interp1D<D, S>
+pub struct Interp1DBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
     S: Clone,
 {
     /// Interpolator data.
-    pub data: InterpData1D<D>,
+    pub data: InterpData1DBase<D>,
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`Interp1D`] that views data.
-pub type Interp1DViewed<T, S> = Interp1D<ViewRepr<T>, S>;
 /// [`Interp1D`] that owns data.
-pub type Interp1DOwned<T, S> = Interp1D<OwnedRepr<T>, S>;
+pub type Interp1D<T, S> = Interp1DBase<OwnedRepr<T>, S>;
+/// [`Interp1D`] that views data.
+pub type Interp1DView<T, S> = Interp1DBase<ViewRepr<T>, S>;
 
-impl<D, S> Interp1D<D, S>
+impl<D, S> Interp1DBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -79,8 +79,7 @@ where
     /// use ndarray::prelude::*;
     /// use ninterp::prelude::*;
     /// // f(x) = 0.4 * x
-    /// // type annotation for clarity
-    /// let interp: Interp1DOwned<f64, _> = Interp1D::new(
+    /// let interp = Interp1D::new(
     ///     // x
     ///     array![0., 1., 2.], // x0, x1, x2
     ///     // f(x)
@@ -102,7 +101,7 @@ where
         D::Elem: PartialOrd,
     {
         let mut interpolator = Self {
-            data: InterpData1D::new(x, f_x)?,
+            data: InterpData1DBase::new(x, f_x)?,
             strategy,
             extrapolate,
         };
@@ -113,17 +112,17 @@ where
     }
 
     interp_inherent_methods!(
-        Interp1D,
+        Interp1DBase,
         Strategy1D,
-        Interp1DViewed<&D::Elem, S>,
-        Interp1DOwned<D::Elem, S>
+        Interp1DView<&D::Elem, S>,
+        Interp1D<D::Elem, S>
     );
 }
 
 interp_trait_impls!(
+    Interp1DBase,
     Interp1D,
-    Interp1DOwned,
-    InterpData1D,
+    InterpData1DBase,
     Strategy1D,
     strategy::enums::Strategy1DEnum,
     N

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -61,9 +61,9 @@ where
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`Interp1D`] that owns data.
+/// Owned interpolator variant (see [`Interp1DBase`] for the generic form).
 pub type Interp1D<T, S> = Interp1DBase<OwnedRepr<T>, S>;
-/// [`Interp1D`] that views data.
+/// Viewed interpolator variant (see [`Interp1DBase`] for the generic form).
 pub type Interp1DView<T, S> = Interp1DBase<ViewRepr<T>, S>;
 
 impl<D, S> Interp1DBase<D, S>

--- a/src/interpolator/one/strategies.rs
+++ b/src/interpolator/one/strategies.rs
@@ -8,7 +8,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData1D<D>,
+        data: &InterpData1DBase<D>,
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
         // Extrapolation is checked previously in Interpolator::interpolate,
@@ -34,13 +34,13 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures the grid is uniformly spaced.
-    fn validate(&self, data: &InterpData1D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpData1DBase<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)
     }
 
     fn interpolate(
         &self,
-        data: &InterpData1D<D>,
+        data: &InterpData1DBase<D>,
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
         let grid = data.grid[0].view();
@@ -64,7 +64,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData1D<D>,
+        data: &InterpData1DBase<D>,
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
         let x_l = locate_lower_index(data.grid[0].view(), &point[0]);
@@ -89,7 +89,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
-    fn validate(&self, _data: &InterpData1D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, _data: &InterpData1DBase<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 {
             return Err(ValidateError::Other(format!(
                 "Step strategy has {} directions but interpolator is 1-D (expected 1)",
@@ -101,7 +101,7 @@ where
 
     fn interpolate(
         &self,
-        data: &InterpData1D<D>,
+        data: &InterpData1DBase<D>,
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
         Ok(data.values[locate_step_index(self.dir(0), data.grid[0].view(), &point[0])])
@@ -119,7 +119,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData1D<D>,
+        data: &InterpData1DBase<D>,
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
         Ok(data.values[locate_step_index(StepDirection::Lower, data.grid[0].view(), &point[0])])
@@ -138,7 +138,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData1D<D>,
+        data: &InterpData1DBase<D>,
         point: &[D::Elem; 1],
     ) -> Result<D::Elem, InterpolateError> {
         Ok(data.values[locate_step_index(StepDirection::Upper, data.grid[0].view(), &point[0])])

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -472,7 +472,7 @@ fn test_batch_interpolate_dyn() {
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct(InterpData1DOwned<f64>);
+    struct MyStruct(InterpData1D<f64>);
 
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -61,7 +61,7 @@ fn test_dyn_interpolator() {
         InterpolateError::PointLength(1)
     ));
     assert_eq!(
-        boxed.as_any().downcast_ref::<Interp1DOwned<f64, _>>(),
+        boxed.as_any().downcast_ref::<Interp1D<f64, _>>(),
         Some(&interp)
     );
 }
@@ -476,7 +476,7 @@ fn test_partialeq() {
 
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct2(Interp1DOwned<f64, strategy::Linear>);
+    struct MyStruct2(Interp1D<f64, strategy::Linear>);
 }
 
 #[test]
@@ -491,7 +491,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: Interp1DOwned<f64, strategy::Step> = serde_json::from_str(&ser).unwrap();
+    let de: Interp1DBase<f64, strategy::Step> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // `ndarray` format by default
@@ -508,7 +508,7 @@ fn test_serde() {
     );
     // ...and the whole interpolator nests too
     let interp_ser_nested = serde_json::to_string(&crate::prelude::Nested(&interp)).unwrap();
-    let de_nested: Interp1DOwned<f64, strategy::Step> =
+    let de_nested: Interp1DBase<f64, strategy::Step> =
         serde_json::from_str(&interp_ser_nested).unwrap();
     assert_eq!(interp, de_nested);
 

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -491,7 +491,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: Interp1DBase<f64, strategy::Step> = serde_json::from_str(&ser).unwrap();
+    let de: Interp1D<f64, strategy::Step> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // `ndarray` format by default
@@ -508,7 +508,7 @@ fn test_serde() {
     );
     // ...and the whole interpolator nests too
     let interp_ser_nested = serde_json::to_string(&crate::prelude::Nested(&interp)).unwrap();
-    let de_nested: Interp1DBase<f64, strategy::Step> =
+    let de_nested: Interp1D<f64, strategy::Step> =
         serde_json::from_str(&interp_ser_nested).unwrap();
     assert_eq!(interp, de_nested);
 

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -8,14 +8,14 @@ mod tests;
 
 const N: usize = 3;
 
-/// [`InterpData`] for 3-D data.
-pub type InterpData3D<D> = InterpData<D, N>;
+/// [`InterpData`] generic (base) form for 3-D data.
+pub type InterpData3DBase<D> = InterpDataBase<D, N>;
+/// [`InterpData`] for 3-D data that owns data.
+pub type InterpData3D<T> = InterpData3DBase<OwnedRepr<T>>;
 /// [`InterpData3D`] that views data.
-pub type InterpData3DViewed<T> = InterpData3D<ViewRepr<T>>;
-/// [`InterpData3D`] that owns data.
-pub type InterpData3DOwned<T> = InterpData3D<OwnedRepr<T>>;
+pub type InterpData3DView<T> = InterpData3DBase<ViewRepr<T>>;
 
-impl<D> InterpData3D<D>
+impl<D> InterpData3DBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
@@ -53,25 +53,25 @@ where
         "
     ))
 )]
-pub struct Interp3D<D, S>
+pub struct Interp3DBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
     S: Clone,
 {
     /// Interpolator data.
-    pub data: InterpData3D<D>,
+    pub data: InterpData3DBase<D>,
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`Interp3D`] that views data.
-pub type Interp3DViewed<T, S> = Interp3D<ViewRepr<T>, S>;
 /// [`Interp3D`] that owns data.
-pub type Interp3DOwned<T, S> = Interp3D<OwnedRepr<T>, S>;
+pub type Interp3D<T, S> = Interp3DBase<OwnedRepr<T>, S>;
+/// [`Interp3D`] that views data.
+pub type Interp3DView<T, S> = Interp3DBase<ViewRepr<T>, S>;
 
-impl<D, S> Interp3D<D, S>
+impl<D, S> Interp3DBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -84,8 +84,7 @@ where
     /// use ndarray::prelude::*;
     /// use ninterp::prelude::*;
     /// // f(x, y, z) = 0.2 * x + 0.2 * y + 0.2 * z
-    /// // type annotation for clarity
-    /// let interp: Interp3DOwned<f64, _> = Interp3D::new(
+    /// let interp = Interp3D::new(
     ///     // x
     ///     array![1., 2.], // x0, x1
     ///     // y
@@ -128,7 +127,7 @@ where
         D::Elem: PartialOrd,
     {
         let mut interpolator = Self {
-            data: InterpData3D::new(x, y, z, f_xyz)?,
+            data: InterpData3DBase::new(x, y, z, f_xyz)?,
             strategy,
             extrapolate,
         };
@@ -139,17 +138,17 @@ where
     }
 
     interp_inherent_methods!(
-        Interp3D,
+        Interp3DBase,
         Strategy3D,
-        Interp3DViewed<&D::Elem, S>,
-        Interp3DOwned<D::Elem, S>
+        Interp3DView<&D::Elem, S>,
+        Interp3D<D::Elem, S>
     );
 }
 
 interp_trait_impls!(
+    Interp3DBase,
     Interp3D,
-    Interp3DOwned,
-    InterpData3D,
+    InterpData3DBase,
     Strategy3D,
     strategy::enums::Strategy3DEnum,
     N

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -8,11 +8,11 @@ mod tests;
 
 const N: usize = 3;
 
-/// [`InterpData`] generic (base) form for 3-D data.
+/// Generic (base) form for 3-D data; parameterized by data representation.
 pub type InterpData3DBase<D> = InterpDataBase<D, N>;
-/// [`InterpData`] for 3-D data that owns data.
+/// Owned data variant for 3-D data (see [`InterpData3DBase`] for the generic form).
 pub type InterpData3D<T> = InterpData3DBase<OwnedRepr<T>>;
-/// [`InterpData3D`] that views data.
+/// Viewed data variant for 3-D data (see [`InterpData3DBase`] for the generic form).
 pub type InterpData3DView<T> = InterpData3DBase<ViewRepr<T>>;
 
 impl<D> InterpData3DBase<D>

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -66,9 +66,9 @@ where
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`Interp3D`] that owns data.
+/// Owned interpolator variant (see [`Interp3DBase`] for the generic form).
 pub type Interp3D<T, S> = Interp3DBase<OwnedRepr<T>, S>;
-/// [`Interp3D`] that views data.
+/// Viewed interpolator variant (see [`Interp3DBase`] for the generic form).
 pub type Interp3DView<T, S> = Interp3DBase<ViewRepr<T>, S>;
 
 impl<D, S> Interp3DBase<D, S>

--- a/src/interpolator/three/strategies.rs
+++ b/src/interpolator/three/strategies.rs
@@ -8,7 +8,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData3D<D>,
+        data: &InterpData3DBase<D>,
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError> {
         // Extrapolation is checked previously in Interpolator::interpolate,
@@ -164,7 +164,7 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures all grid dimensions are uniformly spaced.
-    fn validate(&self, data: &InterpData3D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpData3DBase<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)?;
         check_uniform_grid(data.grid[1].view(), 1)?;
         check_uniform_grid(data.grid[2].view(), 2)
@@ -172,7 +172,7 @@ where
 
     fn interpolate(
         &self,
-        data: &InterpData3D<D>,
+        data: &InterpData3DBase<D>,
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError> {
         let x_step = data.grid[0][1] - data.grid[0][0];
@@ -213,7 +213,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData3D<D>,
+        data: &InterpData3DBase<D>,
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError> {
         // x
@@ -256,7 +256,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
-    fn validate(&self, _data: &InterpData3D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, _data: &InterpData3DBase<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 && self.0.len() != 3 {
             return Err(ValidateError::Other(format!(
                 "Step strategy has {} directions but interpolator is 3-D (expected 1 or 3)",
@@ -268,7 +268,7 @@ where
 
     fn interpolate(
         &self,
-        data: &InterpData3D<D>,
+        data: &InterpData3DBase<D>,
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError> {
         let i = locate_step_index(self.dir(0), data.grid[0].view(), &point[0]);
@@ -290,7 +290,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData3D<D>,
+        data: &InterpData3DBase<D>,
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError> {
         let i = locate_step_index(StepDirection::Lower, data.grid[0].view(), &point[0]);
@@ -311,7 +311,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData3D<D>,
+        data: &InterpData3DBase<D>,
         point: &[D::Elem; 3],
     ) -> Result<D::Elem, InterpolateError> {
         let i = locate_step_index(StepDirection::Upper, data.grid[0].view(), &point[0]);

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -449,7 +449,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: Interp3DBase<_, _> = serde_json::from_str(&ser).unwrap();
+    let de: Interp3D<_, _> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // simple format (new serialization output)

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -417,7 +417,7 @@ fn test_batch_interpolate_error_aggregates_all_points() {
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct(InterpData3DOwned<f64>);
+    struct MyStruct(InterpData3D<f64>);
 
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -54,7 +54,7 @@ fn test_dyn_interpolator() {
         InterpolateError::PointLength(3)
     ));
     assert_eq!(
-        boxed.as_any().downcast_ref::<Interp3DOwned<f64, _>>(),
+        boxed.as_any().downcast_ref::<Interp3D<f64, _>>(),
         Some(&interp)
     );
 }
@@ -421,7 +421,7 @@ fn test_partialeq() {
 
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct2(Interp3DOwned<f64, strategy::Linear>);
+    struct MyStruct2(Interp3D<f64, strategy::Linear>);
 }
 
 #[test]
@@ -449,7 +449,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: Interp3D<_, _> = serde_json::from_str(&ser).unwrap();
+    let de: Interp3DBase<_, _> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // simple format (new serialization output)

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -8,11 +8,11 @@ mod tests;
 
 const N: usize = 2;
 
-/// [`InterpData`] generic (base) form for 2-D data.
+/// Generic (base) form for 2-D data; parameterized by data representation.
 pub type InterpData2DBase<D> = InterpDataBase<D, N>;
-/// [`InterpData`] for 2-D data that owns data.
+/// Owned data variant for 2-D data (see [`InterpData2DBase`] for the generic form).
 pub type InterpData2D<T> = InterpData2DBase<OwnedRepr<T>>;
-/// [`InterpData2D`] that views data.
+/// Viewed data variant for 2-D data (see [`InterpData2DBase`] for the generic form).
 pub type InterpData2DView<T> = InterpData2DBase<ViewRepr<T>>;
 
 impl<D> InterpData2DBase<D>

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -8,14 +8,14 @@ mod tests;
 
 const N: usize = 2;
 
-/// [`InterpData`] for 2-D data.
-pub type InterpData2D<D> = InterpData<D, N>;
+/// [`InterpData`] generic (base) form for 2-D data.
+pub type InterpData2DBase<D> = InterpDataBase<D, N>;
+/// [`InterpData`] for 2-D data that owns data.
+pub type InterpData2D<T> = InterpData2DBase<OwnedRepr<T>>;
 /// [`InterpData2D`] that views data.
-pub type InterpData2DViewed<T> = InterpData2D<ViewRepr<T>>;
-/// [`InterpData2D`] that owns data.
-pub type InterpData2DOwned<T> = InterpData2D<OwnedRepr<T>>;
+pub type InterpData2DView<T> = InterpData2DBase<ViewRepr<T>>;
 
-impl<D> InterpData2D<D>
+impl<D> InterpData2DBase<D>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialOrd + Debug,
@@ -52,25 +52,25 @@ where
         "
     ))
 )]
-pub struct Interp2D<D, S>
+pub struct Interp2DBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
     S: Clone,
 {
     /// Interpolator data.
-    pub data: InterpData2D<D>,
+    pub data: InterpData2DBase<D>,
     /// Interpolation strategy.
     pub strategy: S,
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`Interp2D`] that views data.
-pub type Interp2DViewed<T, S> = Interp2D<ViewRepr<T>, S>;
 /// [`Interp2D`] that owns data.
-pub type Interp2DOwned<T, S> = Interp2D<OwnedRepr<T>, S>;
+pub type Interp2D<T, S> = Interp2DBase<OwnedRepr<T>, S>;
+/// [`Interp2D`] that views data.
+pub type Interp2DView<T, S> = Interp2DBase<ViewRepr<T>, S>;
 
-impl<D, S> Interp2D<D, S>
+impl<D, S> Interp2DBase<D, S>
 where
     D: Data + RawDataClone + Clone,
     D::Elem: PartialEq + Debug,
@@ -83,8 +83,7 @@ where
     /// use ndarray::prelude::*;
     /// use ninterp::prelude::*;
     /// // f(x, y) = 0.2 * x + 0.4 * y
-    /// // type annotation for clarity
-    /// let interp: Interp2DOwned<f64, _> = Interp2D::new(
+    /// let interp = Interp2D::new(
     ///     // x
     ///     array![0., 1., 2.], // x0, x1, x2
     ///     // y
@@ -116,7 +115,7 @@ where
         D::Elem: PartialOrd,
     {
         let mut interpolator = Self {
-            data: InterpData2D::new(x, y, f_xy)?,
+            data: InterpData2DBase::new(x, y, f_xy)?,
             strategy,
             extrapolate,
         };
@@ -127,17 +126,17 @@ where
     }
 
     interp_inherent_methods!(
-        Interp2D,
+        Interp2DBase,
         Strategy2D,
-        Interp2DViewed<&D::Elem, S>,
-        Interp2DOwned<D::Elem, S>
+        Interp2DView<&D::Elem, S>,
+        Interp2D<D::Elem, S>
     );
 }
 
 interp_trait_impls!(
+    Interp2DBase,
     Interp2D,
-    Interp2DOwned,
-    InterpData2D,
+    InterpData2DBase,
     Strategy2D,
     strategy::enums::Strategy2DEnum,
     N

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -65,9 +65,9 @@ where
     /// Extrapolation setting.
     pub extrapolate: Extrapolate<D::Elem>,
 }
-/// [`Interp2D`] that owns data.
+/// Owned interpolator variant (see [`Interp2DBase`] for the generic form).
 pub type Interp2D<T, S> = Interp2DBase<OwnedRepr<T>, S>;
-/// [`Interp2D`] that views data.
+/// Viewed interpolator variant (see [`Interp2DBase`] for the generic form).
 pub type Interp2DView<T, S> = Interp2DBase<ViewRepr<T>, S>;
 
 impl<D, S> Interp2DBase<D, S>

--- a/src/interpolator/two/strategies.rs
+++ b/src/interpolator/two/strategies.rs
@@ -8,7 +8,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData2D<D>,
+        data: &InterpData2DBase<D>,
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError> {
         // Extrapolation is checked previously in Interpolator::interpolate,
@@ -78,14 +78,14 @@ where
     D::Elem: Float + Debug,
 {
     /// Ensures all grid dimensions are uniformly spaced.
-    fn validate(&self, data: &InterpData2D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpData2DBase<D>) -> Result<(), ValidateError> {
         check_uniform_grid(data.grid[0].view(), 0)?;
         check_uniform_grid(data.grid[1].view(), 1)
     }
 
     fn interpolate(
         &self,
-        data: &InterpData2D<D>,
+        data: &InterpData2DBase<D>,
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError> {
         let x_step = data.grid[0][1] - data.grid[0][0];
@@ -116,7 +116,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData2D<D>,
+        data: &InterpData2DBase<D>,
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError> {
         // x
@@ -151,7 +151,7 @@ where
     D::Elem: PartialOrd + Copy + Debug,
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
-    fn validate(&self, _data: &InterpData2D<D>) -> Result<(), ValidateError> {
+    fn validate(&self, _data: &InterpData2DBase<D>) -> Result<(), ValidateError> {
         if self.0.len() != 1 && self.0.len() != 2 {
             return Err(ValidateError::Other(format!(
                 "Step strategy has {} directions but interpolator is 2-D (expected 1 or 2)",
@@ -163,7 +163,7 @@ where
 
     fn interpolate(
         &self,
-        data: &InterpData2D<D>,
+        data: &InterpData2DBase<D>,
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError> {
         let i = locate_step_index(self.dir(0), data.grid[0].view(), &point[0]);
@@ -184,7 +184,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData2D<D>,
+        data: &InterpData2DBase<D>,
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError> {
         let i = locate_step_index(StepDirection::Lower, data.grid[0].view(), &point[0]);
@@ -204,7 +204,7 @@ where
 {
     fn interpolate(
         &self,
-        data: &InterpData2D<D>,
+        data: &InterpData2DBase<D>,
         point: &[D::Elem; 2],
     ) -> Result<D::Elem, InterpolateError> {
         let i = locate_step_index(StepDirection::Upper, data.grid[0].view(), &point[0]);

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -120,7 +120,7 @@ fn test_step() {
     let values = array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]];
 
     // Uniform Lower (floor) in all dimensions
-    let interp = Interp2D::new(
+    let interp = Interp2DView::new(
         grid_x.view(),
         grid_y.view(),
         values.view(),
@@ -139,7 +139,7 @@ fn test_step() {
     assert_eq!(interp.interpolate(&[0.7, 1.4]).unwrap(), f[[0, 1]]); // floor x→0, floor y→1
     assert_eq!(interp.interpolate(&[1.9, 0.1]).unwrap(), f[[1, 0]]); // floor x→1, floor y→0
 
-    let interp_lower = Interp2D::new(
+    let interp_lower = Interp2DView::new(
         grid_x.view(),
         grid_y.view(),
         values.view(),
@@ -149,7 +149,7 @@ fn test_step() {
     .unwrap();
     assert_eq!(interp_lower.interpolate(&[0.7, 1.4]).unwrap(), f[[0, 1]]);
 
-    let interp_upper = Interp2D::new(
+    let interp_upper = Interp2DView::new(
         grid_x.view(),
         grid_y.view(),
         values.view(),
@@ -160,7 +160,7 @@ fn test_step() {
     assert_eq!(interp_upper.interpolate(&[0.7, 1.4]).unwrap(), f[[1, 2]]);
 
     // Per-dimension: Lower in x, Upper in y
-    let interp_mixed = Interp2D::new(
+    let interp_mixed = Interp2DView::new(
         grid_x.view(),
         grid_y.view(),
         values.view(),
@@ -175,7 +175,7 @@ fn test_step() {
     assert_eq!(interp_mixed.interpolate(&[1.3, 0.8]).unwrap(), f[[1, 1]]); // floor x→1, ceil y→1
 
     // Invalid: 3 directions for 2-D
-    assert!(Interp2D::new(
+    assert!(Interp2DView::new(
         grid_x.view(),
         grid_y.view(),
         values.view(),
@@ -615,7 +615,7 @@ fn test_batch_interpolate_into_dyn() {
 fn test_partialeq() {
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct(InterpData2DOwned<f64>);
+    struct MyStruct(InterpData2D<f64>);
 
     #[derive(PartialEq)]
     #[allow(unused)]

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -278,7 +278,7 @@ fn test_set_strategy_runs_init() {
     // `Step`'s `validate` checks its direction count against dimensionality,
     // so swapping in a `Step` with the wrong count via `set_strategy` must
     // surface that error rather than silently leaving the strategy unvalidated.
-    let mut interp: Interp2DBase<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
+    let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
         array![0., 1.],
         array![0., 1.],
         array![[0., 1.], [2., 3.]],
@@ -300,7 +300,7 @@ fn test_set_strategy_runs_validate() {
     // fine, but swapping to `LinearUniform` via `set_strategy` must catch it via
     // `Strategy2D::validate` rather than silently accepting a strategy that will
     // produce wrong results at query time.
-    let mut interp: Interp2DBase<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
+    let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
         array![0., 1., 5.], // non-uniform
         array![0., 1., 2.],
         array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -635,7 +635,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: Interp2DBase<f64, strategy::Linear> = serde_json::from_str(&ser).unwrap();
+    let de: Interp2D<f64, strategy::Linear> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // simple format (new serialization output)

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -278,7 +278,7 @@ fn test_set_strategy_runs_init() {
     // `Step`'s `validate` checks its direction count against dimensionality,
     // so swapping in a `Step` with the wrong count via `set_strategy` must
     // surface that error rather than silently leaving the strategy unvalidated.
-    let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
+    let mut interp: Interp2DBase<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
         array![0., 1.],
         array![0., 1.],
         array![[0., 1.], [2., 3.]],
@@ -300,7 +300,7 @@ fn test_set_strategy_runs_validate() {
     // fine, but swapping to `LinearUniform` via `set_strategy` must catch it via
     // `Strategy2D::validate` rather than silently accepting a strategy that will
     // produce wrong results at query time.
-    let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
+    let mut interp: Interp2DBase<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
         array![0., 1., 5.], // non-uniform
         array![0., 1., 2.],
         array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
@@ -454,7 +454,7 @@ fn test_dyn_interpolator() {
         InterpolateError::PointLength(2)
     ));
     assert_eq!(
-        boxed.as_any().downcast_ref::<Interp2DOwned<f64, _>>(),
+        boxed.as_any().downcast_ref::<Interp2D<f64, _>>(),
         Some(&interp)
     );
 }
@@ -619,7 +619,7 @@ fn test_partialeq() {
 
     #[derive(PartialEq)]
     #[allow(unused)]
-    struct MyStruct2(Interp2DOwned<f64, strategy::Linear>);
+    struct MyStruct2(Interp2D<f64, strategy::Linear>);
 }
 
 #[test]
@@ -635,7 +635,7 @@ fn test_serde() {
     .unwrap();
 
     let ser = serde_json::to_string(&interp).unwrap();
-    let de: Interp2DOwned<f64, strategy::Linear> = serde_json::from_str(&ser).unwrap();
+    let de: Interp2DBase<f64, strategy::Linear> = serde_json::from_str(&ser).unwrap();
     assert_eq!(interp, de);
 
     // simple format (new serialization output)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,13 @@ pub mod prelude {
     pub use crate::interpolator::{Extrapolate, Interpolator};
 
     pub use crate::interpolator::Interp0D;
-    pub use crate::interpolator::{Interp1D, Interp1DOwned, Interp1DViewed};
-    pub use crate::interpolator::{Interp2D, Interp2DOwned, Interp2DViewed};
-    pub use crate::interpolator::{Interp3D, Interp3DOwned, Interp3DViewed};
-    pub use crate::interpolator::{InterpND, InterpNDOwned, InterpNDViewed};
+    pub use crate::interpolator::{Interp1D, Interp1DBase, Interp1DView};
+    pub use crate::interpolator::{Interp2D, Interp2DBase, Interp2DView};
+    pub use crate::interpolator::{Interp3D, Interp3DBase, Interp3DView};
+    pub use crate::interpolator::{InterpND, InterpNDBase, InterpNDView};
 
     pub use crate::interpolator::enums::{
-        InterpolatorEnum, InterpolatorEnumOwned, InterpolatorEnumViewed,
+        InterpolatorEnum, InterpolatorEnumBase, InterpolatorEnumView,
     };
 
     #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 ///   - [`Interp3D`](`interpolator::Interp3D`)
 ///   - [`InterpND`](`interpolator::InterpND`)
 ///   - A `serde`-compatible interpolator enum [`InterpolatorEnum`](`interpolator::enums::InterpolatorEnum`)
-///   - `Owned` and `Viewed` type aliases for all of the above
+///   - `Base` (generic) and `View` (borrowed) type aliases for all of the above
 /// - Their common trait: [`Interpolator`](`interpolator::Interpolator`)
 /// - The [`strategy`] mod, containing pre-defined interpolation strategies:
 ///   - [`strategy::Linear`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(missing_docs)]
 
 /// The `prelude` module exposes a variety of types:
-/// - All interpolator structs:
+/// - All interpolator types:
 ///   - [`Interp0D`](`interpolator::Interp0D`)
 ///   - [`Interp1D`](`interpolator::Interp1D`)
 ///   - [`Interp2D`](`interpolator::Interp2D`)

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -28,7 +28,7 @@ pub trait SerializeNested {
 /// #[derive(serde::Serialize)]
 /// struct Config {
 ///     #[serde(serialize_with = "serialize_nested")]
-///     curve: Interp1DBase<f64, strategy::Linear>,
+///     curve: Interp1D<f64, strategy::Linear>,
 /// }
 /// ```
 ///
@@ -39,7 +39,7 @@ pub trait SerializeNested {
 /// ```
 /// # use ndarray::array;
 /// # use ninterp::prelude::*;
-/// # use ninterp::data::InterpData1DOwned;
+/// # use ninterp::data::InterpData1D;
 /// let interp = Interp1D::new(
 ///     array![0., 1., 2.],
 ///     array![0.0, 0.4, 0.8],
@@ -52,7 +52,7 @@ pub trait SerializeNested {
 /// assert_eq!(json, r#"{"grid":[[0.0,1.0,2.0]],"values":[0.0,0.4,0.8]}"#);
 ///
 /// // ...and reads back regardless of which format it was written in
-/// let de: InterpData1DOwned<f64> = serde_json::from_str(&json).unwrap();
+/// let de: InterpData1D<f64> = serde_json::from_str(&json).unwrap();
 /// assert_eq!(de, interp.data);
 /// ```
 pub struct Nested<'a, T: ?Sized>(pub &'a T);
@@ -83,7 +83,7 @@ where
 /// #[derive(serde::Serialize)]
 /// struct Config {
 ///     #[serde(serialize_with = "serialize_nested")]
-///     curve: Interp1DBase<f64, strategy::Linear>,
+///     curve: Interp1D<f64, strategy::Linear>,
 /// }
 /// ```
 pub fn serialize_nested<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -28,7 +28,7 @@ pub trait SerializeNested {
 /// #[derive(serde::Serialize)]
 /// struct Config {
 ///     #[serde(serialize_with = "serialize_nested")]
-///     curve: Interp1DOwned<f64, strategy::Linear>,
+///     curve: Interp1DBase<f64, strategy::Linear>,
 /// }
 /// ```
 ///
@@ -83,7 +83,7 @@ where
 /// #[derive(serde::Serialize)]
 /// struct Config {
 ///     #[serde(serialize_with = "serialize_nested")]
-///     curve: Interp1DOwned<f64, strategy::Linear>,
+///     curve: Interp1DBase<f64, strategy::Linear>,
 /// }
 /// ```
 pub fn serialize_nested<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/strategy/enums/mod.rs
+++ b/src/strategy/enums/mod.rs
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_1d() {
-        let mut interp: Interp1DBase<_, strategy::enums::Strategy1DEnum> = Interp1DBase::new(
+        let mut interp: Interp1D<_, strategy::enums::Strategy1DEnum> = Interp1D::new(
             array![0., 1., 2., 3., 4.],
             array![0.2, 0.4, 0.6, 0.8, 1.0],
             strategy::Linear.into(),
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_2d() {
-        let mut interp: Interp2DBase<_, strategy::enums::Strategy2DEnum> = Interp2DBase::new(
+        let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
             array![0.05, 0.10, 0.15],
             array![0.10, 0.20, 0.30],
             array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_3d() {
-        let mut interp: Interp3DBase<_, strategy::enums::Strategy3DEnum> = Interp3DBase::new(
+        let mut interp: Interp3D<_, strategy::enums::Strategy3DEnum> = Interp3D::new(
             array![0.05, 0.10, 0.15],
             array![0.10, 0.20, 0.30],
             array![0.20, 0.40, 0.60],
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_nd() {
-        let mut interp: InterpNDBase<_, strategy::enums::StrategyNDEnum> = InterpNDBase::new(
+        let mut interp: InterpND<_, strategy::enums::StrategyNDEnum> = InterpND::new(
             vec![
                 array![0.05, 0.10, 0.15],
                 array![0.10, 0.20, 0.30],

--- a/src/strategy/enums/mod.rs
+++ b/src/strategy/enums/mod.rs
@@ -12,7 +12,7 @@
 //! use ndarray::prelude::*;
 //! use ninterp::prelude::*;
 //!
-//! let mut interp: Interp1DOwned<_, strategy::enums::Strategy1DEnum> = Interp1D::new(
+//! let mut interp: Interp1DBase<_, strategy::enums::Strategy1DEnum> = Interp1D::new(
 //!     // x
 //!     array![0., 1., 2., 3., 4.],
 //!     // f(x)
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_1d() {
-        let mut interp: Interp1D<_, strategy::enums::Strategy1DEnum> = Interp1D::new(
+        let mut interp: Interp1DBase<_, strategy::enums::Strategy1DEnum> = Interp1DBase::new(
             array![0., 1., 2., 3., 4.],
             array![0.2, 0.4, 0.6, 0.8, 1.0],
             strategy::Linear.into(),
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_2d() {
-        let mut interp: Interp2D<_, strategy::enums::Strategy2DEnum> = Interp2D::new(
+        let mut interp: Interp2DBase<_, strategy::enums::Strategy2DEnum> = Interp2DBase::new(
             array![0.05, 0.10, 0.15],
             array![0.10, 0.20, 0.30],
             array![[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]],
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_3d() {
-        let mut interp: Interp3D<_, strategy::enums::Strategy3DEnum> = Interp3D::new(
+        let mut interp: Interp3DBase<_, strategy::enums::Strategy3DEnum> = Interp3DBase::new(
             array![0.05, 0.10, 0.15],
             array![0.10, 0.20, 0.30],
             array![0.20, 0.40, 0.60],
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_nd() {
-        let mut interp: InterpND<_, strategy::enums::StrategyNDEnum> = InterpND::new(
+        let mut interp: InterpNDBase<_, strategy::enums::StrategyNDEnum> = InterpNDBase::new(
             vec![
                 array![0.05, 0.10, 0.15],
                 array![0.10, 0.20, 0.30],

--- a/src/strategy/enums/mod.rs
+++ b/src/strategy/enums/mod.rs
@@ -12,7 +12,7 @@
 //! use ndarray::prelude::*;
 //! use ninterp::prelude::*;
 //!
-//! let mut interp: Interp1DBase<_, strategy::enums::Strategy1DEnum> = Interp1D::new(
+//! let mut interp: Interp1D<_, strategy::enums::Strategy1DEnum> = Interp1D::new(
 //!     // x
 //!     array![0., 1., 2., 3., 4.],
 //!     // f(x)

--- a/src/strategy/enums/n.rs
+++ b/src/strategy/enums/n.rs
@@ -3,7 +3,7 @@ use super::*;
 strategy_enum_impl!(
     StrategyNDEnum,
     StrategyND,
-    InterpDataND,
+    InterpDataNDBase,
     &[D::Elem],
     [
         (Linear, strategy::Linear),

--- a/src/strategy/enums/one.rs
+++ b/src/strategy/enums/one.rs
@@ -3,7 +3,7 @@ use super::*;
 strategy_enum_impl!(
     Strategy1DEnum,
     Strategy1D,
-    InterpData1D,
+    InterpData1DBase,
     &[D::Elem; 1],
     [
         (Linear, strategy::Linear),

--- a/src/strategy/enums/three.rs
+++ b/src/strategy/enums/three.rs
@@ -3,7 +3,7 @@ use super::*;
 strategy_enum_impl!(
     Strategy3DEnum,
     Strategy3D,
-    InterpData3D,
+    InterpData3DBase,
     &[D::Elem; 3],
     [
         (Linear, strategy::Linear),

--- a/src/strategy/enums/two.rs
+++ b/src/strategy/enums/two.rs
@@ -3,7 +3,7 @@ use super::*;
 strategy_enum_impl!(
     Strategy2DEnum,
     Strategy2D,
-    InterpData2D,
+    InterpData2DBase,
     &[D::Elem; 2],
     [
         (Linear, strategy::Linear),

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -244,9 +244,24 @@ macro_rules! sized_strategy_trait {
     };
 }
 
-sized_strategy_trait!(Strategy1D, InterpData1D, 1, "1-D interpolation strategy.");
-sized_strategy_trait!(Strategy2D, InterpData2D, 2, "2-D interpolation strategy.");
-sized_strategy_trait!(Strategy3D, InterpData3D, 3, "3-D interpolation strategy.");
+sized_strategy_trait!(
+    Strategy1D,
+    InterpData1DBase,
+    1,
+    "1-D interpolation strategy."
+);
+sized_strategy_trait!(
+    Strategy2D,
+    InterpData2DBase,
+    2,
+    "2-D interpolation strategy."
+);
+sized_strategy_trait!(
+    Strategy3D,
+    InterpData3DBase,
+    3,
+    "3-D interpolation strategy."
+);
 
 /// N-D interpolation strategy.
 pub trait StrategyND<D>: Debug + DynClone
@@ -258,7 +273,7 @@ where
     ///
     /// Default no-op. Override for invariant checks that don't require precomputed
     /// state (grid uniformity, direction-count matching, etc).
-    fn validate(&self, _data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn validate(&self, _data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
         Ok(())
     }
 
@@ -267,7 +282,7 @@ where
     /// Default no-op. Override only when the strategy caches something derived from
     /// `data` (e.g. precomputed spline coefficients). Unlike [`StrategyND::validate`],
     /// this may do real, non-trivial calculation.
-    fn init(&mut self, _data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn init(&mut self, _data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
         Ok(())
     }
 
@@ -281,7 +296,7 @@ where
     /// the same primitives the built-in strategies use.
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError>;
 
@@ -292,7 +307,7 @@ where
     /// strategy's checked path does real internal fallible work beyond producing
     /// the final `Ok(...)`; otherwise the default already compiles to the same thing.
     #[inline]
-    fn interpolate_fast(&self, data: &InterpDataND<D>, point: &[D::Elem]) -> D::Elem {
+    fn interpolate_fast(&self, data: &InterpDataNDBase<D>, point: &[D::Elem]) -> D::Elem {
         self.interpolate(data, point)
             .expect("interpolate_fast: invalid point or data")
     }
@@ -306,7 +321,7 @@ where
     /// no strategy shipped in this crate does that today.
     fn batch_interpolate_into(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         points: &[&[D::Elem]],
         out: &mut [D::Elem],
     ) -> Result<(), InterpolateError> {
@@ -329,7 +344,7 @@ where
     /// [`StrategyND::interpolate_fast`].
     fn batch_interpolate_fast_into(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         points: &[&[D::Elem]],
         out: &mut [D::Elem],
     ) {
@@ -351,7 +366,7 @@ where
     /// for a locate sweep instead of one binary search per point).
     fn batch_interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         points: &[&[D::Elem]],
     ) -> Result<Vec<D::Elem>, InterpolateError>
     where
@@ -372,7 +387,11 @@ where
     /// Do not override this method. Override [`StrategyND::batch_interpolate_into`] instead
     /// if you need to amortize per-point work; the fast variant inherits those optimizations
     /// with no additional override needed.
-    fn batch_interpolate_fast(&self, data: &InterpDataND<D>, points: &[&[D::Elem]]) -> Vec<D::Elem>
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpDataNDBase<D>,
+        points: &[&[D::Elem]],
+    ) -> Vec<D::Elem>
     where
         D::Elem: Num + Copy,
     {
@@ -396,19 +415,19 @@ where
     D::Elem: PartialEq + Debug,
 {
     #[inline]
-    fn validate(&self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn validate(&self, data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
         (**self).validate(data)
     }
 
     #[inline]
-    fn init(&mut self, data: &InterpDataND<D>) -> Result<(), ValidateError> {
+    fn init(&mut self, data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
         (**self).init(data)
     }
 
     #[inline]
     fn interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError> {
         (**self).interpolate(data, point)
@@ -420,14 +439,14 @@ where
     }
 
     #[inline]
-    fn interpolate_fast(&self, data: &InterpDataND<D>, point: &[D::Elem]) -> D::Elem {
+    fn interpolate_fast(&self, data: &InterpDataNDBase<D>, point: &[D::Elem]) -> D::Elem {
         (**self).interpolate_fast(data, point)
     }
 
     #[inline]
     fn batch_interpolate_into(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         points: &[&[D::Elem]],
         out: &mut [D::Elem],
     ) -> Result<(), InterpolateError> {
@@ -437,7 +456,7 @@ where
     #[inline]
     fn batch_interpolate_fast_into(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         points: &[&[D::Elem]],
         out: &mut [D::Elem],
     ) {
@@ -447,7 +466,7 @@ where
     #[inline]
     fn batch_interpolate(
         &self,
-        data: &InterpDataND<D>,
+        data: &InterpDataNDBase<D>,
         points: &[&[D::Elem]],
     ) -> Result<Vec<D::Elem>, InterpolateError>
     where
@@ -457,7 +476,11 @@ where
     }
 
     #[inline]
-    fn batch_interpolate_fast(&self, data: &InterpDataND<D>, points: &[&[D::Elem]]) -> Vec<D::Elem>
+    fn batch_interpolate_fast(
+        &self,
+        data: &InterpDataNDBase<D>,
+        points: &[&[D::Elem]],
+    ) -> Vec<D::Elem>
     where
         D::Elem: Num + Copy,
     {

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -36,7 +36,7 @@ macro_rules! sized_strategy_trait {
             ///
             /// # Note for custom strategies
             /// Index `data.grid[i]` directly via `ArrayView` indexing; avoid `.as_slice()`, which
-            /// panics on non-contiguous storage (possible with `Interp*Viewed`). See
+            /// panics on non-contiguous storage (possible with `Interp*View`). See
             /// [`crate::strategy::utils`] for ready-made per-axis search helpers (bracket search,
             /// exact-match short-circuit, step-direction lookup, uniform-grid fast path) built from
             /// the same primitives the built-in strategies use.
@@ -290,7 +290,7 @@ where
     ///
     /// # Note for custom strategies
     /// Index `data.grid[i]` directly via `ArrayView` indexing; avoid `.as_slice()`, which
-    /// panics on non-contiguous storage (possible with `Interp*Viewed`). See
+    /// panics on non-contiguous storage (possible with `Interp*View`). See
     /// [`crate::strategy::utils`] for ready-made per-axis search helpers (bracket search,
     /// exact-match short-circuit, step-direction lookup, uniform-grid fast path) built from
     /// the same primitives the built-in strategies use.

--- a/tests/serde_formats.rs
+++ b/tests/serde_formats.rs
@@ -6,7 +6,7 @@
 #![cfg(feature = "serde")]
 
 use ndarray::prelude::*;
-use ninterp::data::{InterpData3DOwned, InterpDataND, InterpDataNDOwned};
+use ninterp::data::{InterpData3D, InterpDataND};
 use ninterp::prelude::*;
 
 /// Assert that a value survives a round trip in both the `ndarray` and nested-array formats,
@@ -35,7 +35,7 @@ where
     assert!(cross == *value);
 }
 
-fn interp_1d() -> Interp1DOwned<f64, strategy::Linear> {
+fn interp_1d() -> Interp1D<f64, strategy::Linear> {
     Interp1D::new(
         array![0., 1., 2., 3.],
         array![0.2, 0.4, 0.6, 0.8],
@@ -45,7 +45,7 @@ fn interp_1d() -> Interp1DOwned<f64, strategy::Linear> {
     .unwrap()
 }
 
-fn interp_2d() -> Interp2DOwned<f64, strategy::Linear> {
+fn interp_2d() -> Interp2D<f64, strategy::Linear> {
     Interp2D::new(
         array![0., 1.],
         array![0., 1.],
@@ -56,7 +56,7 @@ fn interp_2d() -> Interp2DOwned<f64, strategy::Linear> {
     .unwrap()
 }
 
-fn interp_3d() -> Interp3DOwned<f64, strategy::Linear> {
+fn interp_3d() -> Interp3D<f64, strategy::Linear> {
     Interp3D::new(
         array![0., 1.],
         array![0., 1.],
@@ -68,7 +68,7 @@ fn interp_3d() -> Interp3DOwned<f64, strategy::Linear> {
     .unwrap()
 }
 
-fn interp_nd() -> InterpNDOwned<f64, strategy::Linear> {
+fn interp_nd() -> InterpND<f64, strategy::Linear> {
     InterpND::new(
         vec![array![0., 1.], array![0., 1.]],
         array![[0., 1.], [2., 3.]].into_dyn(),
@@ -98,7 +98,7 @@ fn round_trip_data() {
 /// Untagged enums fail confusingly when a variant's field names shift, so cover every variant.
 #[test]
 fn round_trip_interpolator_enum() {
-    let variants: Vec<InterpolatorEnumOwned<f64>> = vec![
+    let variants: Vec<InterpolatorEnum<f64>> = vec![
         InterpolatorEnum::new_0d(0.5),
         InterpolatorEnum::new_1d(
             array![0., 1., 2., 3.],
@@ -147,11 +147,11 @@ fn round_trip_through_containers() {
     let nested = serde_json::to_string(&Nested(&curves)).unwrap();
     assert!(nested.starts_with("[{\"data\":{\"grid\":[[0.0,1.0,2.0,3.0]]"));
 
-    let de: Vec<Interp1DOwned<f64, strategy::Linear>> = serde_json::from_str(&nested).unwrap();
+    let de: Vec<Interp1D<f64, strategy::Linear>> = serde_json::from_str(&nested).unwrap();
     assert_eq!(de, curves);
 
     let some = Some(interp_1d());
-    let de: Option<Interp1DOwned<f64, strategy::Linear>> =
+    let de: Option<Interp1D<f64, strategy::Linear>> =
         serde_json::from_str(&serde_json::to_string(&Nested(&some)).unwrap()).unwrap();
     assert_eq!(de, some);
 }
@@ -163,7 +163,7 @@ fn serialize_with_on_a_field() {
     struct Config {
         name: String,
         #[serde(serialize_with = "serialize_nested")]
-        curve: Interp1DOwned<f64, strategy::Linear>,
+        curve: Interp1D<f64, strategy::Linear>,
     }
 
     let config = Config {
@@ -185,28 +185,28 @@ fn binary_formats_round_trip() {
     let data = interp_3d().data;
     let bytes = bincode::serialize(&data).unwrap();
     assert_eq!(
-        bincode::deserialize::<InterpData3DOwned<f64>>(&bytes).unwrap(),
+        bincode::deserialize::<InterpData3D<f64>>(&bytes).unwrap(),
         data
     );
 
     let nd = interp_nd().data;
     let bytes = bincode::serialize(&nd).unwrap();
     assert_eq!(
-        bincode::deserialize::<InterpDataNDOwned<f64>>(&bytes).unwrap(),
+        bincode::deserialize::<InterpDataND<f64>>(&bytes).unwrap(),
         nd
     );
 
     let interp = interp_1d();
     let bytes = bincode::serialize(&interp).unwrap();
     assert_eq!(
-        bincode::deserialize::<Interp1DOwned<f64, strategy::Linear>>(&bytes).unwrap(),
+        bincode::deserialize::<Interp1D<f64, strategy::Linear>>(&bytes).unwrap(),
         interp
     );
 
     // `Nested` degrades to the `ndarray` format here, so it must still round-trip.
     let bytes = bincode::serialize(&Nested(&interp)).unwrap();
     assert_eq!(
-        bincode::deserialize::<Interp1DOwned<f64, strategy::Linear>>(&bytes).unwrap(),
+        bincode::deserialize::<Interp1D<f64, strategy::Linear>>(&bytes).unwrap(),
         interp
     );
 }
@@ -219,13 +219,13 @@ fn zero_dimensional_nd_data() {
 
     let plain = serde_json::to_string(&data).unwrap();
     assert_eq!(
-        serde_json::from_str::<InterpDataNDOwned<f64>>(&plain).unwrap(),
+        serde_json::from_str::<InterpDataND<f64>>(&plain).unwrap(),
         data
     );
 
     let nested = serde_json::to_string(&Nested(&data)).unwrap();
     assert_eq!(
-        serde_json::from_str::<InterpDataNDOwned<f64>>(&nested).unwrap(),
+        serde_json::from_str::<InterpDataND<f64>>(&nested).unwrap(),
         data,
         "0-D values failed to round-trip in nested format: {nested}"
     );


### PR DESCRIPTION
Closes #51

## Summary

Refactor the public API to make owned interpolators the default type, following Rust idioms like `String` vs `&str` and `Vec` vs `&[T]`. This eliminates "Owned" and "Viewed" suffixes from primary type names while maintaining full support for borrowed/viewed data through explicit `View` suffix variants.

**API changes:**
- `Interp1DOwned<T, S>` → `Interp1D<T, S>` (owned, default)
- `Interp1DViewed<T, S>` → `Interp1DView<T, S>` (borrowed)
- Same pattern for `Interp2D`, `Interp3D`, `InterpND` and their data types
- Base struct names made explicit: `Interp1DBase<D, S>` (generic over representation)

**Technical changes:**
- Renamed core structs to Base forms (e.g., `Interp1DBase<D, S>`)
- Created type aliases for owned (no suffix) and viewed (`_View` suffix) variants
- Updated `InterpData` aliases to follow the same pattern
- Updated strategy traits to use base data types for generic owned/viewed support
- Updated all strategy implementations to work with generic base forms

**Breaking changes:** This refactors all public type names. Major version bump.

## Test plan

- ✅ Updated test code for new type names across all test modules
- ✅ All 102 library tests passing
- ✅ All 15 doctests passing
- ✅ Example code updated and compiles (uom.rs, custom_strategy.rs)
- ✅ Custom strategies verified to work with both owned and viewed data via generic `InterpData*Base<D>` bounds
- ✅ README documentation updated with new type scheme and current guidance
