### PR TITLE
Naming audit and structured interpolation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,11 +161,23 @@ Everything below is merged to `main` but not yet tagged/released.
   `Num + PartialOrd`). Other strategies (`Nearest`, `Step`, etc.) keep looser numeric
   bounds after an initial, overly broad `Float` restriction across the whole strategy
   surface was narrowed back down to just the two strategies that actually need it.
-- **Breaking:** `InterpolateError::PointLength(usize)` becomes
-  `PointLength { expected: usize, found: usize }`, matching its neighbor
-  `OutputLength { expected, found }`. The actual length was already available at every
-  construction site and thrown away, so the message can now read "point has length 2,
-  expected 3 for 3-D interpolation" instead of naming only the expectation.
+- **Breaking:** both interpolation-time failures now carry structured positions instead
+  of prose, and both aggregate across a batch rather than one aggregating and the other
+  stopping at the first failure:
+  - `InterpolateError::PointLength(usize)` ->
+    `PointLength { expected: usize, failures: Vec<(usize, usize)> }`, where each entry is
+    `(point index, actual length)`. The actual length was available at every construction
+    site and thrown away.
+  - `InterpolateError::OutOfBounds(String)` -> `OutOfBounds(Vec<(usize, usize)>)`, where
+    each entry is `(point index, dimension)`. A point out of bounds in two dimensions
+    yields two entries. The offending coordinate and grid bounds are no longer echoed
+    into the message: they are `D::Elem`, which the error is not generic over, and the
+    caller can index the `points` and `grid` it already owns. This also drops one
+    `String` allocation per offending coordinate from the batch error path.
+
+  Both variants render a lone failure as a sentence and several as an indented list, and
+  omit point indices entirely when every failure is at index 0, which is every
+  single-point call: `point has length 2, expected 3 for 3-D interpolation`.
 - **Breaking:** `ValidateError::ExtrapolateSelection` becomes the payload-free
   `ExtrapolateUnsupported`. Only `Extrapolate::Enable` can ever be rejected, and only by
   a strategy whose `allow_extrapolate` returns `false`, so the stringified setting the
@@ -177,9 +189,8 @@ Everything below is merged to `main` but not yet tagged/released.
   (a query point outside the grid) rather than the setting that turns it into an
   error. Its message is rewritten to match, from "attempted to interpolate at point(s)
   beyond grid data" to ``point(s) out of bounds with `Extrapolate::Error` set``, so the
-  variant states the condition and the message states which setting to change. It also
-  reads "point(s)" rather than "point", since a batch error can name more than one
-  offending point. `ValidateError::EmptyGrid` is removed outright; a grid dimension
+  variant states the condition and the message states which setting to change.
+  `ValidateError::EmptyGrid` is removed outright; a grid dimension
   with 0 or 1 points is now rejected by the same `InsufficientGridPoints`, since a
   single point can't bracket a query either.
 - **Breaking:** the `serde_ndim` Cargo feature is removed. It switched the nested-array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,16 @@ Everything below is merged to `main` but not yet tagged/released.
   format on non-`is_human_readable` (binary) serializers, since there's nothing to nest
   there and those formats can't read it back anyway.
 - `strategy::utils::exact_index`, `locate_step_index`, `locate_lower_index_uniform`,
-  `check_uniform_grid`, and `AxisLocation`/`locate_axis` are now `pub` (previously
+  `validate_uniform_grid`, and `AxisLocation`/`locate_axis` are now `pub` (previously
   `pub(crate)`). They're the same per-axis primitives `Linear`/`LinearUniform`/`Step`/
   `StepLower`/`StepUpper` are built from, now reusable from custom strategies instead of
-  needing to be reimplemented. `check_uniform_grid`'s error message no longer hardcodes
-  `"LinearUniform:"`, since other strategies can call it directly now too.
+  needing to be reimplemented. `validate_uniform_grid` (named for consistency with the
+  rest of the crate's `validate_*` invariant checks) takes a `tolerance: Option<T>`:
+  `None` keeps the existing default of 1024 × ε scaled by the grid's own step size,
+  `Some(t)` overrides it for a strategy whose precision needs differ. On failure it
+  raises the dedicated `ValidateError::NonUniform { dim, index }` rather than a
+  formatted string, so every strategy that calls it, not just `LinearUniform`, reports
+  a non-uniform grid identically and a caller can match on it instead of parsing text.
 - `interpolate_fast` on `Strategy1D`/`2D`/`3D`/`ND` and `Interpolator<T>` (both
   default-provided, non-breaking): a `Result`-free interpolation path for hot loops
   where the caller has already checked the point is in-bounds and knows extrapolation
@@ -150,7 +155,7 @@ Everything below is merged to `main` but not yet tagged/released.
 - **Breaking:** `find_nearest_index` is renamed to `locate_lower_index` and, along with
   the other grid/index search helpers (`step_index` -> `locate_step_index`,
   `uniform_lower_index` -> `locate_lower_index_uniform`, `exact_index`,
-  `check_uniform_grid`), moves from `strategy::traits` to a new `strategy::utils`
+  `validate_uniform_grid`), moves from `strategy::traits` to a new `strategy::utils`
   module; `traits` now holds only the `Strategy1D`/`2D`/`3D`/`ND` trait definitions.
   No deprecation shim, matching the other breaking renames in this release.
   `locate_lower_index` also now clamps out-of-range points to `[0, len - 2]` itself,
@@ -187,6 +192,12 @@ Everything below is merged to `main` but not yet tagged/released.
   `ExtrapolateUnsupported`. Only `Extrapolate::Enable` can ever be rejected, and only by
   a strategy whose `allow_extrapolate` returns `false`, so the stringified setting the
   variant used to carry said nothing the variant name doesn't.
+- New `ValidateError::GridLength { expected: usize, found: usize }`, for an `InterpDataND`
+  whose grid axis count doesn't match its values' dimensionality. Previously fell through
+  to `ValidateError::Other(String)`; `Other` remains for conditions the crate doesn't
+  model, e.g. a custom strategy validating its own configuration (`Step`'s
+  direction-count check stays `Other` for exactly this reason: it describes the
+  strategy's own arguments, not the data).
 - **Breaking:** error variants renamed for consistency, and no longer read as
   full sentences: `ValidateError::Monotonicity` -> `NonMonotonic`, and
   `InterpolateError::ExtrapolateError` -> `InterpolateError::OutOfBounds`, which drops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,7 @@ Everything below is merged to `main` but not yet tagged/released.
   the stuttering `Error` suffix no sibling variant carried and names the condition
   (a query point outside the grid) rather than the setting that turns it into an
   error. Its message is rewritten to match, from "attempted to interpolate at point(s)
-  beyond grid data" to ``point(s) out of bounds with `Extrapolate::Error` set``, so the
+  beyond grid data" to ``point out of bounds with `Extrapolate::Error` set``, so the
   variant states the condition and the message states which setting to change.
   `ValidateError::EmptyGrid` is removed outright; a grid dimension
   with 0 or 1 points is now rejected by the same `InsufficientGridPoints`, since a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Everything below is merged to `main` but not yet tagged/released.
   `Interp1D`/`2D`/`3D` additionally get an inherent `interpolate_fast(&self, &[D::Elem; N])`
   taking the point as a fixed-size array, so the point length is guaranteed by the type
   system instead of checked at runtime.
-- `InterpolatorEnum` gains `check_extrapolate`/`validate_strategy`/`init_strategy`
+- `InterpolatorEnum` gains `validate_extrapolate`/`validate_strategy`/`init_strategy`
   forwarding to the current variant, matching what `Interp1D`/`2D`/`3D`/`ND` already
   expose as public inherent methods.
 - `batch_interpolate`/`batch_interpolate_fast` on `Interpolator<T>` and
@@ -77,9 +77,8 @@ Everything below is merged to `main` but not yet tagged/released.
   than the trait's either. The checked `batch_interpolate` resolves
   `self.extrapolate` once for the whole batch and funnels every point into at most
   one call to the strategy; under `Extrapolate::Error`, it now reports every
-  out-of-range point in one `ExtrapolateError`, not just the first one found.
-- `ExtrapolateError`'s message now reads "point(s)" instead of "point", since a batch
-  error can name more than one offending point.
+  out-of-range point in one `InterpolateError::OutOfBounds`, not just the first one
+  found.
 - `batch_interpolate_into`/`batch_interpolate_fast_into` on `Interpolator<T>`,
   `Strategy1D`/`2D`/`3D`/`ND`, `Interp1D`/`2D`/`3D`/`InterpND`, and `InterpolatorEnum`:
   allocation-free batched interpolation that writes results into a caller-supplied output
@@ -87,15 +86,15 @@ Everything below is merged to `main` but not yet tagged/released.
   counterparts internally, so a strategy author who overrides `batch_interpolate_into`
   for real batch amortization automatically gets that optimization in both paths (no
   drift risk). New `InterpolateError::OutputLength` variant for length mismatches.
-- `interpolator::DynInterpolator<T>: Interpolator<T> + Send + Sync` (not in the
+- `interpolator::AnyInterpolator<T>: Interpolator<T> + Send + Sync` (not in the
   `prelude`): a downcastable counterpart to `Interpolator<T>`, for storing
-  heterogeneous interpolators behind `Box<dyn DynInterpolator<T>>` and recovering the
+  heterogeneous interpolators behind `Box<dyn AnyInterpolator<T>>` and recovering the
   concrete type via `as_any`. Implemented for owned `Interp1D`/`2D`/`3D`/`ND` only,
   since `as_any` requires `Self: 'static` and the borrowed `Interp*View` types can't
   satisfy that; a viewed interpolator can still be used through `Interpolator<T>`.
   `interpolate`/`batch_interpolate` are inherited from the `Interpolator<T>`
-  supertrait rather than duplicated under `DynInterpolator`-specific names: called
-  through `Box<dyn DynInterpolator<T>>` (or generically), nothing shadows them the way
+  supertrait rather than duplicated under `AnyInterpolator`-specific names: called
+  through `Box<dyn AnyInterpolator<T>>` (or generically), nothing shadows them the way
   `Interp1D`/`2D`/`3D`'s own inherent, array-typed `interpolate`/`batch_interpolate`
   do on the concrete, unboxed type.
 
@@ -127,6 +126,9 @@ Everything below is merged to `main` but not yet tagged/released.
     means `InterpDataBase<OwnedRepr<D>, 1>`, so `D` lands in `Elem` position and the
     failure surfaces as an unsatisfied `D::Elem: PartialEq + Debug` bound, or as a
     signature mismatch against `&InterpData1DBase<D>` on a trait impl.
+- **Breaking:** `Interp1D`/`2D`/`3D`/`ND`'s inherent `check_extrapolate` is renamed to
+  `validate_extrapolate`, matching the `validate`/`validate_strategy` naming every other
+  invariant check in the crate already uses.
 - **Breaking:** `InterpolateError` and `ValidateError` are now `#[non_exhaustive]`,
   allowing new error variants to be added without breaking downstream exhaustive
   matches. Any existing exhaustive `match` over one without a `_` arm now needs one.
@@ -159,11 +161,19 @@ Everything below is merged to `main` but not yet tagged/released.
   `Num + PartialOrd`). Other strategies (`Nearest`, `Step`, etc.) keep looser numeric
   bounds after an initial, overly broad `Float` restriction across the whole strategy
   surface was narrowed back down to just the two strategies that actually need it.
-- **Breaking:** `ValidateError` variants renamed for consistency, and no longer read as
-  full sentences: `ExtrapolateSelection` -> `InvalidExtrapolate`, `Monotonicity` ->
-  `NonMonotonic`. `EmptyGrid` is removed outright; a grid dimension with 0 or 1 points
-  is now rejected by the same `InsufficientGridPoints`, since a single point can't
-  bracket a query either.
+- **Breaking:** error variants renamed for consistency, and no longer read as
+  full sentences: `ValidateError::ExtrapolateSelection` -> `InvalidExtrapolate`,
+  `ValidateError::Monotonicity` -> `NonMonotonic`, and
+  `InterpolateError::ExtrapolateError` -> `InterpolateError::OutOfBounds`, which drops
+  the stuttering `Error` suffix no sibling variant carried and names the condition
+  (a query point outside the grid) rather than the setting that turns it into an
+  error. Its message is rewritten to match, from "attempted to interpolate at point(s)
+  beyond grid data" to ``point(s) out of bounds with `Extrapolate::Error` set``, so the
+  variant states the condition and the message states which setting to change. It also
+  reads "point(s)" rather than "point", since a batch error can name more than one
+  offending point. `ValidateError::EmptyGrid` is removed outright; a grid dimension
+  with 0 or 1 points is now rejected by the same `InsufficientGridPoints`, since a
+  single point can't bracket a query either.
 - **Breaking:** the `serde_ndim` Cargo feature is removed. It switched the nested-array
   write format on for every array field crate-wide, and because Cargo features are
   additive and unify across the dependency graph, enabling it anywhere in a binary
@@ -211,6 +221,11 @@ Everything below is merged to `main` but not yet tagged/released.
 - Various documentation and README improvements; CI workflow polish.
 
 ### Fixed
+- `validate_extrapolate` (formerly `check_extrapolate`) tested the setting passed in but
+  formatted `self.extrapolate` into the resulting `ValidateError::InvalidExtrapolate`. On
+  the `set_extrapolate` path, which vets a candidate before storing it, the rejection
+  message therefore named the currently-stored setting rather than the one that was
+  refused.
 - `InterpND` panicked on `n == 0` (the 0-D-via-`InterpND` case, e.g. after
   dimensionality reduction collapses every axis). The ND `Linear` strategy's exact-match
   scan was rewritten from `iter().position()` (which returned `None` on an empty grid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,9 +129,11 @@ Everything below is merged to `main` but not yet tagged/released.
 - **Breaking:** `Interp1D`/`2D`/`3D`/`ND`'s inherent `check_extrapolate` is renamed to
   `validate_extrapolate`, matching the `validate`/`validate_strategy` naming every other
   invariant check in the crate already uses.
-- **Breaking:** `InterpolateError` and `ValidateError` are now `#[non_exhaustive]`,
-  allowing new error variants to be added without breaking downstream exhaustive
-  matches. Any existing exhaustive `match` over one without a `_` arm now needs one.
+- **Breaking:** `InterpolateError`, `ValidateError`, and `Extrapolate<T>` are now
+  `#[non_exhaustive]`, allowing new variants to be added without breaking downstream
+  exhaustive matches. Any existing exhaustive `match` over one without a `_` arm now
+  needs one. Constructing existing variants is unaffected, so
+  `Extrapolate::Enable`/`Fill(x)`/etc. still work as before.
 - **Breaking:** `Strategy1DEnum`/`Strategy2DEnum`/`Strategy3DEnum`/`StrategyNDEnum` are
   now `#[non_exhaustive]`, since every new built-in strategy adds a variant. Any
   existing exhaustive `match` over one without a `_` arm now needs one; construction
@@ -165,15 +167,18 @@ Everything below is merged to `main` but not yet tagged/released.
   of prose, and both aggregate across a batch rather than one aggregating and the other
   stopping at the first failure:
   - `InterpolateError::PointLength(usize)` ->
-    `PointLength { expected: usize, failures: Vec<(usize, usize)> }`, where each entry is
-    `(point index, actual length)`. The actual length was available at every construction
+    `PointLength { expected: usize, failures: Vec<WrongLengthAt> }`, where each entry
+    carries `index` and `found`. The actual length was available at every construction
     site and thrown away.
-  - `InterpolateError::OutOfBounds(String)` -> `OutOfBounds(Vec<(usize, usize)>)`, where
-    each entry is `(point index, dimension)`. A point out of bounds in two dimensions
+  - `InterpolateError::OutOfBounds(String)` -> `OutOfBounds(Vec<OutOfBoundsAt>)`, where
+    each entry carries `index` and `dim`. A point out of bounds in two dimensions
     yields two entries. The offending coordinate and grid bounds are no longer echoed
     into the message: they are `D::Elem`, which the error is not generic over, and the
     caller can index the `points` and `grid` it already owns. This also drops one
     `String` allocation per offending coordinate from the batch error path.
+  - Both entry types are `#[non_exhaustive]` structs rather than tuples, so per-failure
+    context can be added later without a breaking change. Read them by field
+    (`at.index`, `at.dim`, `at.found`) and match with `..`.
 
   Both variants render a lone failure as a sentence and several as an indented list, and
   omit point indices entirely when every failure is at index 0, which is every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,9 +161,17 @@ Everything below is merged to `main` but not yet tagged/released.
   `Num + PartialOrd`). Other strategies (`Nearest`, `Step`, etc.) keep looser numeric
   bounds after an initial, overly broad `Float` restriction across the whole strategy
   surface was narrowed back down to just the two strategies that actually need it.
+- **Breaking:** `InterpolateError::PointLength(usize)` becomes
+  `PointLength { expected: usize, found: usize }`, matching its neighbor
+  `OutputLength { expected, found }`. The actual length was already available at every
+  construction site and thrown away, so the message can now read "point has length 2,
+  expected 3 for 3-D interpolation" instead of naming only the expectation.
+- **Breaking:** `ValidateError::ExtrapolateSelection` becomes the payload-free
+  `ExtrapolateUnsupported`. Only `Extrapolate::Enable` can ever be rejected, and only by
+  a strategy whose `allow_extrapolate` returns `false`, so the stringified setting the
+  variant used to carry said nothing the variant name doesn't.
 - **Breaking:** error variants renamed for consistency, and no longer read as
-  full sentences: `ValidateError::ExtrapolateSelection` -> `InvalidExtrapolate`,
-  `ValidateError::Monotonicity` -> `NonMonotonic`, and
+  full sentences: `ValidateError::Monotonicity` -> `NonMonotonic`, and
   `InterpolateError::ExtrapolateError` -> `InterpolateError::OutOfBounds`, which drops
   the stuttering `Error` suffix no sibling variant carried and names the condition
   (a query point outside the grid) rather than the setting that turns it into an
@@ -221,11 +229,6 @@ Everything below is merged to `main` but not yet tagged/released.
 - Various documentation and README improvements; CI workflow polish.
 
 ### Fixed
-- `validate_extrapolate` (formerly `check_extrapolate`) tested the setting passed in but
-  formatted `self.extrapolate` into the resulting `ValidateError::InvalidExtrapolate`. On
-  the `set_extrapolate` path, which vets a candidate before storing it, the rejection
-  message therefore named the currently-stored setting rather than the one that was
-  refused.
 - `InterpND` panicked on `n == 0` (the 0-D-via-`InterpND` case, e.g. after
   dimensionality reduction collapses every axis). The ND `Linear` strategy's exact-match
   scan was rewritten from `iter().position()` (which returned `None` on an empty grid

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = "0.2.15"
 serde = { version = "1.0.103", optional = true, features = ["derive"] }
 serde_unit_struct = { version = "0.1.3", optional = true }
 serde-ndim = { version = "2.2.1", optional = true, features = ["ndarray"] }
-thiserror = "1.0.1"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Interpolation-time (`interpolate`):
 
 | Error | Meaning |
 | --- | --- |
-| `InterpolateError::PointLength` | Query point has wrong dimensionality; carries `(point index, actual length)` per offending point |
-| `InterpolateError::OutOfBounds` | Query point is out of bounds while using `Extrapolate::Error`; carries `(point index, dimension)` per offending coordinate |
+| `InterpolateError::PointLength` | Query point has wrong dimensionality; carries a `WrongLengthAt` per offending point |
+| `InterpolateError::OutOfBounds` | Query point is out of bounds while using `Extrapolate::Error`; carries an `OutOfBoundsAt` per offending coordinate |
 
 ## Using Owned and Borrowed (Viewed) Data
 All interpolators support both owned and borrowed data via the generic `D` bound on

--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ Validation-time (`new` / `validate`):
 | --- | --- |
 | `ValidateError::InsufficientGridPoints` | Fewer than 2 grid coordinates in a dimension |
 | `ValidateError::NonMonotonic` | Non-monotonic coordinates |
+| `ValidateError::NonUniform` | Non-uniformly-spaced grid, required by `LinearUniform` and any strategy calling `validate_uniform_grid` |
 | `ValidateError::IncompatibleShapes` | Grid/value shape mismatch |
+| `ValidateError::GridLength` | `InterpDataND` grid axis count doesn't match the dimensionality of `values` |
 | `ValidateError::ExtrapolateUnsupported` | `Extrapolate::Enable` on a strategy that can't extrapolate |
 
 Interpolation-time (`interpolate`):

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Validation-time (`new` / `validate`):
 | `ValidateError::InsufficientGridPoints` | Fewer than 2 grid coordinates in a dimension |
 | `ValidateError::NonMonotonic` | Non-monotonic coordinates |
 | `ValidateError::IncompatibleShapes` | Grid/value shape mismatch |
-| `ValidateError::InvalidExtrapolate` | Inapplicable extrapolation setting |
+| `ValidateError::ExtrapolateUnsupported` | `Extrapolate::Enable` on a strategy that can't extrapolate |
 
 Interpolation-time (`interpolate`):
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Interpolation-time (`interpolate`):
 
 | Error | Meaning |
 | --- | --- |
-| `InterpolateError::PointLength` | Query point has wrong dimensionality |
-| `InterpolateError::OutOfBounds` | Query point is out of bounds while using `Extrapolate::Error` |
+| `InterpolateError::PointLength` | Query point has wrong dimensionality; carries `(point index, actual length)` per offending point |
+| `InterpolateError::OutOfBounds` | Query point is out of bounds while using `Extrapolate::Error`; carries `(point index, dimension)` per offending coordinate |
 
 ## Using Owned and Borrowed (Viewed) Data
 All interpolators support both owned and borrowed data via the generic `D` bound on

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Interpolation-time (`interpolate`):
 | Error | Meaning |
 | --- | --- |
 | `InterpolateError::PointLength` | Query point has wrong dimensionality |
-| `InterpolateError::ExtrapolateError` | Query point is out of bounds while using `Extrapolate::Error` |
+| `InterpolateError::OutOfBounds` | Query point is out of bounds while using `Extrapolate::Error` |
 
 ## Using Owned and Borrowed (Viewed) Data
 All interpolators support both owned and borrowed data via the generic `D` bound on

--- a/examples/custom_strategy.rs
+++ b/examples/custom_strategy.rs
@@ -38,8 +38,8 @@ where
     fn validate(&self, data: &InterpData2DBase<D>) -> Result<(), ninterp::error::ValidateError> {
         // Dummy invariant: reject non-uniformly-spaced grids. `strategy::utils` has a
         // ready-made helper for exactly this, used by the built-in `LinearUniform` strategy.
-        ninterp::strategy::utils::check_uniform_grid(data.grid[0].view(), 0)?;
-        ninterp::strategy::utils::check_uniform_grid(data.grid[1].view(), 1)?;
+        ninterp::strategy::utils::validate_uniform_grid(data.grid[0].view(), 0, None)?;
+        ninterp::strategy::utils::validate_uniform_grid(data.grid[1].view(), 1, None)?;
         println!("validated!");
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,7 +76,7 @@ fn fmt_out_of_bounds(failures: &[(usize, usize)]) -> String {
     let show = show_index(failures);
     match failures {
         [(index, dim)] => format!(
-            "{} is out of bounds in dim {dim}, with `Extrapolate::Error` set",
+            "{} is out of bounds in dim {dim} with `Extrapolate::Error` set",
             point_at(*index, show)
         ),
         many => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,8 +14,22 @@ pub enum ValidateError {
     InsufficientGridPoints(usize),
     #[error("supplied coordinates must be monotonically increasing: dim {0}")]
     NonMonotonic(usize),
+    /// Raised by [`crate::strategy::utils::validate_uniform_grid`], so any strategy
+    /// requiring uniform spacing reports it the same way, not just `LinearUniform`.
+    ///
+    /// `index` is the first coordinate whose following interval, `grid[index + 1] -
+    /// grid[index]`, differs from the grid's first interval, in either direction.
+    #[error("grid[{dim}] is not uniformly spaced (spacing changes at index {index})")]
+    NonUniform { dim: usize, index: usize },
     #[error("supplied grid and values are not compatible shapes: dim {0}")]
     IncompatibleShapes(usize),
+    /// Number of grid axes doesn't match the dimensionality of `values`. Only reachable
+    /// for `InterpDataND`, whose axis count isn't fixed by the type. Distinct from
+    /// [`ValidateError::IncompatibleShapes`], which compares extents within one axis.
+    #[error("grid has {found} axes, expected {expected} to match the values")]
+    GridLength { expected: usize, found: usize },
+    /// Escape hatch for conditions this crate doesn't model, chiefly custom strategies
+    /// validating their own configuration.
     #[error("{0}")]
     Other(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,14 @@ fn fmt_out_of_bounds(failures: &[(usize, usize)]) -> String {
             point_at(*index, show)
         ),
         many => {
-            let mut s = String::from("point(s) out of bounds with `Extrapolate::Error` set:");
+            // One point can be out of bounds in several dimensions, so the number of
+            // failures doesn't decide the plural here; the number of distinct points does.
+            let subject = if many.iter().any(|(index, _)| *index != many[0].0) {
+                "points"
+            } else {
+                "point"
+            };
+            let mut s = format!("{subject} out of bounds with `Extrapolate::Error` set:");
             for (index, dim) in many {
                 s.push_str(&format!("\n    {} in dim {dim}", point_at(*index, show)));
             }
@@ -98,7 +105,9 @@ fn fmt_point_length(expected: usize, failures: &[(usize, usize)]) -> String {
             point_at(*index, show)
         ),
         many => {
-            let mut s = format!("point(s) have the wrong length for {expected}-D interpolation:");
+            // Unlike out-of-bounds, each failure here is a distinct point, so reaching
+            // this arm always means more than one.
+            let mut s = format!("points have the wrong length for {expected}-D interpolation:");
             for (index, found) in many {
                 s.push_str(&format!(
                     "\n    {} has length {found}",

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,8 +31,8 @@ impl fmt::Debug for ValidateError {
 #[derive(Error, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum InterpolateError {
-    #[error("attempted to interpolate at point(s) beyond grid data: {0}")]
-    ExtrapolateError(String),
+    #[error("point(s) out of bounds with `Extrapolate::Error` set: {0}")]
+    OutOfBounds(String),
     #[error("supplied point slice should have length {0} for {0}-D interpolation")]
     PointLength(usize),
     #[error("output slice has length {found}, expected {expected}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,8 +8,8 @@ use thiserror::Error;
 #[derive(Error, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum ValidateError {
-    #[error("selected `Extrapolate` variant ({0}) is unimplemented/inapplicable for interpolator")]
-    InvalidExtrapolate(String),
+    #[error("`Extrapolate::Enable` is not supported by this strategy")]
+    ExtrapolateUnsupported,
     #[error("at least 2 grid points are required per dimension: dim {0}")]
     InsufficientGridPoints(usize),
     #[error("supplied coordinates must be monotonically increasing: dim {0}")]
@@ -33,8 +33,8 @@ impl fmt::Debug for ValidateError {
 pub enum InterpolateError {
     #[error("point(s) out of bounds with `Extrapolate::Error` set: {0}")]
     OutOfBounds(String),
-    #[error("supplied point slice should have length {0} for {0}-D interpolation")]
-    PointLength(usize),
+    #[error("point has length {found}, expected {expected} for {expected}-D interpolation")]
+    PointLength { expected: usize, found: usize },
     #[error("output slice has length {found}, expected {expected}")]
     OutputLength { expected: usize, found: usize },
     #[error("{0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,16 +31,15 @@ impl fmt::Debug for ValidateError {
 #[derive(Error, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum InterpolateError {
-    /// `(point index, dimension)` for every coordinate that fell outside the grid. One
-    /// point out of bounds in two dimensions yields two entries. Index the `points` and
-    /// `grid` you supplied to recover the offending coordinate and the bounds it missed.
+    /// One entry per coordinate that fell outside the grid. A single point out of bounds
+    /// in two dimensions yields two entries.
     #[error("{}", fmt_out_of_bounds(.0))]
-    OutOfBounds(Vec<(usize, usize)>),
-    /// `(point index, actual length)` for every offending point.
+    OutOfBounds(Vec<OutOfBoundsAt>),
+    /// One entry per point whose length didn't match the interpolator's dimensionality.
     #[error("{}", fmt_point_length(*expected, failures))]
     PointLength {
         expected: usize,
-        failures: Vec<(usize, usize)>,
+        failures: Vec<WrongLengthAt>,
     },
     #[error("output slice has length {found}, expected {expected}")]
     OutputLength { expected: usize, found: usize },
@@ -52,6 +51,30 @@ impl fmt::Debug for InterpolateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
+}
+
+/// Where a query point left the grid, in [`InterpolateError::OutOfBounds`].
+///
+/// Index the `points` and `grid` you supplied to recover the offending coordinate and
+/// the bounds it missed: those are `D::Elem` values, which the error is not generic over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct OutOfBoundsAt {
+    /// Position of the point within the batch, or 0 for a single-point call.
+    pub index: usize,
+    /// Dimension whose bounds the point exceeded.
+    pub dim: usize,
+}
+
+/// A misshapen query point, in [`InterpolateError::PointLength`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WrongLengthAt {
+    /// Position of the point within the batch, or 0 for a single-point call.
+    pub index: usize,
+    /// The length it actually had. The expected length is on the variant, shared by
+    /// every entry.
+    pub found: usize,
 }
 
 /// Renders `point`, or `point[i]` when there is anything to disambiguate. Every
@@ -66,30 +89,35 @@ fn point_at(index: usize, show_index: bool) -> String {
 
 /// Whether point indices are worth printing: only once some failure is at a nonzero
 /// index, which never happens for a single-point call.
-fn show_index(failures: &[(usize, usize)]) -> bool {
-    failures.iter().any(|(index, _)| *index != 0)
+fn show_index(mut indices: impl Iterator<Item = usize>) -> bool {
+    indices.any(|index| index != 0)
 }
 
 /// A lone failure reads as one sentence; several are listed under a summary line.
 /// Shared with [`fmt_point_length`] so both aggregating variants render alike.
-fn fmt_out_of_bounds(failures: &[(usize, usize)]) -> String {
-    let show = show_index(failures);
+fn fmt_out_of_bounds(failures: &[OutOfBoundsAt]) -> String {
+    let show = show_index(failures.iter().map(|at| at.index));
     match failures {
-        [(index, dim)] => format!(
-            "{} is out of bounds in dim {dim} with `Extrapolate::Error` set",
-            point_at(*index, show)
+        [at] => format!(
+            "{} is out of bounds in dim {} with `Extrapolate::Error` set",
+            point_at(at.index, show),
+            at.dim
         ),
         many => {
             // One point can be out of bounds in several dimensions, so the number of
             // failures doesn't decide the plural here; the number of distinct points does.
-            let subject = if many.iter().any(|(index, _)| *index != many[0].0) {
+            let subject = if many.iter().any(|at| at.index != many[0].index) {
                 "points"
             } else {
                 "point"
             };
             let mut s = format!("{subject} out of bounds with `Extrapolate::Error` set:");
-            for (index, dim) in many {
-                s.push_str(&format!("\n    {} in dim {dim}", point_at(*index, show)));
+            for at in many {
+                s.push_str(&format!(
+                    "\n    {} in dim {}",
+                    point_at(at.index, show),
+                    at.dim
+                ));
             }
             s
         }
@@ -97,21 +125,23 @@ fn fmt_out_of_bounds(failures: &[(usize, usize)]) -> String {
 }
 
 /// See [`fmt_out_of_bounds`].
-fn fmt_point_length(expected: usize, failures: &[(usize, usize)]) -> String {
-    let show = show_index(failures);
+fn fmt_point_length(expected: usize, failures: &[WrongLengthAt]) -> String {
+    let show = show_index(failures.iter().map(|at| at.index));
     match failures {
-        [(index, found)] => format!(
-            "{} has length {found}, expected {expected} for {expected}-D interpolation",
-            point_at(*index, show)
+        [at] => format!(
+            "{} has length {}, expected {expected} for {expected}-D interpolation",
+            point_at(at.index, show),
+            at.found
         ),
         many => {
             // Unlike out-of-bounds, each failure here is a distinct point, so reaching
             // this arm always means more than one.
             let mut s = format!("points have the wrong length for {expected}-D interpolation:");
-            for (index, found) in many {
+            for at in many {
                 s.push_str(&format!(
-                    "\n    {} has length {found}",
-                    point_at(*index, show)
+                    "\n    {} has length {}",
+                    point_at(at.index, show),
+                    at.found
                 ));
             }
             s

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,10 +31,17 @@ impl fmt::Debug for ValidateError {
 #[derive(Error, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum InterpolateError {
-    #[error("point(s) out of bounds with `Extrapolate::Error` set: {0}")]
-    OutOfBounds(String),
-    #[error("point has length {found}, expected {expected} for {expected}-D interpolation")]
-    PointLength { expected: usize, found: usize },
+    /// `(point index, dimension)` for every coordinate that fell outside the grid. One
+    /// point out of bounds in two dimensions yields two entries. Index the `points` and
+    /// `grid` you supplied to recover the offending coordinate and the bounds it missed.
+    #[error("{}", fmt_out_of_bounds(.0))]
+    OutOfBounds(Vec<(usize, usize)>),
+    /// `(point index, actual length)` for every offending point.
+    #[error("{}", fmt_point_length(*expected, failures))]
+    PointLength {
+        expected: usize,
+        failures: Vec<(usize, usize)>,
+    },
     #[error("output slice has length {found}, expected {expected}")]
     OutputLength { expected: usize, found: usize },
     #[error("{0}")]
@@ -44,5 +51,61 @@ pub enum InterpolateError {
 impl fmt::Debug for InterpolateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
+    }
+}
+
+/// Renders `point`, or `point[i]` when there is anything to disambiguate. Every
+/// single-point call reports index 0 and only index 0, so the index is noise there.
+fn point_at(index: usize, show_index: bool) -> String {
+    if show_index {
+        format!("point[{index}]")
+    } else {
+        String::from("point")
+    }
+}
+
+/// Whether point indices are worth printing: only once some failure is at a nonzero
+/// index, which never happens for a single-point call.
+fn show_index(failures: &[(usize, usize)]) -> bool {
+    failures.iter().any(|(index, _)| *index != 0)
+}
+
+/// A lone failure reads as one sentence; several are listed under a summary line.
+/// Shared with [`fmt_point_length`] so both aggregating variants render alike.
+fn fmt_out_of_bounds(failures: &[(usize, usize)]) -> String {
+    let show = show_index(failures);
+    match failures {
+        [(index, dim)] => format!(
+            "{} is out of bounds in dim {dim}, with `Extrapolate::Error` set",
+            point_at(*index, show)
+        ),
+        many => {
+            let mut s = String::from("point(s) out of bounds with `Extrapolate::Error` set:");
+            for (index, dim) in many {
+                s.push_str(&format!("\n    {} in dim {dim}", point_at(*index, show)));
+            }
+            s
+        }
+    }
+}
+
+/// See [`fmt_out_of_bounds`].
+fn fmt_point_length(expected: usize, failures: &[(usize, usize)]) -> String {
+    let show = show_index(failures);
+    match failures {
+        [(index, found)] => format!(
+            "{} has length {found}, expected {expected} for {expected}-D interpolation",
+            point_at(*index, show)
+        ),
+        many => {
+            let mut s = format!("point(s) have the wrong length for {expected}-D interpolation:");
+            for (index, found) in many {
+                s.push_str(&format!(
+                    "\n    {} has length {found}",
+                    point_at(*index, show)
+                ));
+            }
+            s
+        }
     }
 }

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -172,16 +172,13 @@ macro_rules! slice_to_array_forward {
                     Interpolator::batch_interpolate(interp, points)
                 }
                 InterpolatorEnumBase::Interp1D(interp) => {
-                    let points: Vec<[D::Elem; 1]> = to_fixed_points(points)?;
-                    interp.batch_interpolate(&points)
+                    interp.batch_interpolate(&to_fixed_points(points)?)
                 }
                 InterpolatorEnumBase::Interp2D(interp) => {
-                    let points: Vec<[D::Elem; 2]> = to_fixed_points(points)?;
-                    interp.batch_interpolate(&points)
+                    interp.batch_interpolate(&to_fixed_points(points)?)
                 }
                 InterpolatorEnumBase::Interp3D(interp) => {
-                    let points: Vec<[D::Elem; 3]> = to_fixed_points(points)?;
-                    interp.batch_interpolate(&points)
+                    interp.batch_interpolate(&to_fixed_points(points)?)
                 }
                 InterpolatorEnumBase::InterpND(interp) => interp.batch_interpolate(points),
             }
@@ -248,16 +245,13 @@ macro_rules! slice_to_array_forward {
                     Ok(())
                 }
                 InterpolatorEnumBase::Interp1D(interp) => {
-                    let points: Vec<[D::Elem; 1]> = to_fixed_points(points)?;
-                    interp.batch_interpolate_into(&points, out)
+                    interp.batch_interpolate_into(&to_fixed_points(points)?, out)
                 }
                 InterpolatorEnumBase::Interp2D(interp) => {
-                    let points: Vec<[D::Elem; 2]> = to_fixed_points(points)?;
-                    interp.batch_interpolate_into(&points, out)
+                    interp.batch_interpolate_into(&to_fixed_points(points)?, out)
                 }
                 InterpolatorEnumBase::Interp3D(interp) => {
-                    let points: Vec<[D::Elem; 3]> = to_fixed_points(points)?;
-                    interp.batch_interpolate_into(&points, out)
+                    interp.batch_interpolate_into(&to_fixed_points(points)?, out)
                 }
                 InterpolatorEnumBase::InterpND(interp) => {
                     interp.batch_interpolate_into(points, out)

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -22,18 +22,18 @@ macro_rules! enum_method_forward {
             }
         }
     };
-    (check_extrapolate) => {
+    (validate_extrapolate) => {
         #[doc = "Check applicability of the current variant's strategy, data, and extrapolate setting."]
-        pub fn check_extrapolate(
+        pub fn validate_extrapolate(
             &self,
             extrapolate: &Extrapolate<D::Elem>,
         ) -> Result<(), ValidateError> {
             match self {
                 InterpolatorEnumBase::Interp0D(_) => Ok(()),
-                InterpolatorEnumBase::Interp1D(interp) => interp.check_extrapolate(extrapolate),
-                InterpolatorEnumBase::Interp2D(interp) => interp.check_extrapolate(extrapolate),
-                InterpolatorEnumBase::Interp3D(interp) => interp.check_extrapolate(extrapolate),
-                InterpolatorEnumBase::InterpND(interp) => interp.check_extrapolate(extrapolate),
+                InterpolatorEnumBase::Interp1D(interp) => interp.validate_extrapolate(extrapolate),
+                InterpolatorEnumBase::Interp2D(interp) => interp.validate_extrapolate(extrapolate),
+                InterpolatorEnumBase::Interp3D(interp) => interp.validate_extrapolate(extrapolate),
+                InterpolatorEnumBase::InterpND(interp) => interp.validate_extrapolate(extrapolate),
             }
         }
     };
@@ -622,7 +622,7 @@ where
 
     enum_method_wrap!(view);
     enum_method_wrap!(into_owned);
-    enum_method_forward!(check_extrapolate);
+    enum_method_forward!(validate_extrapolate);
     enum_method_forward!(validate_strategy);
     enum_method_forward!(mut init_strategy);
 }

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -23,7 +23,7 @@ macro_rules! enum_method_forward {
         }
     };
     (validate_extrapolate) => {
-        #[doc = "Check applicability of the current variant's strategy, data, and extrapolate setting."]
+        #[doc = "Check that `extrapolate` is applicable to the current variant's strategy.\n\nForwards to the variant's own `validate_extrapolate`; `Interp0D` accepts any\nsetting, since it never extrapolates."]
         pub fn validate_extrapolate(
             &self,
             extrapolate: &Extrapolate<D::Elem>,
@@ -126,21 +126,30 @@ macro_rules! slice_to_array_forward {
         fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
             match self {
                 InterpolatorEnumBase::Interp0D(interp) => interp.interpolate(point),
-                InterpolatorEnumBase::Interp1D(interp) => interp.interpolate(
-                    point
-                        .try_into()
-                        .map_err(|_| InterpolateError::PointLength(1))?,
-                ),
-                InterpolatorEnumBase::Interp2D(interp) => interp.interpolate(
-                    point
-                        .try_into()
-                        .map_err(|_| InterpolateError::PointLength(2))?,
-                ),
-                InterpolatorEnumBase::Interp3D(interp) => interp.interpolate(
-                    point
-                        .try_into()
-                        .map_err(|_| InterpolateError::PointLength(3))?,
-                ),
+                InterpolatorEnumBase::Interp1D(interp) => {
+                    interp.interpolate(point.try_into().map_err(|_| {
+                        InterpolateError::PointLength {
+                            expected: 1,
+                            found: point.len(),
+                        }
+                    })?)
+                }
+                InterpolatorEnumBase::Interp2D(interp) => {
+                    interp.interpolate(point.try_into().map_err(|_| {
+                        InterpolateError::PointLength {
+                            expected: 2,
+                            found: point.len(),
+                        }
+                    })?)
+                }
+                InterpolatorEnumBase::Interp3D(interp) => {
+                    interp.interpolate(point.try_into().map_err(|_| {
+                        InterpolateError::PointLength {
+                            expected: 3,
+                            found: point.len(),
+                        }
+                    })?)
+                }
                 InterpolatorEnumBase::InterpND(interp) => interp.interpolate(point),
             }
         }
@@ -181,9 +190,10 @@ macro_rules! slice_to_array_forward {
                     let points: Vec<[D::Elem; 1]> = points
                         .iter()
                         .map(|&point| {
-                            point
-                                .try_into()
-                                .map_err(|_| InterpolateError::PointLength(1))
+                            point.try_into().map_err(|_| InterpolateError::PointLength {
+                                expected: 1,
+                                found: point.len(),
+                            })
                         })
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate(&points)
@@ -192,9 +202,10 @@ macro_rules! slice_to_array_forward {
                     let points: Vec<[D::Elem; 2]> = points
                         .iter()
                         .map(|&point| {
-                            point
-                                .try_into()
-                                .map_err(|_| InterpolateError::PointLength(2))
+                            point.try_into().map_err(|_| InterpolateError::PointLength {
+                                expected: 2,
+                                found: point.len(),
+                            })
                         })
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate(&points)
@@ -203,9 +214,10 @@ macro_rules! slice_to_array_forward {
                     let points: Vec<[D::Elem; 3]> = points
                         .iter()
                         .map(|&point| {
-                            point
-                                .try_into()
-                                .map_err(|_| InterpolateError::PointLength(3))
+                            point.try_into().map_err(|_| InterpolateError::PointLength {
+                                expected: 3,
+                                found: point.len(),
+                            })
                         })
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate(&points)
@@ -278,9 +290,10 @@ macro_rules! slice_to_array_forward {
                     let points: Vec<[D::Elem; 1]> = points
                         .iter()
                         .map(|&point| {
-                            point
-                                .try_into()
-                                .map_err(|_| InterpolateError::PointLength(1))
+                            point.try_into().map_err(|_| InterpolateError::PointLength {
+                                expected: 1,
+                                found: point.len(),
+                            })
                         })
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate_into(&points, out)
@@ -289,9 +302,10 @@ macro_rules! slice_to_array_forward {
                     let points: Vec<[D::Elem; 2]> = points
                         .iter()
                         .map(|&point| {
-                            point
-                                .try_into()
-                                .map_err(|_| InterpolateError::PointLength(2))
+                            point.try_into().map_err(|_| InterpolateError::PointLength {
+                                expected: 2,
+                                found: point.len(),
+                            })
                         })
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate_into(&points, out)
@@ -300,9 +314,10 @@ macro_rules! slice_to_array_forward {
                     let points: Vec<[D::Elem; 3]> = points
                         .iter()
                         .map(|&point| {
-                            point
-                                .try_into()
-                                .map_err(|_| InterpolateError::PointLength(3))
+                            point.try_into().map_err(|_| InterpolateError::PointLength {
+                                expected: 3,
+                                found: point.len(),
+                            })
                         })
                         .collect::<Result<_, _>>()?;
                     interp.batch_interpolate_into(&points, out)
@@ -668,7 +683,10 @@ mod tests {
         .unwrap();
         assert!(matches!(
             interp_1d.interpolate(&[]).unwrap_err(),
-            InterpolateError::PointLength(1)
+            InterpolateError::PointLength {
+                expected: 1,
+                found: 0
+            }
         ));
 
         let interp_2d = InterpolatorEnumBase::new_2d(
@@ -681,7 +699,10 @@ mod tests {
         .unwrap();
         assert!(matches!(
             interp_2d.interpolate(&[]).unwrap_err(),
-            InterpolateError::PointLength(2)
+            InterpolateError::PointLength {
+                expected: 2,
+                found: 0
+            }
         ));
 
         let interp_3d = InterpolatorEnumBase::new_3d(
@@ -695,7 +716,10 @@ mod tests {
         .unwrap();
         assert!(matches!(
             interp_3d.interpolate(&[]).unwrap_err(),
-            InterpolateError::PointLength(3)
+            InterpolateError::PointLength {
+                expected: 3,
+                found: 0
+            }
         ));
     }
 
@@ -755,7 +779,10 @@ mod tests {
         let points: [&[f64]; 1] = [&[0.075]];
         assert!(matches!(
             interp.batch_interpolate(&points).unwrap_err(),
-            InterpolateError::PointLength(2)
+            InterpolateError::PointLength {
+                expected: 2,
+                found: 1
+            }
         ));
     }
 

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -127,28 +127,13 @@ macro_rules! slice_to_array_forward {
             match self {
                 InterpolatorEnumBase::Interp0D(interp) => interp.interpolate(point),
                 InterpolatorEnumBase::Interp1D(interp) => {
-                    interp.interpolate(point.try_into().map_err(|_| {
-                        InterpolateError::PointLength {
-                            expected: 1,
-                            found: point.len(),
-                        }
-                    })?)
+                    interp.interpolate(to_fixed_point(point)?)
                 }
                 InterpolatorEnumBase::Interp2D(interp) => {
-                    interp.interpolate(point.try_into().map_err(|_| {
-                        InterpolateError::PointLength {
-                            expected: 2,
-                            found: point.len(),
-                        }
-                    })?)
+                    interp.interpolate(to_fixed_point(point)?)
                 }
                 InterpolatorEnumBase::Interp3D(interp) => {
-                    interp.interpolate(point.try_into().map_err(|_| {
-                        InterpolateError::PointLength {
-                            expected: 3,
-                            found: point.len(),
-                        }
-                    })?)
+                    interp.interpolate(to_fixed_point(point)?)
                 }
                 InterpolatorEnumBase::InterpND(interp) => interp.interpolate(point),
             }
@@ -187,39 +172,15 @@ macro_rules! slice_to_array_forward {
                     Interpolator::batch_interpolate(interp, points)
                 }
                 InterpolatorEnumBase::Interp1D(interp) => {
-                    let points: Vec<[D::Elem; 1]> = points
-                        .iter()
-                        .map(|&point| {
-                            point.try_into().map_err(|_| InterpolateError::PointLength {
-                                expected: 1,
-                                found: point.len(),
-                            })
-                        })
-                        .collect::<Result<_, _>>()?;
+                    let points: Vec<[D::Elem; 1]> = to_fixed_points(points)?;
                     interp.batch_interpolate(&points)
                 }
                 InterpolatorEnumBase::Interp2D(interp) => {
-                    let points: Vec<[D::Elem; 2]> = points
-                        .iter()
-                        .map(|&point| {
-                            point.try_into().map_err(|_| InterpolateError::PointLength {
-                                expected: 2,
-                                found: point.len(),
-                            })
-                        })
-                        .collect::<Result<_, _>>()?;
+                    let points: Vec<[D::Elem; 2]> = to_fixed_points(points)?;
                     interp.batch_interpolate(&points)
                 }
                 InterpolatorEnumBase::Interp3D(interp) => {
-                    let points: Vec<[D::Elem; 3]> = points
-                        .iter()
-                        .map(|&point| {
-                            point.try_into().map_err(|_| InterpolateError::PointLength {
-                                expected: 3,
-                                found: point.len(),
-                            })
-                        })
-                        .collect::<Result<_, _>>()?;
+                    let points: Vec<[D::Elem; 3]> = to_fixed_points(points)?;
                     interp.batch_interpolate(&points)
                 }
                 InterpolatorEnumBase::InterpND(interp) => interp.batch_interpolate(points),
@@ -287,39 +248,15 @@ macro_rules! slice_to_array_forward {
                     Ok(())
                 }
                 InterpolatorEnumBase::Interp1D(interp) => {
-                    let points: Vec<[D::Elem; 1]> = points
-                        .iter()
-                        .map(|&point| {
-                            point.try_into().map_err(|_| InterpolateError::PointLength {
-                                expected: 1,
-                                found: point.len(),
-                            })
-                        })
-                        .collect::<Result<_, _>>()?;
+                    let points: Vec<[D::Elem; 1]> = to_fixed_points(points)?;
                     interp.batch_interpolate_into(&points, out)
                 }
                 InterpolatorEnumBase::Interp2D(interp) => {
-                    let points: Vec<[D::Elem; 2]> = points
-                        .iter()
-                        .map(|&point| {
-                            point.try_into().map_err(|_| InterpolateError::PointLength {
-                                expected: 2,
-                                found: point.len(),
-                            })
-                        })
-                        .collect::<Result<_, _>>()?;
+                    let points: Vec<[D::Elem; 2]> = to_fixed_points(points)?;
                     interp.batch_interpolate_into(&points, out)
                 }
                 InterpolatorEnumBase::Interp3D(interp) => {
-                    let points: Vec<[D::Elem; 3]> = points
-                        .iter()
-                        .map(|&point| {
-                            point.try_into().map_err(|_| InterpolateError::PointLength {
-                                expected: 3,
-                                found: point.len(),
-                            })
-                        })
-                        .collect::<Result<_, _>>()?;
+                    let points: Vec<[D::Elem; 3]> = to_fixed_points(points)?;
                     interp.batch_interpolate_into(&points, out)
                 }
                 InterpolatorEnumBase::InterpND(interp) => {
@@ -685,8 +622,8 @@ mod tests {
             interp_1d.interpolate(&[]).unwrap_err(),
             InterpolateError::PointLength {
                 expected: 1,
-                found: 0
-            }
+                ref failures
+            } if failures.as_slice() == [(0, 0)]
         ));
 
         let interp_2d = InterpolatorEnumBase::new_2d(
@@ -701,8 +638,8 @@ mod tests {
             interp_2d.interpolate(&[]).unwrap_err(),
             InterpolateError::PointLength {
                 expected: 2,
-                found: 0
-            }
+                ref failures
+            } if failures.as_slice() == [(0, 0)]
         ));
 
         let interp_3d = InterpolatorEnumBase::new_3d(
@@ -718,8 +655,8 @@ mod tests {
             interp_3d.interpolate(&[]).unwrap_err(),
             InterpolateError::PointLength {
                 expected: 3,
-                found: 0
-            }
+                ref failures
+            } if failures.as_slice() == [(0, 0)]
         ));
     }
 
@@ -781,8 +718,8 @@ mod tests {
             interp.batch_interpolate(&points).unwrap_err(),
             InterpolateError::PointLength {
                 expected: 2,
-                found: 1
-            }
+                ref failures
+            } if failures.as_slice() == [(0, 1)]
         ));
     }
 

--- a/src/interpolator/enums.rs
+++ b/src/interpolator/enums.rs
@@ -623,7 +623,7 @@ mod tests {
             InterpolateError::PointLength {
                 expected: 1,
                 ref failures
-            } if failures.as_slice() == [(0, 0)]
+            } if failures.as_slice() == [WrongLengthAt { index: 0, found: 0 }]
         ));
 
         let interp_2d = InterpolatorEnumBase::new_2d(
@@ -639,7 +639,7 @@ mod tests {
             InterpolateError::PointLength {
                 expected: 2,
                 ref failures
-            } if failures.as_slice() == [(0, 0)]
+            } if failures.as_slice() == [WrongLengthAt { index: 0, found: 0 }]
         ));
 
         let interp_3d = InterpolatorEnumBase::new_3d(
@@ -656,7 +656,7 @@ mod tests {
             InterpolateError::PointLength {
                 expected: 3,
                 ref failures
-            } if failures.as_slice() == [(0, 0)]
+            } if failures.as_slice() == [WrongLengthAt { index: 0, found: 0 }]
         ));
     }
 
@@ -719,7 +719,7 @@ mod tests {
             InterpolateError::PointLength {
                 expected: 2,
                 ref failures
-            } if failures.as_slice() == [(0, 1)]
+            } if failures.as_slice() == [WrongLengthAt { index: 0, found: 1 }]
         ));
     }
 

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -198,6 +198,7 @@ pub trait AnyInterpolator<T>: Interpolator<T> + Send + Sync {
 /// is outside the bounds of the coordinate grid.
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[non_exhaustive]
 pub enum Extrapolate<T> {
     /// Evaluate beyond the grid limits. Not applicable for all strategies.
     Enable,
@@ -288,7 +289,7 @@ macro_rules! interpolate_impl {
                             return self.strategy.interpolate(&self.data, &wrapped_point);
                         }
                         Extrapolate::Error => {
-                            errors.push((0, dim));
+                            errors.push(OutOfBoundsAt { index: 0, dim });
                         }
                     };
                 }
@@ -307,7 +308,10 @@ pub(crate) use interpolate_impl;
 pub(crate) fn to_fixed_point<T, const N: usize>(point: &[T]) -> Result<&[T; N], InterpolateError> {
     <&[T; N]>::try_from(point).map_err(|_| InterpolateError::PointLength {
         expected: N,
-        failures: vec![(0, point.len())],
+        failures: vec![WrongLengthAt {
+            index: 0,
+            found: point.len(),
+        }],
     })
 }
 
@@ -322,7 +326,10 @@ pub(crate) fn to_fixed_points<T: Copy, const N: usize>(
     for (i, &point) in points.iter().enumerate() {
         match <&[T; N]>::try_from(point) {
             Ok(arr) => converted.push(*arr),
-            Err(_) => failures.push((i, point.len())),
+            Err(_) => failures.push(WrongLengthAt {
+                index: i,
+                found: point.len(),
+            }),
         }
     }
     if failures.is_empty() {
@@ -462,7 +469,7 @@ macro_rules! batch_interpolate_into_impl {
                                 ..=self.data.grid[dim].last().unwrap())
                                 .contains(&&point[dim])
                             {
-                                point_errors.push((i, dim));
+                                point_errors.push(OutOfBoundsAt { index: i, dim });
                             }
                         }
                         if point_errors.is_empty() {

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -675,8 +675,7 @@ macro_rules! interpolator_trait_impl {
                 points: &[&[D::Elem]],
                 out: &mut [D::Elem],
             ) -> Result<(), InterpolateError> {
-                let points: Vec<[D::Elem; N]> = to_fixed_points(points)?;
-                self.batch_interpolate_into(&points, out)
+                self.batch_interpolate_into(&to_fixed_points(points)?, out)
             }
 
             fn batch_interpolate_fast_into(&self, points: &[&[D::Elem]], out: &mut [D::Elem]) {
@@ -694,8 +693,7 @@ macro_rules! interpolator_trait_impl {
                 &self,
                 points: &[&[D::Elem]],
             ) -> Result<Vec<D::Elem>, InterpolateError> {
-                let points: Vec<[D::Elem; N]> = to_fixed_points(points)?;
-                self.batch_interpolate(&points)
+                self.batch_interpolate(&to_fixed_points(points)?)
             }
 
             fn batch_interpolate_fast(&self, points: &[&[D::Elem]]) -> Vec<D::Elem> {

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -288,22 +288,52 @@ macro_rules! interpolate_impl {
                             return self.strategy.interpolate(&self.data, &wrapped_point);
                         }
                         Extrapolate::Error => {
-                            errors.push(format!(
-                                "\n    point[{dim}] = {:?} is out of bounds for grid[{dim}] = {:?}",
-                                point[dim], self.data.grid[dim],
-                            ));
+                            errors.push((0, dim));
                         }
                     };
                 }
             }
             if !errors.is_empty() {
-                return Err(InterpolateError::OutOfBounds(errors.join("")));
+                return Err(InterpolateError::OutOfBounds(errors));
             }
             self.strategy.interpolate(&self.data, point)
         }
     };
 }
 pub(crate) use interpolate_impl;
+
+/// Reinterpret a runtime-length point as a fixed-size array, for the `Interpolator<T>`
+/// trait methods on `Interp1D`/`2D`/`3D`, whose inherent counterparts take `&[T; N]`.
+pub(crate) fn to_fixed_point<T, const N: usize>(point: &[T]) -> Result<&[T; N], InterpolateError> {
+    <&[T; N]>::try_from(point).map_err(|_| InterpolateError::PointLength {
+        expected: N,
+        failures: vec![(0, point.len())],
+    })
+}
+
+/// Batched [`to_fixed_point`]. Every offending point is reported, not just the first, so
+/// one call surfaces the whole problem with a malformed batch. Mirrors how the
+/// `Extrapolate::Error` path aggregates out-of-bounds points.
+pub(crate) fn to_fixed_points<T: Copy, const N: usize>(
+    points: &[&[T]],
+) -> Result<Vec<[T; N]>, InterpolateError> {
+    let mut converted = Vec::with_capacity(points.len());
+    let mut failures = Vec::new();
+    for (i, &point) in points.iter().enumerate() {
+        match <&[T; N]>::try_from(point) {
+            Ok(arr) => converted.push(*arr),
+            Err(_) => failures.push((i, point.len())),
+        }
+    }
+    if failures.is_empty() {
+        Ok(converted)
+    } else {
+        Err(InterpolateError::PointLength {
+            expected: N,
+            failures,
+        })
+    }
+}
 
 /// Is `point` out of `grid`'s bounds in any dimension?
 ///
@@ -353,7 +383,9 @@ macro_rules! batch_interpolate_into_impl {
                 });
             }
             match &self.extrapolate {
-                Extrapolate::Enable => self.strategy.batch_interpolate_into(&self.data, points, out),
+                Extrapolate::Enable => self
+                    .strategy
+                    .batch_interpolate_into(&self.data, points, out),
                 Extrapolate::Clamp => {
                     // Clamping an in-bounds point is already identity, so every point
                     // can be clamped unconditionally.
@@ -369,7 +401,8 @@ macro_rules! batch_interpolate_into_impl {
                             })
                         })
                         .collect();
-                    self.strategy.batch_interpolate_into(&self.data, &clamped, out)
+                    self.strategy
+                        .batch_interpolate_into(&self.data, &clamped, out)
                 }
                 Extrapolate::Wrap => {
                     // Unlike `Clamp`, `wrap()` isn't identity exactly at the
@@ -390,7 +423,8 @@ macro_rules! batch_interpolate_into_impl {
                             }
                         })
                         .collect();
-                    self.strategy.batch_interpolate_into(&self.data, &wrapped, out)
+                    self.strategy
+                        .batch_interpolate_into(&self.data, &wrapped, out)
                 }
                 Extrapolate::Fill(value) => {
                     // Pre-fill output with the fill value, then scatter interpolated
@@ -407,7 +441,11 @@ macro_rules! batch_interpolate_into_impl {
                             .unzip();
                     if !in_bounds_indices.is_empty() {
                         let mut scratch = vec![D::Elem::zero(); in_bounds_indices.len()];
-                        self.strategy.batch_interpolate_into(&self.data, &in_bounds_points, &mut scratch)?;
+                        self.strategy.batch_interpolate_into(
+                            &self.data,
+                            &in_bounds_points,
+                            &mut scratch,
+                        )?;
                         for (idx, value) in in_bounds_indices.into_iter().zip(scratch) {
                             out[idx] = value;
                         }
@@ -424,10 +462,7 @@ macro_rules! batch_interpolate_into_impl {
                                 ..=self.data.grid[dim].last().unwrap())
                                 .contains(&&point[dim])
                             {
-                                point_errors.push(format!(
-                                    "\n    point[{i}][{dim}] = {:?} is out of bounds for grid[{dim}] = {:?}",
-                                    point[dim], self.data.grid[dim],
-                                ));
+                                point_errors.push((i, dim));
                             }
                         }
                         if point_errors.is_empty() {
@@ -437,9 +472,10 @@ macro_rules! batch_interpolate_into_impl {
                         }
                     }
                     if !errors.is_empty() {
-                        return Err(InterpolateError::OutOfBounds(errors.join("")));
+                        return Err(InterpolateError::OutOfBounds(errors));
                     }
-                    self.strategy.batch_interpolate_into(&self.data, &in_bounds_points, out)
+                    self.strategy
+                        .batch_interpolate_into(&self.data, &in_bounds_points, out)
                 }
             }
         }
@@ -617,14 +653,7 @@ macro_rules! interpolator_trait_impl {
             }
 
             fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-                let point: &[D::Elem; N] =
-                    point
-                        .try_into()
-                        .map_err(|_| InterpolateError::PointLength {
-                            expected: N,
-                            found: point.len(),
-                        })?;
-                self.interpolate(point)
+                self.interpolate(to_fixed_point(point)?)
             }
 
             fn interpolate_fast(&self, point: &[D::Elem]) -> D::Elem {
@@ -639,17 +668,7 @@ macro_rules! interpolator_trait_impl {
                 points: &[&[D::Elem]],
                 out: &mut [D::Elem],
             ) -> Result<(), InterpolateError> {
-                let points: Vec<[D::Elem; N]> = points
-                    .iter()
-                    .map(|&point| {
-                        <&[D::Elem; N]>::try_from(point)
-                            .map(|arr| *arr)
-                            .map_err(|_| InterpolateError::PointLength {
-                                expected: N,
-                                found: point.len(),
-                            })
-                    })
-                    .collect::<Result<_, _>>()?;
+                let points: Vec<[D::Elem; N]> = to_fixed_points(points)?;
                 self.batch_interpolate_into(&points, out)
             }
 
@@ -668,17 +687,7 @@ macro_rules! interpolator_trait_impl {
                 &self,
                 points: &[&[D::Elem]],
             ) -> Result<Vec<D::Elem>, InterpolateError> {
-                let points: Vec<[D::Elem; N]> = points
-                    .iter()
-                    .map(|&point| {
-                        <&[D::Elem; N]>::try_from(point)
-                            .map(|arr| *arr)
-                            .map_err(|_| InterpolateError::PointLength {
-                                expected: N,
-                                found: point.len(),
-                            })
-                    })
-                    .collect::<Result<_, _>>()?;
+                let points: Vec<[D::Elem; N]> = to_fixed_points(points)?;
                 self.batch_interpolate(&points)
             }
 

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -235,9 +235,7 @@ macro_rules! extrapolate_impl {
             ) -> Result<(), ValidateError> {
                 if matches!(extrapolate, Extrapolate::Enable) && !self.strategy.allow_extrapolate()
                 {
-                    return Err(ValidateError::InvalidExtrapolate(format!(
-                        "{extrapolate:?}"
-                    )));
+                    return Err(ValidateError::ExtrapolateUnsupported);
                 }
                 Ok(())
             }
@@ -619,9 +617,13 @@ macro_rules! interpolator_trait_impl {
             }
 
             fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
-                let point: &[D::Elem; N] = point
-                    .try_into()
-                    .map_err(|_| InterpolateError::PointLength(N))?;
+                let point: &[D::Elem; N] =
+                    point
+                        .try_into()
+                        .map_err(|_| InterpolateError::PointLength {
+                            expected: N,
+                            found: point.len(),
+                        })?;
                 self.interpolate(point)
             }
 
@@ -642,7 +644,10 @@ macro_rules! interpolator_trait_impl {
                     .map(|&point| {
                         <&[D::Elem; N]>::try_from(point)
                             .map(|arr| *arr)
-                            .map_err(|_| InterpolateError::PointLength(N))
+                            .map_err(|_| InterpolateError::PointLength {
+                                expected: N,
+                                found: point.len(),
+                            })
                     })
                     .collect::<Result<_, _>>()?;
                 self.batch_interpolate_into(&points, out)
@@ -668,7 +673,10 @@ macro_rules! interpolator_trait_impl {
                     .map(|&point| {
                         <&[D::Elem; N]>::try_from(point)
                             .map(|arr| *arr)
-                            .map_err(|_| InterpolateError::PointLength(N))
+                            .map_err(|_| InterpolateError::PointLength {
+                                expected: N,
+                                found: point.len(),
+                            })
                     })
                     .collect::<Result<_, _>>()?;
                 self.batch_interpolate(&points)

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -178,16 +178,16 @@ impl<T> Interpolator<T> for Box<dyn Interpolator<T>> {
 }
 
 /// A `Send + Sync`, downcastable counterpart to [`Interpolator<T>`], for storing
-/// heterogeneous interpolators behind `Box<dyn DynInterpolator<T>>`.
+/// heterogeneous interpolators behind `Box<dyn AnyInterpolator<T>>`.
 ///
 /// Not in the [`prelude`](`crate::prelude`); reach for it explicitly
-/// (`ninterp::interpolator::DynInterpolator`).
+/// (`ninterp::interpolator::AnyInterpolator`).
 ///
 /// Implemented for owned `Interp1D`/`2D`/`3D`/`ND` types only:
-/// [`as_any`](DynInterpolator::as_any) requires `Self: 'static`, which the borrowed
+/// [`as_any`](AnyInterpolator::as_any) requires `Self: 'static`, which the borrowed
 /// `Interp*View` types can't satisfy. A viewed interpolator can still be used
 /// through [`Interpolator<T>`].
-pub trait DynInterpolator<T>: Interpolator<T> + Send + Sync {
+pub trait AnyInterpolator<T>: Interpolator<T> + Send + Sync {
     /// Downcast to the concrete interpolator type.
     fn as_any(&self) -> &dyn Any;
 }
@@ -223,17 +223,20 @@ macro_rules! extrapolate_impl {
             D::Elem: PartialEq + Debug,
             S: $Strategy<D> + Clone,
         {
-            /// Check applicability of strategy, data, and extrapolate setting.
-            pub fn check_extrapolate(
+            /// Check that `extrapolate` is applicable to the current strategy.
+            ///
+            /// Only [`Extrapolate::Enable`] can be rejected, and only by a strategy whose
+            /// `allow_extrapolate` returns `false`. Takes the setting as an argument rather
+            /// than reading `self.extrapolate`, so `set_extrapolate` can vet a candidate
+            /// before storing it.
+            pub fn validate_extrapolate(
                 &self,
                 extrapolate: &Extrapolate<D::Elem>,
             ) -> Result<(), ValidateError> {
-                // Check applicability of strategy and extrapolate setting
                 if matches!(extrapolate, Extrapolate::Enable) && !self.strategy.allow_extrapolate()
                 {
                     return Err(ValidateError::InvalidExtrapolate(format!(
-                        "{:?}",
-                        self.extrapolate
+                        "{extrapolate:?}"
                     )));
                 }
                 Ok(())
@@ -296,7 +299,7 @@ macro_rules! interpolate_impl {
                 }
             }
             if !errors.is_empty() {
-                return Err(InterpolateError::ExtrapolateError(errors.join("")));
+                return Err(InterpolateError::OutOfBounds(errors.join("")));
             }
             self.strategy.interpolate(&self.data, point)
         }
@@ -436,7 +439,7 @@ macro_rules! batch_interpolate_into_impl {
                         }
                     }
                     if !errors.is_empty() {
-                        return Err(InterpolateError::ExtrapolateError(errors.join("")));
+                        return Err(InterpolateError::OutOfBounds(errors.join("")));
                     }
                     self.strategy.batch_interpolate_into(&self.data, &in_bounds_points, out)
                 }
@@ -531,7 +534,7 @@ macro_rules! set_strategy_box_impl {
                 strategy: Box<dyn $Strategy<D>>,
             ) -> Result<(), ValidateError> {
                 self.strategy = strategy;
-                self.check_extrapolate(&self.extrapolate)?;
+                self.validate_extrapolate(&self.extrapolate)?;
                 self.validate_strategy()?;
                 self.init_strategy()
             }
@@ -561,7 +564,7 @@ macro_rules! set_strategy_enum_impl {
                 strategy: impl Into<$StrategyEnum>,
             ) -> Result<(), ValidateError> {
                 self.strategy = strategy.into();
-                self.check_extrapolate(&self.extrapolate)?;
+                self.validate_extrapolate(&self.extrapolate)?;
                 self.validate_strategy()?;
                 self.init_strategy()
             }
@@ -609,7 +612,7 @@ macro_rules! interpolator_trait_impl {
             }
 
             fn validate(&self) -> Result<(), ValidateError> {
-                self.check_extrapolate(&self.extrapolate)?;
+                self.validate_extrapolate(&self.extrapolate)?;
                 self.data.validate()?;
                 self.validate_strategy()?;
                 Ok(())
@@ -686,7 +689,7 @@ macro_rules! interpolator_trait_impl {
                 &mut self,
                 extrapolate: Extrapolate<D::Elem>,
             ) -> Result<(), ValidateError> {
-                self.check_extrapolate(&extrapolate)?;
+                self.validate_extrapolate(&extrapolate)?;
                 self.extrapolate = extrapolate;
                 Ok(())
             }
@@ -719,14 +722,14 @@ macro_rules! serialize_nested_impl {
     };
 }
 
-/// Generates the [`DynInterpolator`] impl shared by `Interp1D`/`2D`/`3D`/`ND`'s owned
+/// Generates the [`AnyInterpolator`] impl shared by `Interp1D`/`2D`/`3D`/`ND`'s owned
 /// variants. Bounded on `Float + Euclid` (rather than the `Num + PartialOrd + Euclid +
-/// Copy` the [`Interpolator`] impls use) because that's what [`DynInterpolator`] itself
+/// Copy` the [`Interpolator`] impls use) because that's what [`AnyInterpolator`] itself
 /// requires transitively; only owned types implement it, since `as_any` requires
 /// `Self: 'static`.
-macro_rules! dyn_interpolator_impl {
+macro_rules! any_interpolator_impl {
     ($InterpTypeOwned:ident, $Strategy:ident) => {
-        impl<T, S> DynInterpolator<T> for $InterpTypeOwned<T, S>
+        impl<T, S> AnyInterpolator<T> for $InterpTypeOwned<T, S>
         where
             T: Float + Euclid + Debug + Send + Sync + 'static,
             S: $Strategy<OwnedRepr<T>> + Clone + Send + Sync + 'static,
@@ -737,7 +740,7 @@ macro_rules! dyn_interpolator_impl {
         }
     };
 }
-pub(crate) use dyn_interpolator_impl;
+pub(crate) use any_interpolator_impl;
 
 #[cfg(feature = "serde")]
 pub(crate) use serialize_nested_impl;
@@ -781,7 +784,7 @@ pub(crate) use view_into_owned_impl;
 
 /// Generates all trait impls for an interpolator: `PartialEq`, `SerializeNested`,
 /// `extrapolate_impl`, `Interpolator`, `set_strategy` for `Box<dyn Strategy>`,
-/// `set_strategy` for the strategy enum, and `DynInterpolator`.
+/// `set_strategy` for the strategy enum, and `AnyInterpolator`.
 macro_rules! interp_trait_impls {
     ($InterpType:ident, $InterpTypeOwned:ident, $InterpData:ident, $Strategy:ident, $StrategyEnum:path, $N:expr) => {
         partialeq_impl!($InterpType, $InterpData, $Strategy);
@@ -789,7 +792,7 @@ macro_rules! interp_trait_impls {
         interpolator_trait_impl!($InterpType, $Strategy, $N);
         set_strategy_box_impl!($InterpType, $Strategy);
         set_strategy_enum_impl!($InterpType, $StrategyEnum);
-        dyn_interpolator_impl!($InterpTypeOwned, $Strategy);
+        any_interpolator_impl!($InterpTypeOwned, $Strategy);
         #[cfg(feature = "serde")]
         serialize_nested_impl!($InterpType, $InterpData, $Strategy);
     };

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -630,7 +630,7 @@ pub(crate) use partialeq_impl;
 
 /// Generates the entire [`Interpolator<T>`] trait impl shared by `Interp1D`/`2D`/`3D`/`ND`.
 /// Parameterized by interpolator type, strategy trait, and the ndim return value
-/// (a literal for sized types, `self.data.ndim()` for ND). Includes slice-to-array
+/// (a literal for fixed-dimensionality types, `self.data.ndim()` for ND). Includes slice-to-array
 /// conversion logic for `interpolate`/`interpolate_fast`/`batch_interpolate`/`batch_interpolate_fast`.
 macro_rules! interpolator_trait_impl {
     ($InterpType:ident, $Strategy:ident, $NdimExpr:expr) => {

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -95,11 +95,10 @@ where
         let n = self.ndim();
         if (self.grid.len() != n) && !(n == 0 && self.grid.iter().all(|g| g.is_empty())) {
             // Only possible for `InterpDataND`
-            return Err(ValidateError::Other(format!(
-                "grid length {} does not match dimensionality {}",
-                self.grid.len(),
-                n,
-            )));
+            return Err(ValidateError::GridLength {
+                expected: n,
+                found: self.grid.len(),
+            });
         }
         for i in 0..n {
             let i_grid_len = self.grid[i].len();

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -329,7 +329,10 @@ where
     fn interpolate(&self, point: &[D::Elem]) -> Result<D::Elem, InterpolateError> {
         let n = self.ndim();
         if point.len() != n {
-            return Err(InterpolateError::PointLength(n));
+            return Err(InterpolateError::PointLength {
+                expected: n,
+                found: point.len(),
+            });
         }
         let mut errors = Vec::new();
         for dim in 0..n {
@@ -405,7 +408,10 @@ where
         let n = self.ndim();
         for point in points {
             if point.len() != n {
-                return Err(InterpolateError::PointLength(n));
+                return Err(InterpolateError::PointLength {
+                    expected: n,
+                    found: point.len(),
+                });
             }
         }
         if out.len() != points.len() {

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -261,7 +261,7 @@ where
     /// // out of bounds point with `Extrapolate::Error` fails
     /// assert!(matches!(
     ///     interp.interpolate(&[5.5, 5.5, 5.5]).unwrap_err(),
-    ///     ninterp::error::InterpolateError::ExtrapolateError(_)
+    ///     ninterp::error::InterpolateError::OutOfBounds(_)
     /// ));
     /// ```
     pub fn new(
@@ -275,7 +275,7 @@ where
             strategy,
             extrapolate,
         };
-        interpolator.check_extrapolate(&interpolator.extrapolate)?;
+        interpolator.validate_extrapolate(&interpolator.extrapolate)?;
         interpolator.validate_strategy()?;
         interpolator.init_strategy()?;
         Ok(interpolator)
@@ -320,7 +320,7 @@ where
     }
 
     fn validate(&self) -> Result<(), ValidateError> {
-        self.check_extrapolate(&self.extrapolate)?;
+        self.validate_extrapolate(&self.extrapolate)?;
         self.data.validate()?;
         self.validate_strategy()?;
         Ok(())
@@ -377,13 +377,13 @@ where
             }
         }
         if !errors.is_empty() {
-            return Err(InterpolateError::ExtrapolateError(errors.join("")));
+            return Err(InterpolateError::OutOfBounds(errors.join("")));
         }
         self.strategy.interpolate(&self.data, point)
     }
 
     fn set_extrapolate(&mut self, extrapolate: Extrapolate<D::Elem>) -> Result<(), ValidateError> {
-        self.check_extrapolate(&extrapolate)?;
+        self.validate_extrapolate(&extrapolate)?;
         self.extrapolate = extrapolate;
         Ok(())
     }
@@ -515,7 +515,7 @@ where
                     }
                 }
                 if !errors.is_empty() {
-                    return Err(InterpolateError::ExtrapolateError(errors.join("")));
+                    return Err(InterpolateError::OutOfBounds(errors.join("")));
                 }
                 self.strategy
                     .batch_interpolate_into(&self.data, &in_bounds_points, out)
@@ -562,4 +562,4 @@ where
 extrapolate_impl!(InterpNDBase, StrategyND);
 set_strategy_box_impl!(InterpNDBase, StrategyND);
 set_strategy_enum_impl!(InterpNDBase, strategy::enums::StrategyNDEnum);
-dyn_interpolator_impl!(InterpND, StrategyND);
+any_interpolator_impl!(InterpND, StrategyND);

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -331,7 +331,7 @@ where
         if point.len() != n {
             return Err(InterpolateError::PointLength {
                 expected: n,
-                found: point.len(),
+                failures: vec![(0, point.len())],
             });
         }
         let mut errors = Vec::new();
@@ -371,16 +371,13 @@ where
                         return self.strategy.interpolate(&self.data, &wrapped_point);
                     }
                     Extrapolate::Error => {
-                        errors.push(format!(
-                            "\n    point[{dim}] = {:?} is out of bounds for grid[{dim}] = {:?}",
-                            point[dim], self.data.grid[dim],
-                        ));
+                        errors.push((0, dim));
                     }
                 };
             }
         }
         if !errors.is_empty() {
-            return Err(InterpolateError::OutOfBounds(errors.join("")));
+            return Err(InterpolateError::OutOfBounds(errors));
         }
         self.strategy.interpolate(&self.data, point)
     }
@@ -406,13 +403,17 @@ where
         out: &mut [D::Elem],
     ) -> Result<(), InterpolateError> {
         let n = self.ndim();
-        for point in points {
-            if point.len() != n {
-                return Err(InterpolateError::PointLength {
-                    expected: n,
-                    found: point.len(),
-                });
-            }
+        let failures: Vec<(usize, usize)> = points
+            .iter()
+            .enumerate()
+            .filter(|(_, point)| point.len() != n)
+            .map(|(i, point)| (i, point.len()))
+            .collect();
+        if !failures.is_empty() {
+            return Err(InterpolateError::PointLength {
+                expected: n,
+                failures,
+            });
         }
         if out.len() != points.len() {
             return Err(InterpolateError::OutputLength {
@@ -509,9 +510,7 @@ where
                     for (dim, (axis, &coord)) in self.data.grid.iter().zip(point.iter()).enumerate()
                     {
                         if !(axis.first().unwrap()..=axis.last().unwrap()).contains(&&coord) {
-                            point_errors.push(format!(
-                                "\n    point[{i}][{dim}] = {coord:?} is out of bounds for grid[{dim}] = {axis:?}",
-                            ));
+                            point_errors.push((i, dim));
                         }
                     }
                     if point_errors.is_empty() {
@@ -521,7 +520,7 @@ where
                     }
                 }
                 if !errors.is_empty() {
-                    return Err(InterpolateError::OutOfBounds(errors.join("")));
+                    return Err(InterpolateError::OutOfBounds(errors));
                 }
                 self.strategy
                     .batch_interpolate_into(&self.data, &in_bounds_points, out)

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -331,7 +331,10 @@ where
         if point.len() != n {
             return Err(InterpolateError::PointLength {
                 expected: n,
-                failures: vec![(0, point.len())],
+                failures: vec![WrongLengthAt {
+                    index: 0,
+                    found: point.len(),
+                }],
             });
         }
         let mut errors = Vec::new();
@@ -371,7 +374,7 @@ where
                         return self.strategy.interpolate(&self.data, &wrapped_point);
                     }
                     Extrapolate::Error => {
-                        errors.push((0, dim));
+                        errors.push(OutOfBoundsAt { index: 0, dim });
                     }
                 };
             }
@@ -403,11 +406,14 @@ where
         out: &mut [D::Elem],
     ) -> Result<(), InterpolateError> {
         let n = self.ndim();
-        let failures: Vec<(usize, usize)> = points
+        let failures: Vec<WrongLengthAt> = points
             .iter()
             .enumerate()
             .filter(|(_, point)| point.len() != n)
-            .map(|(i, point)| (i, point.len()))
+            .map(|(i, point)| WrongLengthAt {
+                index: i,
+                found: point.len(),
+            })
             .collect();
         if !failures.is_empty() {
             return Err(InterpolateError::PointLength {
@@ -510,7 +516,7 @@ where
                     for (dim, (axis, &coord)) in self.data.grid.iter().zip(point.iter()).enumerate()
                     {
                         if !(axis.first().unwrap()..=axis.last().unwrap()).contains(&&coord) {
-                            point_errors.push((i, dim));
+                            point_errors.push(OutOfBoundsAt { index: i, dim });
                         }
                     }
                     if point_errors.is_empty() {

--- a/src/interpolator/n/strategies.rs
+++ b/src/interpolator/n/strategies.rs
@@ -94,7 +94,7 @@ where
     /// Ensures grid uniformity in all dimensions
     fn validate(&self, data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
         for (dim, grid) in data.grid.iter().enumerate() {
-            check_uniform_grid(grid.view(), dim)?;
+            validate_uniform_grid(grid.view(), dim, None)?;
         }
         Ok(())
     }
@@ -181,14 +181,7 @@ where
 {
     /// Ensures the number of provided step directions matches the dimensionality of the interpolator
     fn validate(&self, data: &InterpDataNDBase<D>) -> Result<(), ValidateError> {
-        let n = data.values.ndim();
-        if self.0.len() != 1 && self.0.len() != n {
-            return Err(ValidateError::Other(format!(
-                "Step strategy has {} step directions but interpolator is {n}-D (expected 1 or {n})",
-                self.0.len()
-            )));
-        }
-        Ok(())
+        self.validate_len(data.values.ndim())
     }
 
     fn interpolate(

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -591,12 +591,13 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     .unwrap();
     let points: [&[f64]; 3] = [&[0.4, 0.4, 0.4], &[-1., -1., -1.], &[2., 2., 2.]];
     let err = interp.batch_interpolate(&points).unwrap_err();
-    let InterpolateError::OutOfBounds(message) = err else {
+    let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    assert!(message.contains("point[1]"));
-    assert!(message.contains("point[2]"));
-    assert!(!message.contains("point[0]"));
+    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    assert!(offending.contains(&1));
+    assert!(offending.contains(&2));
+    assert!(!offending.contains(&0));
 }
 
 #[test]

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -72,7 +72,7 @@ fn test_dyn_interpolator() {
     .unwrap();
     let points: [&[f64]; 2] = [&[0.05, 0.10, 0.20], &[0.15, 0.30, 0.60]];
 
-    let boxed: Box<dyn DynInterpolator<f64>> = Box::new(interp.clone());
+    let boxed: Box<dyn AnyInterpolator<f64>> = Box::new(interp.clone());
     assert_eq!(
         boxed.interpolate(&[0.05, 0.10, 0.20]).unwrap(),
         interp.interpolate(&[0.05, 0.10, 0.20]).unwrap(),
@@ -417,11 +417,11 @@ fn test_extrapolate_inputs() {
     .unwrap();
     assert!(matches!(
         interp.interpolate(&[-1., -1., -1.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
     assert!(matches!(
         interp.interpolate(&[2., 2., 2.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
 }
 
@@ -591,8 +591,8 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     .unwrap();
     let points: [&[f64]; 3] = [&[0.4, 0.4, 0.4], &[-1., -1., -1.], &[2., 2., 2.]];
     let err = interp.batch_interpolate(&points).unwrap_err();
-    let InterpolateError::ExtrapolateError(message) = err else {
-        panic!("expected ExtrapolateError");
+    let InterpolateError::OutOfBounds(message) = err else {
+        panic!("expected InterpolateError::OutOfBounds");
     };
     assert!(message.contains("point[1]"));
     assert!(message.contains("point[2]"));
@@ -728,9 +728,9 @@ fn test_serde() {
 
 #[test]
 fn test_dyn_interpolator_heterogeneous_storage() {
-    // The motivating use case for `DynInterpolator`: interpolators of differing
-    // dimensionality and strategy, stored behind one `Vec<Box<dyn DynInterpolator<T>>>`.
-    let interp1d: Box<dyn DynInterpolator<f64>> = Box::new(
+    // The motivating use case for `AnyInterpolator`: interpolators of differing
+    // dimensionality and strategy, stored behind one `Vec<Box<dyn AnyInterpolator<T>>>`.
+    let interp1d: Box<dyn AnyInterpolator<f64>> = Box::new(
         Interp1D::new(
             array![0., 1., 2.],
             array![0.0, 0.4, 0.8],
@@ -739,7 +739,7 @@ fn test_dyn_interpolator_heterogeneous_storage() {
         )
         .unwrap(),
     );
-    let interp2d: Box<dyn DynInterpolator<f64>> = Box::new(
+    let interp2d: Box<dyn AnyInterpolator<f64>> = Box::new(
         Interp2D::new(
             array![0., 1.],
             array![0., 1.],
@@ -749,7 +749,7 @@ fn test_dyn_interpolator_heterogeneous_storage() {
         )
         .unwrap(),
     );
-    let interpnd: Box<dyn DynInterpolator<f64>> = Box::new(
+    let interpnd: Box<dyn AnyInterpolator<f64>> = Box::new(
         InterpND::new(
             vec![array![0., 1.]],
             array![0.0, 0.4].into_dyn(),
@@ -759,7 +759,7 @@ fn test_dyn_interpolator_heterogeneous_storage() {
         .unwrap(),
     );
 
-    let interps: Vec<Box<dyn DynInterpolator<f64>>> = vec![interp1d, interp2d, interpnd];
+    let interps: Vec<Box<dyn AnyInterpolator<f64>>> = vec![interp1d, interp2d, interpnd];
     let points: [&[f64]; 3] = [&[1.5], &[0.6, 0.6], &[0.5]];
     let results: Vec<f64> = interps
         .iter()

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -594,7 +594,7 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    let offending: Vec<usize> = failures.iter().map(|at| at.index).collect();
     assert!(offending.contains(&1));
     assert!(offending.contains(&2));
     assert!(!offending.contains(&0));

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -642,7 +642,10 @@ fn test_mismatched_grid() {
             Extrapolate::Error,
         )
         .unwrap_err(),
-        ValidateError::Other(_)
+        ValidateError::GridLength {
+            expected: 2,
+            found: 3
+        }
     ));
     assert!(InterpND::new(
         vec![array![]],
@@ -661,7 +664,11 @@ fn test_mismatched_grid() {
             Extrapolate::Error,
         )
         .unwrap_err(),
-        ValidateError::Other(_)
+        // A single value reads as 0-D, so a non-empty grid has one axis too many
+        ValidateError::GridLength {
+            expected: 0,
+            found: 1
+        }
     ));
 }
 

--- a/src/interpolator/n/tests.rs
+++ b/src/interpolator/n/tests.rs
@@ -83,7 +83,7 @@ fn test_dyn_interpolator() {
     );
     assert!(matches!(
         boxed.interpolate(&[]).unwrap_err(),
-        InterpolateError::PointLength(3)
+        InterpolateError::PointLength { expected: 3, .. }
     ));
     assert_eq!(
         boxed.as_any().downcast_ref::<InterpND<f64, _>>(),
@@ -405,7 +405,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::InvalidExtrapolate(_)
+        ValidateError::ExtrapolateUnsupported
     ));
     // Extrapolate::Error
     let interp = InterpND::new(
@@ -611,7 +611,7 @@ fn test_batch_interpolate_point_length_mismatch() {
     let points: [&[f64]; 2] = [&[0.25, 0.65, 0.9], &[0.5, 0.5]];
     assert!(matches!(
         interp.batch_interpolate(&points).unwrap_err(),
-        InterpolateError::PointLength(3)
+        InterpolateError::PointLength { expected: 3, .. }
     ));
 }
 

--- a/src/interpolator/one/mod.rs
+++ b/src/interpolator/one/mod.rs
@@ -105,7 +105,7 @@ where
             strategy,
             extrapolate,
         };
-        interpolator.check_extrapolate(&interpolator.extrapolate)?;
+        interpolator.validate_extrapolate(&interpolator.extrapolate)?;
         interpolator.validate_strategy()?;
         interpolator.init_strategy()?;
         Ok(interpolator)

--- a/src/interpolator/one/strategies.rs
+++ b/src/interpolator/one/strategies.rs
@@ -15,7 +15,7 @@ where
         // meaning by now, point is within grid bounds or extrapolation is enabled
         match locate_axis(data.grid[0].view(), &point[0]) {
             AxisLocation::Exact(i) => Ok(data.values[i]),
-            AxisLocation::Interp { lower, frac } => {
+            AxisLocation::Between { lower, frac } => {
                 let upper = lower + 1;
                 Ok(data.values[lower] * (D::Elem::one() - frac) + data.values[upper] * frac)
             }

--- a/src/interpolator/one/strategies.rs
+++ b/src/interpolator/one/strategies.rs
@@ -35,7 +35,7 @@ where
 {
     /// Ensures the grid is uniformly spaced.
     fn validate(&self, data: &InterpData1DBase<D>) -> Result<(), ValidateError> {
-        check_uniform_grid(data.grid[0].view(), 0)
+        validate_uniform_grid(data.grid[0].view(), 0, None)
     }
 
     fn interpolate(
@@ -90,13 +90,7 @@ where
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
     fn validate(&self, _data: &InterpData1DBase<D>) -> Result<(), ValidateError> {
-        if self.0.len() != 1 {
-            return Err(ValidateError::Other(format!(
-                "Step strategy has {} directions but interpolator is 1-D (expected 1)",
-                self.0.len()
-            )));
-        }
-        Ok(())
+        self.validate_len(1)
     }
 
     fn interpolate(

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -443,13 +443,14 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let err = interp
         .batch_interpolate(&[[1.], [-1.], [2.], [5.]])
         .unwrap_err();
-    let InterpolateError::OutOfBounds(message) = err else {
+    let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    assert!(message.contains("point[1]"));
-    assert!(message.contains("point[3]"));
-    assert!(!message.contains("point[0]"));
-    assert!(!message.contains("point[2]"));
+    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    assert!(offending.contains(&1));
+    assert!(offending.contains(&3));
+    assert!(!offending.contains(&0));
+    assert!(!offending.contains(&2));
 }
 
 #[test]

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -50,7 +50,7 @@ fn test_dyn_interpolator() {
     .unwrap();
     let points: [&[f64]; 2] = [&[1.0], &[2.5]];
 
-    let boxed: Box<dyn DynInterpolator<f64>> = Box::new(interp.clone());
+    let boxed: Box<dyn AnyInterpolator<f64>> = Box::new(interp.clone());
     assert_eq!(boxed.interpolate(&[1.0]).unwrap(), 0.4);
     assert_eq!(
         boxed.batch_interpolate(&points).unwrap(),
@@ -304,12 +304,12 @@ fn test_extrapolate_inputs() {
     // Fail to extrapolate below lowest grid value
     assert!(matches!(
         interp.interpolate(&[-1.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
     // Fail to extrapolate above highest grid value
     assert!(matches!(
         interp.interpolate(&[5.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
 }
 
@@ -443,8 +443,8 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let err = interp
         .batch_interpolate(&[[1.], [-1.], [2.], [5.]])
         .unwrap_err();
-    let InterpolateError::ExtrapolateError(message) = err else {
-        panic!("expected ExtrapolateError");
+    let InterpolateError::OutOfBounds(message) = err else {
+        panic!("expected InterpolateError::OutOfBounds");
     };
     assert!(message.contains("point[1]"));
     assert!(message.contains("point[3]"));

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -14,7 +14,7 @@ fn test_invalid_args() {
     // generic/`dyn` callers passing a real slice) still catches it at runtime.
     assert!(matches!(
         Interpolator::interpolate(&interp, &[]).unwrap_err(),
-        InterpolateError::PointLength(_)
+        InterpolateError::PointLength { .. }
     ));
     assert_eq!(interp.interpolate(&[1.0]).unwrap(), 0.4);
 }
@@ -34,7 +34,7 @@ fn test_invalid_args_dyn() {
     // reachable, so a wrong-length point still fails at runtime, not compile time.
     assert!(matches!(
         interp.interpolate(&[]).unwrap_err(),
-        InterpolateError::PointLength(_)
+        InterpolateError::PointLength { .. }
     ));
     assert_eq!(interp.interpolate(&[1.0]).unwrap(), 0.4);
 }
@@ -58,7 +58,7 @@ fn test_dyn_interpolator() {
     );
     assert!(matches!(
         boxed.interpolate(&[]).unwrap_err(),
-        InterpolateError::PointLength(1)
+        InterpolateError::PointLength { expected: 1, .. }
     ));
     assert_eq!(
         boxed.as_any().downcast_ref::<Interp1D<f64, _>>(),
@@ -290,7 +290,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::InvalidExtrapolate(_)
+        ValidateError::ExtrapolateUnsupported
     ));
 
     // Extrapolate::Error

--- a/src/interpolator/one/tests.rs
+++ b/src/interpolator/one/tests.rs
@@ -446,7 +446,7 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    let offending: Vec<usize> = failures.iter().map(|at| at.index).collect();
     assert!(offending.contains(&1));
     assert!(offending.contains(&3));
     assert!(!offending.contains(&0));

--- a/src/interpolator/three/mod.rs
+++ b/src/interpolator/three/mod.rs
@@ -112,7 +112,7 @@ where
     /// // out of bounds point with `Extrapolate::Error` fails
     /// assert!(matches!(
     ///     interp.interpolate(&[5.5, 5.5, 5.5]).unwrap_err(),
-    ///     ninterp::error::InterpolateError::ExtrapolateError(_)
+    ///     ninterp::error::InterpolateError::OutOfBounds(_)
     /// ));
     /// ```
     pub fn new(
@@ -131,7 +131,7 @@ where
             strategy,
             extrapolate,
         };
-        interpolator.check_extrapolate(&interpolator.extrapolate)?;
+        interpolator.validate_extrapolate(&interpolator.extrapolate)?;
         interpolator.validate_strategy()?;
         interpolator.init_strategy()?;
         Ok(interpolator)

--- a/src/interpolator/three/strategies.rs
+++ b/src/interpolator/three/strategies.rs
@@ -27,7 +27,7 @@ where
             (
                 AxisLocation::Exact(i),
                 AxisLocation::Exact(j),
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: z_l,
                     frac: z_diff,
                 },
@@ -38,7 +38,7 @@ where
             }
             (
                 AxisLocation::Exact(i),
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: y_l,
                     frac: y_diff,
                 },
@@ -49,7 +49,7 @@ where
                     + data.values[[i, y_u, k]] * y_diff)
             }
             (
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: x_l,
                     frac: x_diff,
                 },
@@ -62,11 +62,11 @@ where
             }
             (
                 AxisLocation::Exact(i),
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: y_l,
                     frac: y_diff,
                 },
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: z_l,
                     frac: z_diff,
                 },
@@ -80,12 +80,12 @@ where
                 Ok(f0 * (D::Elem::one() - z_diff) + f1 * z_diff)
             }
             (
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: x_l,
                     frac: x_diff,
                 },
                 AxisLocation::Exact(j),
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: z_l,
                     frac: z_diff,
                 },
@@ -99,11 +99,11 @@ where
                 Ok(f0 * (D::Elem::one() - z_diff) + f1 * z_diff)
             }
             (
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: x_l,
                     frac: x_diff,
                 },
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: y_l,
                     frac: y_diff,
                 },
@@ -118,15 +118,15 @@ where
                 Ok(f0 * (D::Elem::one() - y_diff) + f1 * y_diff)
             }
             (
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: x_l,
                     frac: x_diff,
                 },
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: y_l,
                     frac: y_diff,
                 },
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: z_l,
                     frac: z_diff,
                 },

--- a/src/interpolator/three/strategies.rs
+++ b/src/interpolator/three/strategies.rs
@@ -165,9 +165,9 @@ where
 {
     /// Ensures all grid dimensions are uniformly spaced.
     fn validate(&self, data: &InterpData3DBase<D>) -> Result<(), ValidateError> {
-        check_uniform_grid(data.grid[0].view(), 0)?;
-        check_uniform_grid(data.grid[1].view(), 1)?;
-        check_uniform_grid(data.grid[2].view(), 2)
+        validate_uniform_grid(data.grid[0].view(), 0, None)?;
+        validate_uniform_grid(data.grid[1].view(), 1, None)?;
+        validate_uniform_grid(data.grid[2].view(), 2, None)
     }
 
     fn interpolate(
@@ -257,13 +257,7 @@ where
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
     fn validate(&self, _data: &InterpData3DBase<D>) -> Result<(), ValidateError> {
-        if self.0.len() != 1 && self.0.len() != 3 {
-            return Err(ValidateError::Other(format!(
-                "Step strategy has {} directions but interpolator is 3-D (expected 1 or 3)",
-                self.0.len()
-            )));
-        }
-        Ok(())
+        self.validate_len(3)
     }
 
     fn interpolate(

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -20,7 +20,7 @@ fn test_invalid_args() {
     // generic/`dyn` callers passing a real slice) still catches it at runtime.
     assert!(matches!(
         Interpolator::interpolate(&interp, &[]).unwrap_err(),
-        InterpolateError::PointLength(_)
+        InterpolateError::PointLength { .. }
     ));
 }
 
@@ -51,7 +51,7 @@ fn test_dyn_interpolator() {
     );
     assert!(matches!(
         boxed.interpolate(&[]).unwrap_err(),
-        InterpolateError::PointLength(3)
+        InterpolateError::PointLength { expected: 3, .. }
     ));
     assert_eq!(
         boxed.as_any().downcast_ref::<Interp3D<f64, _>>(),
@@ -281,7 +281,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::InvalidExtrapolate(_)
+        ValidateError::ExtrapolateUnsupported
     ));
     // Extrapolate::Error
     let interp = Interp3D::new(

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -405,12 +405,13 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let err = interp
         .batch_interpolate(&[[0.4, 0.4, 0.4], [-1., -1., -1.], [2., 2., 2.]])
         .unwrap_err();
-    let InterpolateError::OutOfBounds(message) = err else {
+    let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    assert!(message.contains("point[1]"));
-    assert!(message.contains("point[2]"));
-    assert!(!message.contains("point[0]"));
+    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    assert!(offending.contains(&1));
+    assert!(offending.contains(&2));
+    assert!(!offending.contains(&0));
 }
 
 #[test]

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -41,7 +41,7 @@ fn test_dyn_interpolator() {
     .unwrap();
     let points: [&[f64]; 2] = [&[0.05, 0.10, 0.20], &[0.15, 0.30, 0.60]];
 
-    let boxed: Box<dyn DynInterpolator<f64>> = Box::new(interp.clone());
+    let boxed: Box<dyn AnyInterpolator<f64>> = Box::new(interp.clone());
     assert_eq!(boxed.interpolate(&[0.05, 0.10, 0.20]).unwrap(), 0.);
     assert_eq!(
         boxed.batch_interpolate(&points).unwrap(),
@@ -295,11 +295,11 @@ fn test_extrapolate_inputs() {
     .unwrap();
     assert!(matches!(
         interp.interpolate(&[-1., -1., -1.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
     assert!(matches!(
         interp.interpolate(&[2., 2., 2.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
 }
 
@@ -405,8 +405,8 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let err = interp
         .batch_interpolate(&[[0.4, 0.4, 0.4], [-1., -1., -1.], [2., 2., 2.]])
         .unwrap_err();
-    let InterpolateError::ExtrapolateError(message) = err else {
-        panic!("expected ExtrapolateError");
+    let InterpolateError::OutOfBounds(message) = err else {
+        panic!("expected InterpolateError::OutOfBounds");
     };
     assert!(message.contains("point[1]"));
     assert!(message.contains("point[2]"));

--- a/src/interpolator/three/tests.rs
+++ b/src/interpolator/three/tests.rs
@@ -408,7 +408,7 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    let offending: Vec<usize> = failures.iter().map(|at| at.index).collect();
     assert!(offending.contains(&1));
     assert!(offending.contains(&2));
     assert!(!offending.contains(&0));

--- a/src/interpolator/two/mod.rs
+++ b/src/interpolator/two/mod.rs
@@ -119,7 +119,7 @@ where
             strategy,
             extrapolate,
         };
-        interpolator.check_extrapolate(&interpolator.extrapolate)?;
+        interpolator.validate_extrapolate(&interpolator.extrapolate)?;
         interpolator.validate_strategy()?;
         interpolator.init_strategy()?;
         Ok(interpolator)

--- a/src/interpolator/two/strategies.rs
+++ b/src/interpolator/two/strategies.rs
@@ -23,7 +23,7 @@ where
             (AxisLocation::Exact(i), AxisLocation::Exact(j)) => Ok(data.values[[i, j]]),
             (
                 AxisLocation::Exact(i),
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: y_l,
                     frac: y_diff,
                 },
@@ -33,7 +33,7 @@ where
                     + data.values[[i, y_u]] * y_diff)
             }
             (
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: x_l,
                     frac: x_diff,
                 },
@@ -44,11 +44,11 @@ where
                     + data.values[[x_u, j]] * x_diff)
             }
             (
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: x_l,
                     frac: x_diff,
                 },
-                AxisLocation::Interp {
+                AxisLocation::Between {
                     lower: y_l,
                     frac: y_diff,
                 },

--- a/src/interpolator/two/strategies.rs
+++ b/src/interpolator/two/strategies.rs
@@ -79,8 +79,8 @@ where
 {
     /// Ensures all grid dimensions are uniformly spaced.
     fn validate(&self, data: &InterpData2DBase<D>) -> Result<(), ValidateError> {
-        check_uniform_grid(data.grid[0].view(), 0)?;
-        check_uniform_grid(data.grid[1].view(), 1)
+        validate_uniform_grid(data.grid[0].view(), 0, None)?;
+        validate_uniform_grid(data.grid[1].view(), 1, None)
     }
 
     fn interpolate(
@@ -152,13 +152,7 @@ where
 {
     /// Ensures the number of provided step directions matches the interpolator dimensionality.
     fn validate(&self, _data: &InterpData2DBase<D>) -> Result<(), ValidateError> {
-        if self.0.len() != 1 && self.0.len() != 2 {
-            return Err(ValidateError::Other(format!(
-                "Step strategy has {} directions but interpolator is 2-D (expected 1 or 2)",
-                self.0.len()
-            )));
-        }
-        Ok(())
+        self.validate_len(2)
     }
 
     fn interpolate(

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -310,7 +310,8 @@ fn test_set_strategy_runs_validate() {
     .unwrap();
     assert!(matches!(
         interp.set_strategy(strategy::LinearUniform).unwrap_err(),
-        ValidateError::Other(_)
+        // grid[0] = [0., 1., 5.]: the interval after index 1 is 4, not 1
+        ValidateError::NonUniform { dim: 0, index: 1 }
     ));
 }
 

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -407,7 +407,7 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    let offending: Vec<usize> = failures.iter().map(|at| at.index).collect();
     assert!(offending.contains(&1));
     assert!(offending.contains(&2));
     assert!(!offending.contains(&0));
@@ -582,7 +582,7 @@ fn test_batch_interpolate_into_error_aggregates_all_points() {
     match err {
         InterpolateError::OutOfBounds(failures) => {
             // Should report all out-of-bounds points
-            let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+            let offending: Vec<usize> = failures.iter().map(|at| at.index).collect();
             assert!(offending.contains(&1));
             assert!(offending.contains(&2));
         }

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -15,7 +15,7 @@ fn test_invalid_args() {
     // generic/`dyn` callers passing a real slice) still catches it at runtime.
     assert!(matches!(
         Interpolator::interpolate(&interp, &[]).unwrap_err(),
-        InterpolateError::PointLength(_)
+        InterpolateError::PointLength { .. }
     ));
     assert_eq!(interp.interpolate(&[0.075, 0.25]).unwrap(), 3.);
 }
@@ -201,7 +201,7 @@ fn test_extrapolate_inputs() {
             Extrapolate::Enable,
         )
         .unwrap_err(),
-        ValidateError::InvalidExtrapolate(_)
+        ValidateError::ExtrapolateUnsupported
     ));
     // Extrapolate::Error
     let interp = Interp2D::new(
@@ -451,7 +451,7 @@ fn test_dyn_interpolator() {
     );
     assert!(matches!(
         boxed.interpolate(&[]).unwrap_err(),
-        InterpolateError::PointLength(2)
+        InterpolateError::PointLength { expected: 2, .. }
     ));
     assert_eq!(
         boxed.as_any().downcast_ref::<Interp2D<f64, _>>(),

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -404,12 +404,13 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let err = interp
         .batch_interpolate(&[[0.5, 0.5], [-1., -1.], [2., 2.]])
         .unwrap_err();
-    let InterpolateError::OutOfBounds(message) = err else {
+    let InterpolateError::OutOfBounds(failures) = err else {
         panic!("expected InterpolateError::OutOfBounds");
     };
-    assert!(message.contains("point[1]"));
-    assert!(message.contains("point[2]"));
-    assert!(!message.contains("point[0]"));
+    let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+    assert!(offending.contains(&1));
+    assert!(offending.contains(&2));
+    assert!(!offending.contains(&0));
 }
 
 #[test]
@@ -579,10 +580,11 @@ fn test_batch_interpolate_into_error_aggregates_all_points() {
         .batch_interpolate_into(&[[0.5, 0.5], [-1., -1.], [2., 2.]], &mut out)
         .unwrap_err();
     match err {
-        InterpolateError::OutOfBounds(s) => {
-            // Should mention all out-of-bounds points
-            assert!(s.contains("point[1]"));
-            assert!(s.contains("point[2]"));
+        InterpolateError::OutOfBounds(failures) => {
+            // Should report all out-of-bounds points
+            let offending: Vec<usize> = failures.iter().map(|(index, _)| *index).collect();
+            assert!(offending.contains(&1));
+            assert!(offending.contains(&2));
         }
         _ => panic!("expected InterpolateError::OutOfBounds"),
     }

--- a/src/interpolator/two/tests.rs
+++ b/src/interpolator/two/tests.rs
@@ -214,11 +214,11 @@ fn test_extrapolate_inputs() {
     .unwrap();
     assert!(matches!(
         interp.interpolate(&[-1., -1.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
     assert!(matches!(
         interp.interpolate(&[2., 2.]).unwrap_err(),
-        InterpolateError::ExtrapolateError(_)
+        InterpolateError::OutOfBounds(_)
     ));
 }
 
@@ -404,8 +404,8 @@ fn test_batch_interpolate_error_aggregates_all_points() {
     let err = interp
         .batch_interpolate(&[[0.5, 0.5], [-1., -1.], [2., 2.]])
         .unwrap_err();
-    let InterpolateError::ExtrapolateError(message) = err else {
-        panic!("expected ExtrapolateError");
+    let InterpolateError::OutOfBounds(message) = err else {
+        panic!("expected InterpolateError::OutOfBounds");
     };
     assert!(message.contains("point[1]"));
     assert!(message.contains("point[2]"));
@@ -441,7 +441,7 @@ fn test_dyn_interpolator() {
     .unwrap();
     let points: [&[f64]; 2] = [&[0.075, 0.25], &[0.05, 0.10]];
 
-    let boxed: Box<dyn DynInterpolator<f64>> = Box::new(interp.clone());
+    let boxed: Box<dyn AnyInterpolator<f64>> = Box::new(interp.clone());
     assert_eq!(boxed.interpolate(&[0.075, 0.25]).unwrap(), 3.);
     assert_eq!(
         boxed.batch_interpolate(&points).unwrap(),
@@ -579,12 +579,12 @@ fn test_batch_interpolate_into_error_aggregates_all_points() {
         .batch_interpolate_into(&[[0.5, 0.5], [-1., -1.], [2., 2.]], &mut out)
         .unwrap_err();
     match err {
-        InterpolateError::ExtrapolateError(s) => {
+        InterpolateError::OutOfBounds(s) => {
             // Should mention all out-of-bounds points
             assert!(s.contains("point[1]"));
             assert!(s.contains("point[2]"));
         }
-        _ => panic!("Expected ExtrapolateError"),
+        _ => panic!("expected InterpolateError::OutOfBounds"),
     }
 }
 

--- a/src/interpolator/zero/mod.rs
+++ b/src/interpolator/zero/mod.rs
@@ -67,7 +67,7 @@ where
         if !point.is_empty() {
             return Err(InterpolateError::PointLength {
                 expected: N,
-                found: point.len(),
+                failures: vec![(0, point.len())],
             });
         }
         Ok(self.0.clone())

--- a/src/interpolator/zero/mod.rs
+++ b/src/interpolator/zero/mod.rs
@@ -65,7 +65,10 @@ where
     /// Errors if `!point.is_empty()`.
     fn interpolate(&self, point: &[T]) -> Result<T, InterpolateError> {
         if !point.is_empty() {
-            return Err(InterpolateError::PointLength(N));
+            return Err(InterpolateError::PointLength {
+                expected: N,
+                found: point.len(),
+            });
         }
         Ok(self.0.clone())
     }

--- a/src/interpolator/zero/mod.rs
+++ b/src/interpolator/zero/mod.rs
@@ -67,7 +67,10 @@ where
         if !point.is_empty() {
             return Err(InterpolateError::PointLength {
                 expected: N,
-                failures: vec![(0, point.len())],
+                failures: vec![WrongLengthAt {
+                    index: 0,
+                    found: point.len(),
+                }],
             });
         }
         Ok(self.0.clone())

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -136,6 +136,28 @@ impl From<StepDirection> for Step {
 }
 
 impl Step {
+    /// Checks the stored direction count against an interpolator's dimensionality: one
+    /// direction broadcasts to every dimension, otherwise there must be exactly one per
+    /// dimension. Shared by the `Strategy1D`/`2D`/`3D`/`ND` impls so all four report it
+    /// identically.
+    ///
+    /// Stays a [`ValidateError::Other`] rather than earning a variant: it describes how
+    /// this strategy was configured, not anything about the data.
+    pub(crate) fn validate_len(&self, ndim: usize) -> Result<(), ValidateError> {
+        let found = self.0.len();
+        if found == 1 || found == ndim {
+            return Ok(());
+        }
+        let expected = if ndim == 1 {
+            "1".to_string()
+        } else {
+            format!("1 or {ndim}")
+        };
+        Err(ValidateError::Other(format!(
+            "Step strategy has {found} directions but interpolator is {ndim}-D (expected {expected})"
+        )))
+    }
+
     /// Returns the direction for dimension `dim`.
     /// A single stored direction broadcasts to all dimensions.
     pub(crate) fn dir(&self, dim: usize) -> StepDirection {

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -5,7 +5,7 @@ use super::*;
 /// Generates a fixed-dimensionality strategy trait (`Strategy1D`/`2D`/`3D`) plus its
 /// `impl … for Box<dyn …>` forwarding impl. `StrategyND` takes points as `&[D::Elem]`
 /// instead of `&[D::Elem; N]`, so it can't share this shape and stays hand-written below.
-macro_rules! sized_strategy_trait {
+macro_rules! fixed_strategy_trait {
     ($Trait:ident, $InterpData:ident, $N:literal, $doc:literal) => {
         #[doc = $doc]
         pub trait $Trait<D>: Debug + DynClone
@@ -244,19 +244,19 @@ macro_rules! sized_strategy_trait {
     };
 }
 
-sized_strategy_trait!(
+fixed_strategy_trait!(
     Strategy1D,
     InterpData1DBase,
     1,
     "1-D interpolation strategy."
 );
-sized_strategy_trait!(
+fixed_strategy_trait!(
     Strategy2D,
     InterpData2DBase,
     2,
     "2-D interpolation strategy."
 );
-sized_strategy_trait!(
+fixed_strategy_trait!(
     Strategy3D,
     InterpData3DBase,
     3,

--- a/src/strategy/utils.rs
+++ b/src/strategy/utils.rs
@@ -121,7 +121,7 @@ pub fn exact_index<T: PartialOrd>(grid: ArrayView1<T>, lower: usize, point: &T) 
 /// Computes the lower bracket index for a uniformly-spaced grid in O(1).
 ///
 /// Equivalent to [`locate_lower_index`] but replaces binary search with direct arithmetic.
-/// Only valid when the grid spacing is uniform; validate with [`check_uniform_grid`] first.
+/// Only valid when the grid spacing is uniform; validate with [`validate_uniform_grid`] first.
 pub fn locate_lower_index_uniform<T: Float>(grid0: T, step: T, n: usize, point: T) -> usize {
     let t = (point - grid0) / step;
     if t < T::zero() {
@@ -131,27 +131,36 @@ pub fn locate_lower_index_uniform<T: Float>(grid0: T, step: T, n: usize, point: 
     }
 }
 
-/// Validates that `grid` is uniformly spaced within floating-point tolerance.
+/// Validates that `grid` is uniformly spaced within `tolerance`.
 ///
-/// Uses a relative tolerance of 1024 × ε to accommodate accumulated floating-point rounding
-/// error in grids constructed from repeated arithmetic. Pair with [`locate_lower_index_uniform`]
-/// for the matching O(1) lookup.
-pub fn check_uniform_grid<T: Float>(grid: ArrayView1<T>, dim: usize) -> Result<(), ValidateError> {
+/// `tolerance` is an absolute bound, in the same units as `grid`, on how far a interval
+/// may drift from the grid's first interval (either wider or narrower). Pass `None` for a
+/// sensible default: a relative tolerance of 1024 × ε, scaled by the grid's own step
+/// size, loose enough to absorb the rounding error that accumulates in grids built from
+/// repeated arithmetic (e.g. `Array::linspace`) while still catching a grid that was
+/// never meant to be uniform. Pass `Some(_)` when a strategy's precision needs differ
+/// from that default.
+///
+/// Pair with [`locate_lower_index_uniform`] for the matching O(1) lookup.
+pub fn validate_uniform_grid<T: Float>(
+    grid: ArrayView1<T>,
+    dim: usize,
+    tolerance: Option<T>,
+) -> Result<(), ValidateError> {
     let step = grid[1] - grid[0];
-    // 1024 * epsilon via 10 doublings, avoids numeric literal casting
-    let tolerance = {
+    let tolerance = tolerance.unwrap_or_else(|| {
+        // 1024 * epsilon via 10 doublings, avoids numeric literal casting
         let mut tol = T::epsilon();
         for _ in 0..10 {
             tol = tol + tol;
         }
         step.abs() * tol
-    };
+    });
     for i in 1..grid.len() - 1 {
-        let gap = grid[i + 1] - grid[i];
-        if (gap - step).abs() > tolerance {
-            return Err(ValidateError::Other(format!(
-                "grid[{dim}] is not uniformly spaced (gap at index {i})"
-            )));
+        // Wider or narrower than the first interval both count as non-uniform.
+        let spacing = grid[i + 1] - grid[i];
+        if (spacing - step).abs() > tolerance {
+            return Err(ValidateError::NonUniform { dim, index: i });
         }
     }
     Ok(())

--- a/src/strategy/utils.rs
+++ b/src/strategy/utils.rs
@@ -48,7 +48,7 @@ pub enum AxisLocation<T> {
     /// `point` coincides exactly with `grid[_]` at this index.
     Exact(usize),
     /// `point` falls strictly between two grid coordinates.
-    Interp {
+    Between {
         /// Index of the lower bracketing grid coordinate.
         lower: usize,
         /// Fractional position of `point` between `grid[lower]` and `grid[lower + 1]`, in `[0, 1)`.
@@ -66,7 +66,7 @@ pub fn locate_axis<T: Float>(grid: ArrayView1<T>, point: &T) -> AxisLocation<T> 
         Some(idx) => AxisLocation::Exact(idx),
         None => {
             let frac = (*point - grid[lower]) / (grid[lower + 1] - grid[lower]);
-            AxisLocation::Interp { lower, frac }
+            AxisLocation::Between { lower, frac }
         }
     }
 }

--- a/src/strategy/utils.rs
+++ b/src/strategy/utils.rs
@@ -133,7 +133,7 @@ pub fn locate_lower_index_uniform<T: Float>(grid0: T, step: T, n: usize, point: 
 
 /// Validates that `grid` is uniformly spaced within `tolerance`.
 ///
-/// `tolerance` is an absolute bound, in the same units as `grid`, on how far a interval
+/// `tolerance` is an absolute bound, in the same units as `grid`, on how far an interval
 /// may drift from the grid's first interval (either wider or narrower). Pass `None` for a
 /// sensible default: a relative tolerance of 1024 × ε, scaled by the grid's own step
 /// size, loose enough to absorb the rounding error that accumulates in grids built from


### PR DESCRIPTION
Follow-up to the 0.10 breaking batch. Audits the names across the public surface, then
restructures the two interpolation-time error variants. No open issue tracks this;
context lives in #46, which introduced `DynInterpolator`, and #29, which last revisited
the locate-helper names.

## Naming

| Before | After | Why |
|---|---|---|
| `DynInterpolator<T>` | `AnyInterpolator<T>` | "Dyn" never distinguished it. `Interpolator<T>` is already dyn-compatible and says so in its own docs. What this trait adds is `as_any` downcasting plus `Send + Sync`, so the name now matches the method. New in 0.10 and unreleased, so no migration cost |
| `check_extrapolate` | `validate_extrapolate` | The only `check_*` verb in a crate where every other invariant check is `validate`/`validate_strategy`. The parallel is exact: `validate_strategy` checks the strategy against the current data, this checks a setting against the current strategy |
| `AxisLocation::Interp` | `AxisLocation::Between` | `Interp` is the crate's most overloaded token, prefixing every interpolator and data type, and here it meant something unrelated. `Between` pairs with the sibling `Exact` and matches the variant's own `{ lower, frac }` payload. `AxisLocation` only becomes `pub` in 0.10, so nobody has seen the old name |
| `sized_strategy_trait!` | `fixed_strategy_trait!` | The crate used "fixed" and "sized" interchangeably, roughly 15 sites to 2. Beyond the count, `Sized` is a Rust trait meaning "size known at compile time", which both `&[T]` and `[T; N]` satisfy, so "sized" names the wrong distinction. Both affected sites are private |

## Errors

`PointLength` and `OutOfBounds` disagreed on two axes: one carried prose and the other a
scalar, and one aggregated across a batch while the other returned on the first failure.
Both now carry a `Vec` of a `#[non_exhaustive]` struct and both aggregate.

```rust
// before
OutOfBounds(String),
PointLength(usize),
InvalidExtrapolate(String),   // ValidateError

// after
OutOfBounds(Vec<OutOfBoundsAt>),                                 // { index, dim }
PointLength { expected: usize, failures: Vec<WrongLengthAt> },   // { index, found }
ExtrapolateUnsupported,                                          // ValidateError
NonUniform { dim: usize, index: usize },                         // ValidateError, new
GridLength { expected: usize, found: usize },                    // ValidateError, new
```

- **`ExtrapolateError` -> `OutOfBounds`.** Drops a stuttering `Error` suffix no sibling
  variant carried, and names the condition rather than the setting that turns it into an
  error. The README error table already had to gloss the variant as "query point is out
  of bounds", which is the name it should have had.
- **Values are no longer echoed into the message.** Coordinates and grid bounds are
  `D::Elem`, which the error is not generic over, so carrying them meant a `String`. The
  caller can index the `points` and `grid` it already owns from `{ index, dim }`. This
  also removes one `String` allocation per offending coordinate from the batch error
  path, which sat badly next to `interpolate_fast` and the `_into` variants.
- **`PointLength` now aggregates and reports the actual length.** The length was already
  available at every construction site and discarded by `map_err(|_| PointLength(N))`.
  Aggregating meant the eight `collect::<Result<_, _>>()?` sites could no longer
  short-circuit; they share new `to_fixed_point`/`to_fixed_points` helpers rather than
  repeating the partition loop.
- **`InvalidExtrapolate(String)` -> payload-free `ExtrapolateUnsupported`.** Only
  `Extrapolate::Enable` can ever be rejected, and only by a strategy whose
  `allow_extrapolate` returns `false`, so the stringified setting said nothing the variant
  name doesn't.
- **`OutOfBoundsAt`/`WrongLengthAt` are `#[non_exhaustive]` structs, not tuples.**
  Callers read these rather than construct them, so a struct leaves room to add
  per-failure context later without a breaking change; `failure.dim` also beats
  `failure.1` at the use site. `Extrapolate<T>` gains `#[non_exhaustive]` too, alongside
  both error enums and the strategy enums, since it's the enum most likely to grow a
  variant and the attribute is only free to add before release.
- **Two conditions move out of `ValidateError::Other(String)` into dedicated variants:**
  `NonUniform { dim, index }`, raised by `strategy::utils::validate_uniform_grid` (see
  below) so any strategy requiring uniform spacing, not just `LinearUniform`, reports it
  identically; and `GridLength { expected, found }`, for an `InterpDataND` whose grid
  axis count doesn't match its values' dimensionality. `Step`'s direction-count check
  stays `Other`: it's four sites (one per dimensionality, now sharing
  `Step::validate_len` after they'd drifted to three different wordings) describing how
  the strategy was configured, not a property of the data, so it isn't a candidate for
  its own variant. `Other` now means only that: an escape hatch for conditions the crate
  doesn't model.
- **`check_uniform_grid` -> `validate_uniform_grid`**, the last `check_*` holdout in a
  crate where every other invariant check is `validate_*`, and gains a `tolerance:
  Option<T>` parameter (`None` keeps the existing 1024×ε default; `Some(t)` overrides it
  for a strategy whose precision needs differ). All 8 existing call sites pass `None`.

### Bug fixed along the way

`check_extrapolate` tested the setting passed in but formatted `self.extrapolate` into the
error. On the `set_extrapolate` path, which vets a candidate before storing it, the
rejection named the currently-stored setting rather than the one refused. The payload-free
variant retires the bug rather than keeping the fix.

### Message rendering

A lone failure reads as one sentence, several are listed under a summary line, and point
indices are omitted when every failure is at index 0, which is every single-point call.
The plural resolves against distinct point indices for `OutOfBounds`, since one point can
be out of bounds in several dimensions, and against the failure count for `PointLength`,
where each failure is a distinct point.

Before, on `main`:

```
attempted to interpolate at point(s) beyond grid data: 
    point[1][0] = -1.0 is out of bounds for grid[0] = [0.0, 1.0, 2.0], shape=[3], strides=[1], layout=CFcf (0xf), const ndim=1
    point[1][1] = -1.0 is out of bounds for grid[1] = [0.0, 1.0, 2.0], shape=[3], strides=[1], layout=CFcf (0xf), const ndim=1
    point[2][0] = 5.0 is out of bounds for grid[0] = [0.0, 1.0, 2.0], shape=[3], strides=[1], layout=CFcf (0xf), const ndim=1
    point[2][1] = 5.0 is out of bounds for grid[1] = [0.0, 1.0, 2.0], shape=[3], strides=[1], layout=CFcf (0xf), const ndim=1

supplied point slice should have length 3 for 3-D interpolation
supplied point slice should have length 3 for 3-D interpolation
```

`{:?}` on an `ArrayBase` prints the whole array header, so every offending coordinate
carried `shape`/`strides`/`layout`. The two `PointLength` lines are a single-point call
and a four-point batch with two misshapen points: identical output, and the batch names
neither the offending points nor the lengths it actually got.

After:

```
points out of bounds with `Extrapolate::Error` set:
    point[1] in dim 0
    point[1] in dim 1
    point[2] in dim 0
    point[2] in dim 1

point has length 2, expected 3 for 3-D interpolation
points have the wrong length for 3-D interpolation:
    point[1] has length 2
    point[3] has length 1
```

## Also

`thiserror` 1.0 -> 2.0, ahead of `no_std` support, which 1.0 cannot provide. No source
changes on its own; no `thiserror` type appears in the public surface.

## Test plan

- 113 lib tests, 7 integration tests, 18 doctests pass
- `cargo clippy --all-features --all-targets` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` clean
- `cargo fmt --check` clean
- `cargo build --examples --all-features` clean
- Batch aggregation tests previously asserted `message.contains("point[1]")`; they now
  assert against the failure positions directly
- Every message above is real output, captured by running a driver against this branch
  and against `main`

## Migration

| Before | After |
|---|---|
| `DynInterpolator<T>` | `AnyInterpolator<T>` |
| `interp.check_extrapolate(&e)` | `interp.validate_extrapolate(&e)` |
| `AxisLocation::Interp { lower, frac }` | `AxisLocation::Between { lower, frac }` |
| `InterpolateError::ExtrapolateError(s)` | `InterpolateError::OutOfBounds(failures)` |
| `InterpolateError::PointLength(n)` | `InterpolateError::PointLength { expected, failures }` |
| `ValidateError::InvalidExtrapolate(s)` | `ValidateError::ExtrapolateUnsupported` |
| `strategy::utils::check_uniform_grid(grid, dim)` | `validate_uniform_grid(grid, dim, None)` |

Both error enums, `Extrapolate<T>`, and the two new failure structs are `#[non_exhaustive]`,
so downstream exhaustive matches already need a `_` arm (or `..` on the structs), but
constructing existing variants is unaffected.
