### PR TITLE
interpolate_wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ Everything below is merged to `main` but not yet tagged/released.
   interpolators behind `Box<dyn AnyInterpolator<T>>` and recovering the concrete type via
   `as_any`. Implemented for owned `Interp1D`/`2D`/`3D`/`ND` only, since `as_any` requires
   `Self: 'static`; viewed interpolators can still be used through `Interpolator<T>`.
+- `Strategy1D`/`2D`/`3D`/`ND::interpolate_wrapped`: resolves an `Extrapolate::Wrap`
+  query point, then interpolates. Default reproduces existing behavior (wraps in the
+  grid's own coordinate space) for every built-in strategy; a strategy whose working
+  coordinate space differs from the grid's can override it. Groundwork for #56.
 
 ### Changed
 - **Breaking:** owned data is now the default in type names, following Rust idioms

--- a/src/interpolator/mod.rs
+++ b/src/interpolator/mod.rs
@@ -287,14 +287,7 @@ macro_rules! interpolate_impl {
                             return self.strategy.interpolate(&self.data, &clamped_point);
                         }
                         Extrapolate::Wrap => {
-                            let wrapped_point = std::array::from_fn(|i| {
-                                wrap(
-                                    point[i],
-                                    *self.data.grid[i].first().unwrap(),
-                                    *self.data.grid[i].last().unwrap(),
-                                )
-                            });
-                            return self.strategy.interpolate(&self.data, &wrapped_point);
+                            return self.strategy.interpolate_wrapped(&self.data, *point);
                         }
                         Extrapolate::Error => {
                             errors.push(OutOfBoundsAt { index: 0, dim });

--- a/src/interpolator/n/mod.rs
+++ b/src/interpolator/n/mod.rs
@@ -362,18 +362,7 @@ where
                         return self.strategy.interpolate(&self.data, &clamped_point);
                     }
                     Extrapolate::Wrap => {
-                        let wrapped_point: Vec<_> = point
-                            .iter()
-                            .enumerate()
-                            .map(|(dim, pt)| {
-                                wrap(
-                                    *pt,
-                                    *self.data.grid[dim].first().unwrap(),
-                                    *self.data.grid[dim].last().unwrap(),
-                                )
-                            })
-                            .collect();
-                        return self.strategy.interpolate(&self.data, &wrapped_point);
+                        return self.strategy.interpolate_wrapped(&self.data, point);
                     }
                     Extrapolate::Error => {
                         errors.push(OutOfBoundsAt { index: 0, dim });

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -58,7 +58,7 @@ macro_rules! fixed_strategy_trait {
             where
                 D::Elem: Num + Euclid + Copy,
             {
-                let wrapped = std::array::from_fn(|i| {
+                let wrapped = core::array::from_fn(|i| {
                     wrap(
                         point[i],
                         *data.grid[i].first().unwrap(),

--- a/src/strategy/traits.rs
+++ b/src/strategy/traits.rs
@@ -46,6 +46,28 @@ macro_rules! fixed_strategy_trait {
                 point: &[D::Elem; $N],
             ) -> Result<D::Elem, InterpolateError>;
 
+            /// Resolves an out-of-bounds point under [`Extrapolate::Wrap`](`crate::interpolator::Extrapolate::Wrap`), then interpolates.
+            ///
+            /// Default wraps in `data.grid`'s own (raw) coordinate space. Override only if
+            /// this strategy's working coordinate space differs from `data.grid`'s.
+            fn interpolate_wrapped(
+                &self,
+                data: &$InterpData<D>,
+                point: [D::Elem; $N],
+            ) -> Result<D::Elem, InterpolateError>
+            where
+                D::Elem: Num + Euclid + Copy,
+            {
+                let wrapped = std::array::from_fn(|i| {
+                    wrap(
+                        point[i],
+                        *data.grid[i].first().unwrap(),
+                        *data.grid[i].last().unwrap(),
+                    )
+                });
+                self.interpolate(data, &wrapped)
+            }
+
             #[doc = concat!(
                 " Interpolate without the `Result` wrapper, assuming `point` and `data` are\n",
                 " already valid.\n",
@@ -188,6 +210,18 @@ macro_rules! fixed_strategy_trait {
             }
 
             #[inline]
+            fn interpolate_wrapped(
+                &self,
+                data: &$InterpData<D>,
+                point: [D::Elem; $N],
+            ) -> Result<D::Elem, InterpolateError>
+            where
+                D::Elem: Num + Euclid + Copy,
+            {
+                (**self).interpolate_wrapped(data, point)
+            }
+
+            #[inline]
             fn interpolate_fast(&self, data: &$InterpData<D>, point: &[D::Elem; $N]) -> D::Elem {
                 (**self).interpolate_fast(data, point)
             }
@@ -299,6 +333,32 @@ where
         data: &InterpDataNDBase<D>,
         point: &[D::Elem],
     ) -> Result<D::Elem, InterpolateError>;
+
+    /// Resolves an out-of-bounds point under [`Extrapolate::Wrap`](`crate::interpolator::Extrapolate::Wrap`), then interpolates.
+    ///
+    /// Default wraps in `data.grid`'s own (raw) coordinate space. Override only if
+    /// this strategy's working coordinate space differs from `data.grid`'s.
+    fn interpolate_wrapped(
+        &self,
+        data: &InterpDataNDBase<D>,
+        point: &[D::Elem],
+    ) -> Result<D::Elem, InterpolateError>
+    where
+        D::Elem: Num + Euclid + Copy,
+    {
+        let wrapped: Vec<D::Elem> = point
+            .iter()
+            .enumerate()
+            .map(|(dim, &pt)| {
+                wrap(
+                    pt,
+                    *data.grid[dim].first().unwrap(),
+                    *data.grid[dim].last().unwrap(),
+                )
+            })
+            .collect();
+        self.interpolate(data, &wrapped)
+    }
 
     /// Interpolate without the `Result` wrapper, assuming `point` and `data` are
     /// already valid.
@@ -436,6 +496,18 @@ where
     #[inline]
     fn allow_extrapolate(&self) -> bool {
         (**self).allow_extrapolate()
+    }
+
+    #[inline]
+    fn interpolate_wrapped(
+        &self,
+        data: &InterpDataNDBase<D>,
+        point: &[D::Elem],
+    ) -> Result<D::Elem, InterpolateError>
+    where
+        D::Elem: Num + Euclid + Copy,
+    {
+        (**self).interpolate_wrapped(data, point)
     }
 
     #[inline]


### PR DESCRIPTION
Part of #56.

`Extrapolate::Wrap` currently wraps a query point in the grid's raw coordinate
space before calling into the strategy, computed inline in `interpolate_impl!`
and duplicated by hand in `InterpND`. A strategy whose working coordinate space
differs from the grid's (the `GridTransformed` wrapper `#56` plans) needs to wrap
in its own space instead, so this gives strategies a hook: `interpolate_wrapped`,
new on `Strategy1D`/`2D`/`3D`/`ND`, defaulting to today's raw-space behavior, with
both `Wrap` call sites delegating to it.

Pure refactor, no behavior change: the default reproduces the exact old inline
logic, and every existing strategy uses the default. Confirmed by the existing
`Extrapolate::Wrap` test suite passing unchanged.

## Test plan
- [x] `cargo test --all-features`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo build` / `cargo build --no-default-features`
