### PR TITLE
v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ bump the minor version (`0.x` -> `0.(x+1)`), other changes bump the patch versio
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-22
+
 ### Added
 - `std` feature, on by default: opting out via `default-features = false` makes the
   crate `no_std`-compatible (`alloc` still required). The `serde` feature doesn't yet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninterp"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 # 1.81 for core::error::Error, needed by thiserror's derive under no_std.
 rust-version = "1.81"


### PR DESCRIPTION
## v0.11.1

No breaking changes since 0.11.0.

### Added
- `std` feature, on by default: opting out via `default-features = false` makes the
  crate `no_std`-compatible (`alloc` still required). The `serde` feature doesn't yet
  build without `std`, blocked on an upstream fix
  ([RReverser/serde-ndim#8](https://github.com/RReverser/serde-ndim/pull/8)).
